### PR TITLE
Add Dutch Simplex noise parameters

### DIFF
--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -2698,7 +2698,7 @@ STR_2696    :Bomen plaatsen
 STR_2697    :???
 STR_2698    :???
 STR_2699    :???
-STR_2700    :Frequentie automatisch opslaan
+STR_2700    :Automatisch opslaan:
 STR_2701    :Elke week
 STR_2702    :Elke 2 weken
 STR_2703    :Elke maand

--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -2683,11 +2683,11 @@ STR_2681    :???
 STR_2682    :???
 STR_2683    :???
 STR_2684    :???
-STR_2685    :???
-STR_2686    :???
-STR_2687    :???
-STR_2688    :???
-STR_2689    :???
+STR_2685    :Parameters voor Simplex noise
+STR_2686    :Minimum:
+STR_2687    :Maximum:
+STR_2688    :Basisfrequentie:
+STR_2689    :Octaven:
 STR_2690    :Kaartgenerator
 STR_2691    :{WINDOW_COLOUR_2}Basishoogte:
 STR_2692    :{WINDOW_COLOUR_2}Waterniveau:
@@ -2698,13 +2698,13 @@ STR_2696    :Bomen plaatsen
 STR_2697    :???
 STR_2698    :???
 STR_2699    :???
-STR_2700    :Parameters voor Simplex noise
-STR_2701    :Minimum:
-STR_2702    :Maximum:
-STR_2703    :Basisfrequentie:
-STR_2704    :Octaven:
-STR_2705    :???
-STR_2706    :???
+STR_2700    :Frequentie automatisch opslaan
+STR_2701    :Elke week
+STR_2702    :Elke 2 weken
+STR_2703    :Elke maand
+STR_2704    :Elke 4 maanden
+STR_2705    :Elk jaar
+STR_2706    :Nooit
 STR_2707    :Open nieuw scherm
 STR_2708    :{WINDOW_COLOUR_1}Weet je zeker dat je {STRINGID} wilt vervangen?
 STR_2709    :Vervangen

--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -2698,11 +2698,11 @@ STR_2696    :Bomen plaatsen
 STR_2697    :???
 STR_2698    :???
 STR_2699    :???
-STR_2700    :???
-STR_2701    :???
-STR_2702    :???
-STR_2703    :???
-STR_2704    :???
+STR_2700    :Parameters voor Simplex noise
+STR_2701    :Minimum:
+STR_2702    :Maximum:
+STR_2703    :Basisfrequentie:
+STR_2704    :Octaven:
 STR_2705    :???
 STR_2706    :???
 STR_2707    :Open nieuw scherm


### PR DESCRIPTION
Met @ThomasDenH's commentaar al verwerkt.
Zoals aangegeven heb ik 'Simplex noise' zo laten staan omdat de meeste Nederlandstalige teksten het ook zo lijken te gebruiken.