### PR TITLE
Fixed number in giga-coaster description

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -581,7 +581,7 @@ STR_0576    :
 STR_0577    :Boggivagnar kör på ett träspår, vänder runt på speciella vändsektioner
 STR_0578    :Vagnar åker runt en bana omgiven av ringar utför branta nedförsbackar och skruvar
 STR_0579    :
-STR_0580    :En gigantisk stål berg- och dalbana som klara mjuka fall och höjder på över 1000 m
+STR_0580    :En gigantisk stål berg- och dalbana som klara mjuka fall och höjder på över 100 m
 STR_0581    :En ring med säten dras upp till toppen av ett högt torn medan det roterar sakta, därefter faller det fritt varefter det stoppas mjukt vid botten med hjälp av magnetbromsar
 STR_0582    :
 STR_0583    :


### PR DESCRIPTION
Fixed Swedish translation of STR_0580 saying 1000m (wrong conversion from 300 ft).