### PR TITLE
All languages: Adding missing string 6034

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -4343,6 +4343,7 @@ STR_6030    :{SMALLFONT}{BLACK}Výběr kulis. Klikněte na jakoukoliv kulisu na 
 STR_6031    :Popis serveru:
 STR_6032    :Uvítací zpráva serveru:
 STR_6033    :Cesta k RCT1 instalaci:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :Prosím vyberte složku s RCT1
 STR_6036    :{SMALLFONT}{BLACK}Zrušit
 STR_6037    :Prosím vyberte správnou složku s RCT1

--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -4334,6 +4334,7 @@ STR_6030    :{SMALLFONT}{BLACK}Landschaftsauswahl. Wählen Sie ein Landschaftsel
 STR_6031    :Serverbeschreibung:
 STR_6032    :Serverbegrüßung:
 STR_6033    :Pfad zur RCT1-Installation:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :Bitte wählen Sie ein RCT1-Verzeichnis
 STR_6036    :{SMALLFONT}{BLACK}Leeren
 STR_6037    :Bitte wählen Sie ein valides RCT1-Verzeichnis

--- a/data/language/it-IT.txt
+++ b/data/language/it-IT.txt
@@ -4345,6 +4345,7 @@ STR_6030    :{SMALLFONT}{BLACK}Contagocce scenario. Fare clic su un qualsiasi el
 STR_6031    :Descrizione server:
 STR_6032    :Messaggio di benvenuto server:
 STR_6033    :Cartella di RCT1:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :Selezionare la cartella di installazione di RCT1
 STR_6036    :{SMALLFONT}{BLACK}Pulisci
 STR_6037    :Selezionare una cartella di installazione di RCT1 valida

--- a/data/language/ko-KR.txt
+++ b/data/language/ko-KR.txt
@@ -4340,6 +4340,7 @@ STR_6030    :{SMALLFONT}{BLACK}오브젝트 스포이드 기능입니다. 지도
 STR_6031    :서버 설명:
 STR_6032    :서버 인사말:
 STR_6033    :RCT1 설치 경로:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :RCT1이 설치된 폴더를 선택하세요
 STR_6036    :{SMALLFONT}{BLACK}초기화
 STR_6037    :RCT1이 설치된 폴더를 올바르게 선택해주세요

--- a/data/language/nb-NO.txt
+++ b/data/language/nb-NO.txt
@@ -4342,6 +4342,7 @@ STR_6030    :{SMALLFONT}{BLACK}Pyntvelger. Klikk hvilken som helst pynt på kart
 STR_6031    :Serverbeskrivelse:
 STR_6032    :Server-velkomstbeskjed:
 STR_6033    :Sti til RCT1 insallasjonsmappe:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :Velg din RCT1-mappe
 STR_6036    :{SMALLFONT}{BLACK}Visk ut
 STR_6037    :Vennligst velg en gyldig RCT1 mappe

--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -4335,6 +4335,7 @@ STR_6030    :{SMALLFONT}{BLACK}Decorselector. Klik op een al geplaatst decorstuk
 STR_6031    :Serverbeschrijving:
 STR_6032    :Welkomstboodschap:
 STR_6033    :Locatie RCT1-bestanden:
+STR_6034    :{SMALLFONT}{BLACK}{STRING}
 STR_6035    :Selecteer de map waar je RCT1-bestanden staan
 STR_6036    :{SMALLFONT}{BLACK}Wissen
 STR_6037    :Selecteer een geldige RCT1-map.


### PR DESCRIPTION
To correct the "99%" the language checker pushes out on some languages
PS. Wish I could squash them all, but my Github and localisation folder ain't getting along :( 