### PR TITLE
Remove en-GB from template (Suggestion inside)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,6 @@ STR_0000    :...
 ```
 
 Updated in:
-- [ ] en-GB
 - [ ] en-US
 - [ ] cs-CZ
 - [ ] nl-NL
@@ -17,4 +16,3 @@ Updated in:
 - [ ] ko-KR
 - [ ] zh-CN
 - [ ] zh-TW
-


### PR DESCRIPTION
As en-GB is the original file which shouldn't be translated, it's not in the Localisation folder

What we could do is mark it as done like: 
[X] en-GB