### PR TITLE
Add strings for the RCT1 colour scheme and disabling breakdown, mostly fill other languages to make them more useful

### DIFF
--- a/data/language/dutch.txt
+++ b/data/language/dutch.txt
@@ -3463,3 +3463,6 @@ STR_5134    :{SMALLFONT}{BLACK}Een groter gebied landrechten aanpassen
 STR_5135    :{SMALLFONT}{BLACK}Land en bouwrechten kopen
 STR_5136    :Landrechten
 STR_5137    :Kettingliften kunnen tot {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Defecte remmen onmogelijk maken

--- a/data/language/english_us.txt
+++ b/data/language/english_us.txt
@@ -3474,3 +3474,6 @@ STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
 STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
 STR_5136    :Land rights
 STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/french.txt
+++ b/data/language/french.txt
@@ -3452,9 +3452,24 @@ STR_3445    :Définir Zone de Patrouille
 STR_3446    :Annuler Zone de Patrouille
 
 # New strings, cleaner
-STR_5120 :Show finances button on toolbar
-STR_5121 :Show research button on toolbar
-STR_5122 :Show all vehicles sharing a track/ride type
-STR_5123 :Renouveler attr.
-STR_5124 :Pas de Six Flags
-STR_5125 :All destructable
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renouveler attr.
+STR_5124    :Pas de Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/german.txt
+++ b/data/language/german.txt
@@ -3451,3 +3451,26 @@ STR_3443    :Seite 4
 STR_3444    :Seite 5
 STR_3445    :Patrouillenbereich festlegen
 STR_3446    :Patrouillenbereich verwerfen
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/hungarian.txt
+++ b/data/language/hungarian.txt
@@ -3450,3 +3450,26 @@ STR_3443    :Page 4
 STR_3444    :Page 5
 STR_3445    :Set Patrol Area
 STR_3446    :Cancel Patrol Area
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/italian.txt
+++ b/data/language/italian.txt
@@ -3448,3 +3448,26 @@ STR_3443    :Pagina 4
 STR_3444    :Pagina 5
 STR_3445    :Imposta l'area da pattugliare
 STR_3446    :Annulla l'area da pattugliare
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/polish.txt
+++ b/data/language/polish.txt
@@ -3506,3 +3506,26 @@ STR_3443    :Strona 4
 STR_3444    :Strona 5
 STR_3445    :Ustaw obszar do patrolowania
 STR_3446    :Wyłącz patrolowanie
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/spanish_sp.txt
+++ b/data/language/spanish_sp.txt
@@ -3450,3 +3450,26 @@ STR_3443    :Page 4
 STR_3444    :Page 5
 STR_3445    :Set Patrol Area
 STR_3446    :Cancelar Patrol Area
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure

--- a/data/language/swedish.txt
+++ b/data/language/swedish.txt
@@ -3454,3 +3454,26 @@ STR_3443    :Sida 4
 STR_3444    :Sida 5
 STR_3445    :Sätt Patrullområde
 STR_3446    :Avbryt Patrullområde
+
+# New strings, cleaner
+STR_5120    :Show finances button on toolbar
+STR_5121    :Show research button on toolbar
+STR_5122    :Show all vehicles sharing a track/ride type
+STR_5123    :Renew rides
+STR_5124    :No Six Flags
+STR_5125    :All destructable
+STR_5126    :Random title music
+STR_5127    :{SMALLFONT}{BLACK}Disable land elevation
+STR_5128    :Selection size
+STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5130    :Map size
+STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5132    :Fix all rides
+STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
+STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
+STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
+STR_5136    :Land rights
+STR_5137    :Allow lift hill speeds up to {VELOCITY}
+STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
+STR_5139    :{WHITE}{STRINGID}
+STR_5140    :Disable brakes failure


### PR DESCRIPTION
Assumes https://github.com/IntelOrca/OpenRCT2/pull/1076 gets merged.