### PR TITLE
en_US: Use "cattails" instead of "bulrushes"

### DIFF
--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -2715,3 +2715,11 @@ STR_CPTY    :4 passengers per car
 STR_NAME    :Conger Eel Coaster
 STR_DESC    :A compact steel-tracked roller coaster where the Eel-shaped train travels through corkscrews and loops
 STR_CPTY    :4 passengers per car
+
+###########
+# Scenery #
+###########
+
+#Bulrushes
+[TBR]
+STR_NAME    :Cattails


### PR DESCRIPTION
Pretty trivial, I know... but "cattail" is far more common in American English. In fact, I had never
even heard of "bulrushes" before noticing in-game.

Plus the USDA uses "cattail" as well, so I guess it's official
https://plants.usda.gov/core/profile?symbol=TYPHA