### PR TITLE
Fix Italian date display

### DIFF
--- a/data/language/italian.txt
+++ b/data/language/italian.txt
@@ -2737,8 +2737,8 @@ STR_2732    :???
 STR_2733    :???
 STR_2734    :???
 STR_2735    :???
-STR_2736    :???
-STR_2737    :???
+STR_2736    :{MONTH}, anno {COMMA16}
+STR_2737    :{STRINGID} {MONTH}, anno {COMMA16}
 STR_2738    :???
 STR_2739    :???
 STR_2740    :???


### PR DESCRIPTION
The Italian file will need more updates than just this one, but this one was causing the date display to be completely broken, which I'd say is worse than a few missing strings. It's also a translation that is just within my knowledge of Italian.