### PR TITLE
Changing STR_3160 for:   pl-PL + ja-JP + fi-FI + ru-RU (Applying #645)

### DIFF
--- a/data/language/fi-FI.txt
+++ b/data/language/fi-FI.txt
@@ -3171,7 +3171,7 @@ STR_3156    :
 STR_3157    :kartta
 STR_3158    :graph
 STR_3159    :lista
-STR_3160    :<not used anymore>
+
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/fi-FI.txt
+++ b/data/language/fi-FI.txt
@@ -3171,7 +3171,7 @@ STR_3156    :
 STR_3157    :kartta
 STR_3158    :graph
 STR_3159    :lista
-
+STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -3167,7 +3167,7 @@ STR_3156    :
 STR_3157    :map
 STR_3158    :graph
 STR_3159    :list
-STR_3160    :<not used anymore>
+
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -3167,7 +3167,7 @@ STR_3156    :
 STR_3157    :map
 STR_3158    :graph
 STR_3159    :list
-
+STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/pl-PL.txt
+++ b/data/language/pl-PL.txt
@@ -3204,7 +3204,7 @@ STR_3156    :
 STR_3157    :mapa
 STR_3158    :wykres
 STR_3159    :lista
-STR_3160    :<not used anymore>
+
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/pl-PL.txt
+++ b/data/language/pl-PL.txt
@@ -3204,7 +3204,7 @@ STR_3156    :
 STR_3157    :mapa
 STR_3158    :wykres
 STR_3159    :lista
-
+STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/ru-RU.txt
+++ b/data/language/ru-RU.txt
@@ -3167,7 +3167,7 @@ STR_3156    :
 STR_3157    :map
 STR_3158    :graph
 STR_3159    :list
-STR_3160    :<not used anymore>
+
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 

--- a/data/language/ru-RU.txt
+++ b/data/language/ru-RU.txt
@@ -3167,7 +3167,7 @@ STR_3156    :
 STR_3157    :map
 STR_3158    :graph
 STR_3159    :list
-
+STR_3160    :{SMALLFONT}{BLACK}Select the number of circuits per ride
 STR_3161    :<not used anymore>
 STR_3162    :Unable to allocate enough memory
 STR_3163    :Installing new data: 


### PR DESCRIPTION
As requested in: #645 

**Q&A**
**Q**uestion: Why did I add the strings and not just remove them?
**A**nswer: As these strings will need to be translated anyways later on when someone translates the file, it's better to fill in the blank instead of leaving a empty space easily for someone to miss :U 