### PR TITLE
Define thousands separator (STR_5151) in cs-CZ.txt.

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -3491,7 +3491,7 @@ STR_5147    :Cheaty
 STR_5148    :{SMALLFONT}{BLACK}Změnit rychlost hry
 STR_5149    :{SMALLFONT}{BLACK}Zobrazit možnosti cheatů
 STR_5150    :Zapnout debug nástroje
-STR_5151    :
+STR_5151    : 
 STR_5152    :,
 STR_5153    :Upravit motivy...
 STR_5154    :Hardwarové zobrazování


### PR DESCRIPTION
User Hurec on the forums posted that money is not being displayed correctly when using the Czech localisation.
For example, a value of €10000 (ten thousand) is displayed as "€10,".
The thousands separator (STR_5151) is empty in cs-CZ.txt.
According to wikipedia, Czech uses a space as the thousands separator.
Updated cs-CZ.txt accordingly. Money displays properly - e.g. "€10 000,00"
