### PR TITLE
ja-JP: object name translations; miscellaneous other translations.

### DIFF
--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -886,8 +886,8 @@ STR_0880    :ここに地形を上げられません…
 STR_0881    :オブジェクトが途中
 STR_0882    :ゲームをロードする
 STR_0883    :ゲームをセーブする
-STR_0884    :景色をロードする
-STR_0885    :景色をセーブする
+STR_0884    :地形をロードする
+STR_0885    :地形をセーブする
 STR_0886    :ゲームを閉じる
 STR_0887    :シナリオエディタを閉じる
 STR_0888    :トラックデザイナーを閉める
@@ -1051,7 +1051,7 @@ STR_1045    :OpenRCT2の景色ファイル
 STR_1046    :OpenRCT2のトラックディサインファイル
 STR_1047    :ゲームをセーブが失敗しました！
 STR_1048    :シナリオをセーブが失敗しました！
-STR_1049    :景色をセーブが失敗しました！
+STR_1049    :地形をセーブが失敗しました！
 STR_1050    :Failed to load...{NEWLINE}File contains invalid data!
 STR_1051    :支柱の切り替え
 STR_1052    :ゲストの切替え
@@ -1814,18 +1814,18 @@ STR_1807    :コントロールが故障した
 STR_1808    :{WINDOW_COLOUR_2}最後の故障: {BLACK}{STRINGID}
 STR_1809    :{WINDOW_COLOUR_2}今の故障: {OUTLINE}{RED}{STRINGID}
 STR_1810    :{WINDOW_COLOUR_2}所持品:
-STR_1811    :Can't build this here...
+STR_1811    :ここで建てることはできません。
 STR_1812    :{SMALLFONT}{BLACK}{STRINGID}
-STR_1813    :Miscellaneous Objects
+STR_1813    :雑貨のオブジェックト
 STR_1814    :活動
 STR_1815    :思考
 STR_1816    :{SMALLFONT}{BLACK}Select information type to show in guest list
 STR_1817    :({COMMA16})
-STR_1818    :{WINDOW_COLOUR_2}All guests
-STR_1819    :{WINDOW_COLOUR_2}All guests (summarised)
-STR_1820    :{WINDOW_COLOUR_2}Guests {STRINGID}
-STR_1821    :{WINDOW_COLOUR_2}Guests thinking {STRINGID}
-STR_1822    :{WINDOW_COLOUR_2}Guests thinking about {POP16}{STRINGID}
+STR_1818    :{WINDOW_COLOUR_2}全てのゲスト
+STR_1819    :{WINDOW_COLOUR_2}全てのゲスト (要約)
+STR_1820    :{WINDOW_COLOUR_2}{STRINGID}のゲスト
+STR_1821    :{WINDOW_COLOUR_2}{STRINGID}を考えるのゲスト
+STR_1822    :{WINDOW_COLOUR_2}{POP16}{STRINGID}を考えるのゲスト
 STR_1823    :{SMALLFONT}{BLACK}Show guests' thoughts about this ride/attraction
 STR_1824    :{SMALLFONT}{BLACK}Show guests on this ride/attraction
 STR_1825    :{SMALLFONT}{BLACK}Show guests queuing for this ride/attraction
@@ -2058,7 +2058,7 @@ STR_2049    :ドリンク
 STR_2050    :バーガー
 STR_2051    :ポテトフライ
 STR_2052    :アイスクリーム
-STR_2053    :some Candyfloss
+STR_2053    :綿菓子
 STR_2054    :空のキャン
 STR_2055    :くず
 STR_2056    :空のバーガーボックス
@@ -2755,18 +2755,18 @@ STR_2745    :\
 STR_2746    :]
 STR_2747    :{ENDQUOTES}
 STR_2748    :Bar
-STR_2749    :My new scenario
+STR_2749    :題名なしのシナリオ
 # New strings used in the cheats window previously these were ???
-STR_2750    :Move all items to top
-STR_2751    :Move all items to bottom
-STR_2752    :Clear grass
-STR_2753    :Mowed grass
-STR_2754    :Water plants
-STR_2755    :Fix vandalism
-STR_2756    :Remove litter
+STR_2750    :全てのオブジェクト上に移動する
+STR_2751    :全てのオブジェクト下に移動する
+STR_2752    :草をクリアする
+STR_2753    :草を刈る
+STR_2754    :庭木に水をやる
+STR_2755    :壊れた物を補修する
+STR_2756    :ゴミを削除する
 STR_2757    :<removed string - do not use>
 STR_2758    :<removed string - do not use>
-STR_2759    :Zero Clearance
+STR_2759    :ゼロ・クリアランス
 STR_2760    :+{CURRENCY}
 STR_2761    :<removed string - do not use>
 STR_2762    :<removed string - do not use>
@@ -3189,32 +3189,32 @@ STR_3177    :Unable to de-select this object
 STR_3178    :At least one path object must be selected
 STR_3179    :At least one ride vehicle/attraction object must be selected
 STR_3180    :Invalid selection of objects
-STR_3181    :Object Selection - {STRINGID}
-STR_3182    :Park entrance type must be selected
-STR_3183    :Water type must be selected
-STR_3184    :Ride Vehicles/Attractions
+STR_3181    :オブジェクト選択 - {STRINGID}
+STR_3182    :パーク入口タイプを選択する必要があります。
+STR_3183    :ウォタータイプを選択する必要があります。
+STR_3184    :ライド乗り物/アトラクション
 STR_3185    :小さな景観物
 STR_3186    :大きな景観物
-STR_3187    :Walls/Fences
+STR_3187    :壁とフェンス
 STR_3188    :歩道のバナー
 STR_3189    :歩道
-STR_3190    :Path Extras
-STR_3191    :Scenery Groups
+STR_3190    :歩道の余分
+STR_3191    :景色物グループ
 STR_3192    :パークの入口
 STR_3193    :水
-STR_3194    :Scenario Description
-STR_3195    :Invention List
-STR_3196    :{WINDOW_COLOUR_2}Research Group: {BLACK}{STRINGID}
-STR_3197    :{WINDOW_COLOUR_2}Items pre-invented at start of game:
-STR_3198    :{WINDOW_COLOUR_2}Items to invent during game:
-STR_3199    :Random Shuffle
-STR_3200    :{SMALLFONT}{BLACK}Randomly shuffle the list of items to invent during the game
-STR_3201    :Object Selection
-STR_3202    :Landscape Editor
-STR_3203    :Invention List Set Up
-STR_3204    :Options Selection
-STR_3205    :Objective Selection
-STR_3206    :Save Scenario
+STR_3194    :シナリオの説明
+STR_3195    :発明品リスト
+STR_3196    :{WINDOW_COLOUR_2}研究開発グループ: {BLACK}{STRINGID}
+STR_3197    :{WINDOW_COLOUR_2}ゲームの開始時に事前に発明されたオブジェクト:
+STR_3198    :{WINDOW_COLOUR_2}ゲーム中に発明されたオブジェクト:
+STR_3199    :ランダムシャッフル
+STR_3200    :{SMALLFONT}{BLACK}オブジェクトのリストをランダムシャッフルするにクリックして下さい。
+STR_3201    :オブジェクト選択
+STR_3202    :地形エディター
+STR_3203    :発明品リスト設定
+STR_3204    :設定の選択
+STR_3205    :目標の選択
+STR_3206    :シナリオをセーブする
 STR_3207    :トラックデザイナー
 STR_3208    :トラックデザインマネージャー
 STR_3209    :前のステップに戻る:
@@ -3550,10 +3550,10 @@ STR_5207    :スタッフ
 STR_5208    :スタッフ一覧
 STR_5209    :バナー
 STR_5210    :オブジェクト選択
-STR_5211    :Invention List
+STR_5211    :発明品リスト
 STR_5212    :シナリオ設定
 STR_5213    :目標の設定
-STR_5214    :Map Generation
+STR_5214    :地図の生成
 STR_5215    :トラックデサインマネージャー
 STR_5216    :トラックデサインマネージャーリスト
 STR_5217    :カンニング
@@ -3614,8 +3614,8 @@ STR_5271    :{SMALLFONT}{BLACK}Twitch
 STR_5272    :{SMALLFONT}{BLACK}小さな景観物
 STR_5273    :{SMALLFONT}{BLACK}大きな景観物
 STR_5274    :{SMALLFONT}{BLACK}歩道
-STR_5275    :Search for Objects
-STR_5276    :Enter the name of an object to search for
+STR_5275    :オブジェクトを調べる
+STR_5276    :オブジェクトの名を入力して下さい。
 STR_5277    :Clear
 STR_5278    :サンドボックスモード
 STR_5279    :サンドボックスモードを切る
@@ -3758,10 +3758,10 @@ STR_5415    :Load{MOVE_X}{87}{STRING}
 STR_5416    :Load{MOVE_X}{87}No save selected
 STR_5417    :Location
 STR_5418    :Location{MOVE_X}{87}{COMMA16}   {COMMA16}
-STR_5419    :Rotate
-STR_5420    :Rotate{MOVE_X}{87}{COMMA16}
-STR_5421    :Zoom
-STR_5422    :Zoom{MOVE_X}{87}{COMMA16}
+STR_5419    :回転
+STR_5420    :回転{MOVE_X}{87}{COMMA16}
+STR_5421    :ズーム
+STR_5422    :ズーム{MOVE_X}{87}{COMMA16}
 STR_5423    :Wait
 STR_5424    :Wait{MOVE_X}{87}{UINT16}
 STR_5425    :Restart
@@ -3769,7 +3769,7 @@ STR_5426    :End
 STR_5427    :Coordinates:
 STR_5428    :Anticlockwise rotations:
 STR_5429    :Zoom level:
-STR_5430    :Seconds to wait:
+STR_5430    :Milliseconds to wait:
 STR_5431    :Save to load:
 STR_5432    :Command:
 STR_5433    :Title Sequences
@@ -3786,20 +3786,20 @@ STR_5443    :スピード{MOVE_X}{87}{STRINGID}
 STR_5444    :スピード:
 STR_5445    :スピード
 STR_5446    :Get
-STR_5447    :Type {STRINGID}
-STR_5448    :Ride / Vehicle {STRINGID}
+STR_5447    :タイプ {STRINGID}
+STR_5448    :ライド／乗り物 {STRINGID}
 STR_5449    :ゲームのスピードを下げる
 STR_5450    :ゲームのスピードを上げる
 STR_5451    :Open cheats window
 STR_5452    :Toggle visibility of toolbars
-STR_5453    :Select another ride
+STR_5453    :他のライドを選択する
 STR_5454    :Uncap FPS
 STR_5455    :Enable sandbox mode
 STR_5456    :Disable clearance checks
 STR_5457    :Disable support limits
-STR_5458    :Rotate clockwise
-STR_5459    :Rotate anti-clockwise
-STR_5460    :Rotate view anti-clockwise
+STR_5458    :右へ回転する
+STR_5459    :左へ回転する
+STR_5460    :ビュウを左へ回転する
 STR_5461    :Set guests' parameters
 STR_5462    :{CURRENCY}
 STR_5463    :楽しむの目的
@@ -3826,13 +3826,13 @@ STR_5483    :{BLACK}(残り{COMMA16}週間)
 STR_5484    :{BLACK}(残り{COMMA16}週間)
 STR_5485    :{SMALLFONT}{STRING}
 STR_5486    :{BLACK}{COMMA16}
-STR_5487    :{SMALLFONT}{BLACK}Show recent messages
-STR_5488    :No entrance (OpenRCT2 only!)
+STR_5487    :{SMALLFONT}{BLACK}最近のメッセージの表示
+STR_5488    :入口なし (OpenRCT2だけ!)
 STR_5489    :{SMALLFONT}{BLACK}Show only tracked guests
 STR_5490    :Disable audio on focus loss
-STR_5491    :Inventions list
+STR_5491    :発明品リスト
 STR_5492    :シナリオ設定
-STR_5493    :Send Message
+STR_5493    :メッセージを送る
 STR_5494    :<not used anymore>
 STR_5495    :プレーヤー 名鑑
 STR_5496    :プレーヤー:
@@ -4189,8 +4189,8 @@ STR_5876    :{SMALLFONT}{BLACK}The engine to use for drawing the game.
 STR_5877    :Software
 STR_5878    :Software (hardware display)
 STR_5879    :OpenGL (experimental)
-STR_5880    :Selected only
-STR_5881    :Non-selected only
+STR_5880    :選定だけ
+STR_5881    :選定ないだけ
 STR_5882    :カスタム通貨記号
 STR_5883    :カスタム通貨記号設定
 STR_5884    :{WINDOW_COLOUR_2}円相場:
@@ -4413,14 +4413,14 @@ STR_6100    :You disconnected from the server.
 STR_6101    :Rides don't decrease in value over time
 STR_6102    :{SMALLFONT}{BLACK}The value of a ride won't decrease over time, so guests will not suddenly think that a ride is too expensive.
 STR_6103    :{SMALLFONT}{BLACK}This option is disabled during network play.
-STR_6104    :Corkscrew Roller Coaster
-STR_6105    :Hypercoaster
-STR_6106    :Car Ride
-STR_6107    :Monster Trucks
-STR_6108    :Steel Twister
-STR_6109    :Hyper-Twister
-STR_6110    :Junior Roller Coaster
-STR_6111    :Classic Mini Roller Coaster
+STR_6104    :コークスクリュー・ジェットコースター
+STR_6105    :ハイパーコースター
+STR_6106    :カーライド
+STR_6107    :モンスタートラック
+STR_6108    :スチール・ツイスター
+STR_6109    :ハイパー・ツイスター
+STR_6110    :子供用ローラーコースター
+STR_6111    :クラシック・ミニ・ジェットコースター
 STR_6112    :A compact steel-tracked roller coaster where the train travels through corkscrews and loops
 STR_6113    :A tall non-inverting roller coaster with large drops, high speed, and comfortable trains with only lap bar restraints
 STR_6114    :Riders travel slowly in powered vehicles along a track-based route
@@ -4480,7 +4480,7 @@ STR_DESC    :動力付きで、急斜面もものともしない巨大な四輪�
 STR_CPTY    :各車両2名
 
 [AML1]
-STR_NAME    :American Style Steam Trains
+STR_NAME    :アメリカンスタイルの蒸気機関車
 STR_DESC    :レプリカの蒸気機関車と炭水車、布製の屋根の木製客車からなるミニチュア列車です
 STR_CPTY    :各客車6名
 
@@ -4490,27 +4490,27 @@ STR_DESC    :昔の線路のようなスチールのコースを走る、鉱山�
 STR_CPTY    :各車両2名または4名
 
 [ARRSW1]
-STR_NAME    :Suspended Swinging Cars
+STR_NAME    :サスペンデッド・スイング車両
 STR_DESC    :車両がコーナーを回る際、大きく揺れ動くようになっている吊り下げ式のローラーコースターです
 STR_CPTY    :各車両4名
 
 [ARRSW2]
-STR_NAME    :Suspended Swinging Aeroplane Cars
+STR_NAME    :サスペンデッド・スイング飛行車両
 STR_DESC    :ぶら下がった飛行機型の車両が、コーナーで大きく揺れ動くコースターです
 STR_CPTY    :各車両4名
 
 [ARRT1]
-STR_NAME    :Corkscrew Roller Coaster
+STR_NAME    :コークスクリュー・ジェットコースター
 STR_DESC    :コークスクリューとループがあるスチールコースを持つ、コンパクトなローラーコースターです
 STR_CPTY    :各車両4名
 
 [ARRT2]
-STR_NAME    :Hypercoaster
+STR_NAME    :ハイパーコースター
 STR_DESC    :高低差もあり速度も速いですが、逆さにはならず膝にしか安全バーがないので、快適な車両です
 STR_CPTY    :各車両6名
 
 [ARRX]
-STR_NAME    :Multi-Dimension Coaster Train
+STR_NAME    :多次元コースター列車
 STR_DESC    :乗客を縦方向に逆さまにできる座席を備えた車両です
 STR_CPTY    :各車両4名
 
@@ -4523,7 +4523,7 @@ STR_NAME    :風船ショップ
 STR_DESC    :ヘリウムガスの入った風船を売る売店です
 
 [BATFL]
-STR_NAME    :Swinging Cars
+STR_NAME    :スイング車両
 STR_DESC    :上部のレールからスイングする、小さい車両です
 STR_CPTY    :各車両2名
 
@@ -4533,41 +4533,41 @@ STR_DESC    :丸い小型ボートで、乗客が操作する中央部のモー�
 STR_CPTY    :各ボート2名
 
 [BMAIR]
-STR_NAME    :Flying Roller Coaster
+STR_NAME    :フライング・ローラーコースター
 STR_DESC    :コースの下にある快適な座席に座り、ひねったコースによって究極の飛行体験が楽しめるコースターです
 STR_CPTY    :各車両4名
 
 [BMFL]
-STR_NAME    :Floorless Roller Coaster
+STR_NAME    :フロアレス・ジェットコースター
 STR_DESC    :床がない幅広のコースターで、コースにはひねりと複数の反転があり、あたかも空を飛んでいるような気分になります
 STR_CPTY    :各車両4名
 
 [BMRB]
-STR_NAME    :Hyper-Twister Trains (wide cars)
-STR_DESC    :?字型で高い座席のある幅広のコースターで、簡単な膝の安全バーを備えています
+STR_NAME    :ハイパー・ツイスター・トレイン (広い車両)
+STR_DESC    :型で高い座席のある幅広のコースターで、簡単な膝の安全バーを備えています
 STR_CPTY    :各車両4名
 
 [BMSD]
-STR_NAME    :Twister Roller Coaster
+STR_NAME    :ツイスター・ジェットコースター
 STR_DESC    :さまざまな反転を持つスムーズなスチールコースを滑走する幅広のローラーコースターです
 STR_CPTY    :各車両4名
 
 [BMSU]
-STR_NAME    :Stand-up Twister Coaster
+STR_NAME    :立ち乗り・ツイスター・コースター
 STR_DESC    :特殊な安全装置の付いた幅広の立ち乗りコースターで、スムーズな降下や複数の反転のあるコースを疾走します
 STR_CPTY    :各車両4名
 
 [BMVD]
-STR_NAME    :Vertical Drop Roller Coaster
+STR_NAME    :バーティカル・ドロップ・ジェットコースター
 STR_DESC    :超幅広の車両が垂直に切り立ったコースを降下する、究極のフリーフォール体験ができるコースターです
 STR_CPTY    :各車両6名
 
 [BNOODLES]
-STR_NAME    :Beef Noodles Stall
-STR_DESC    :中華風ビーフヌードルを売るお店です
+STR_NAME    :牛肉ヌードルショップ
+STR_DESC    :中華風牛肉ヌードルを売るお店です
 
 [BOB1]
-STR_NAME    :Bobsleigh Coaster
+STR_NAME    :ボブスレー・コースター
 STR_DESC    :半円形のコースを、カーブとバンクだけで支えられたボブスレー形の車両が疾走するコースターです
 STR_CPTY    :各車両2名
 
@@ -4607,7 +4607,7 @@ STR_NAME    :フライドポテト・ショップ
 STR_DESC    :フライドポテトを売る売店です
 
 [CINDR]
-STR_NAME    :Sujongkwa Stall
+STR_NAME    :スジョングァ・ショップ
 STR_DESC    :韓国風の柿ジュースを売る売店です
 
 [CIRCUS1]
@@ -4616,66 +4616,66 @@ STR_DESC    :動物のサーカスショーをやっている大テントです
 STR_CPTY    :定員30名
 
 [CLIFT1]
-STR_NAME    :Chairlift Cars
+STR_NAME    :チェアリフト車両
 STR_DESC    :屋根のないリフトカーです
 STR_CPTY    :各車両2名
 
 [CLIFT2]
-STR_NAME    :Ski-lift Chairs
+STR_NAME    :スキーリフト車両
 STR_DESC    :屋根のないリフトカーです
 STR_CPTY    :各車両2名
 
 [CNDYF]
-STR_NAME    :Candyfloss Stall
+STR_NAME    :綿菓子ショップ
 STR_DESC    :ピンク色の綿菓子を売る、綿菓子形の売店です
 
 [COFFS]
-STR_NAME    :Coffee Shop
+STR_NAME    :コーヒーショップ
 STR_DESC    :コーヒーを売るアールデコ風の売店です
 
 [COOKST]
-STR_NAME    :Cookie Shop
+STR_NAME    :クッキーショップ
 STR_DESC    :巨大なクッキーを売る売店です
 
 [CSTBOAT]
-STR_NAME    :Coaster Boats
+STR_NAME    :コースター・ボート
 STR_DESC    :ボート型の車両を持つローラーコースターです
 STR_CPTY    :各車両6名
 
 [CTCAR]
-STR_NAME    :Cheshire Cats
+STR_NAME    :チェシャ猫
 STR_DESC    :決められたコースにしたがって走る、動力つきの猫型車両です
 STR_CPTY    :各車両2名
 
 [DING1]
-STR_NAME    :Dinghy Slide
+STR_NAME    :ディンジー・スライド
 STR_DESC    :ねじれた半円形のコース、またはパイプの中を通るゴムボートです
 STR_CPTY    :各ボート2名
 
 [DODG1]
-STR_NAME    :Dodgems
+STR_NAME    :ダージャムズ
 STR_DESC    :乗客が運転する、電動のバンパーカーです
 STR_CPTY    :各車両1名
 
 [DOUGH]
-STR_NAME    :Doughnut Shop
+STR_NAME    :ドーナツショップ
 STR_DESC    :リングドーナツを売る売店です
 
 [DRNKS]
-STR_NAME    :Drinks Stall
+STR_NAME    :飲み物ショップ
 STR_DESC    :炭酸飲料を売る、缶の形の売店です
 
 [ENTERP]
-STR_NAME    :Enterprise
+STR_NAME    :エンタープライズ
 STR_DESC    :乗客の乗ったポッドがぶら下がった大きな輪が、回転しながら傾斜する乗物です
 STR_CPTY    :定員16名
 
 [FAID1]
-STR_NAME    :First Aid Room
+STR_NAME    :救護所
 STR_DESC    :気分の悪くなった来園客がここに来ると、早く治すことができます
 
 [FRNOOD]
-STR_NAME    :Fried Rice Noodles Stall
+STR_NAME    :焼飯ヌードル
 STR_DESC    :中華風の焼きビーフンを売る売店です
 
 [FSAUC]
@@ -4693,8 +4693,8 @@ STR_DESC    :屋根のないイスが付いた、大きな観覧車です
 STR_CPTY    :定員32名
 
 [GDROP1]
-STR_NAME    :Roto-Drop
-STR_DESC    :円形の座席がゆっくりと回りながら高い塔の上まで上がり、落下して磁気ブレーキで?フトに止まります
+STR_NAME    :ロトドロップ
+STR_DESC    :円形の座席がゆっくりと回りながら高い塔の上まで上がり、落下して磁気ブレーキでリフトに止まります
 STR_CPTY    :定員16名
 
 [GOLF1]
@@ -4702,7 +4702,7 @@ STR_NAME    :ミニゴルフ
 STR_DESC    :やさしいミニゴルフゲームです
 
 [GOLTR]
-STR_NAME    :Hyper-Twister Trains
+STR_NAME    :ハイパー・ツイスター車両
 STR_DESC    :簡単な膝の安全バーだけが付いた、広々とした列車です
 STR_CPTY    :各車両6名
 
@@ -4734,7 +4734,7 @@ STR_NAME    :迷路
 STR_DESC    :高さ6フィート(約1.8m)の生垣または壁を持つ迷路で、出口が見つからないと出られません
 
 [HMCAR]
-STR_NAME    :Haunted Mansion Ride
+STR_NAME    :ホーンテッド・マンション・ライド
 STR_DESC    :特殊な仕掛けと景観が施された多層式のコースを、動力付きの車両が走行する乗物です
 STR_CPTY    :各車両2名
 
@@ -4763,12 +4763,12 @@ STR_NAME    :インフォーメーションキオスク
 STR_DESC    :園内の案内図や傘を売る売店です
 
 [INTBOB]
-STR_NAME    :Flying Turns
+STR_NAME    :フライング・ターン
 STR_DESC    :ひねりのある半円形のコースを、カーブとバンクだけで支えられた大きなボブスレー形の車両が疾走するコースターです
 STR_CPTY    :各車両6名
 
 [INTINV]
-STR_NAME    :Inverted Impulse Coaster
+STR_NAME    :インバーテッド・インパルス・コースター
 STR_DESC    :逆向きのローラーコースターで、発着所から加速して発進し、垂直な絶壁を駆け上ると今度は後ろから発着所に戻り、もうひとつの絶壁を後ろ向きに登ります
 STR_CPTY    :各車両4名
 
@@ -4778,27 +4778,27 @@ STR_DESC    :300フィート(約91m)もの高さの丘と、スムーズな降�
 STR_CPTY    :各車両4名
 
 [IVMC1]
-STR_NAME    :Inverted Hairpin Coaster
+STR_NAME    :インバーテッド・ヘアピン・コースター
 STR_DESC    :ジグザグのコースの下に個別の車両があり、ヘアピンや急降下を進むコースターです
 STR_CPTY    :各車両4名
 
 [JSKI]
-STR_NAME    :Jet Skis
+STR_NAME    :ジェットスキー
 STR_DESC    :乗客が自分で操縦できる、ひとり乗りのジェットスキーです
 STR_CPTY    :各1名
 
 [JSTAR1]
-STR_NAME    :Toboggan Cars
+STR_NAME    :トボガン車両
 STR_DESC    :リュージュ形の座席が直列したローラーコースターです
 STR_CPTY    :各車両4名
 
 [KART1]
-STR_NAME    :Go Karts
-STR_DESC    :自分で操縦する、ガ?リンエンジンのゴーカートです
+STR_NAME    :ゴーカート
+STR_DESC    :自分で操縦する、ガソリンエンジンのゴーカートです
 STR_CPTY    :各車両1名
 
 [LEMST]
-STR_NAME    :Lemonade Stall
+STR_NAME    :レモネードショップ
 STR_DESC    :レモネードを売る売店です
 
 [LFB1]
@@ -4812,16 +4812,16 @@ STR_DESC    :垂直なタワーの各階を移動する際のエレベーター�
 STR_CPTY    :定員16名
 
 [MBSOUP]
-STR_NAME    :Meatball Soup Stall
-STR_DESC    :中華風の肉だんごスープを売る売店です
+STR_NAME    :肉団子スープショップ
+STR_DESC    :中華風の肉団子スープを売る売店です
 
 [MCARPET1]
-STR_NAME    :Magic Carpet
+STR_NAME    :空飛ぶ絨毯
 STR_DESC    :4本のアームの端に大きな空飛ぶじゅうたんの車両が付き、上下しながら回転する乗物です
 STR_CPTY    :定員12名
 
 [MFT]
-STR_NAME    :Articulated Roller Coaster Trains
+STR_NAME    :接合式ローラーコースター列車
 STR_DESC    :前の空いた短い車両のローラーコースターです
 STR_CPTY    :各車両2名
 
@@ -4831,37 +4831,37 @@ STR_DESC    :昔ながらの木彫りの回転木馬です
 STR_CPTY    :定員16名
 
 [MONBK]
-STR_NAME    :Monorail Cycles
+STR_NAME    :モノレール自転車
 STR_DESC    :乗客がペダルで漕ぐ、スチールのモノレールコースを走る特殊な自転車の乗物です
 STR_CPTY    :各車両1名
 
 [MONO1]
-STR_NAME    :Streamlined Monorail Trains
+STR_NAME    :流線型のモノレール車両
 STR_DESC    :流線型の先頭車と客車から成る、定員の多いモノレールです
 STR_CPTY    :各車両5名または10名
 
 [MONO2]
-STR_NAME    :Small Monorail Cars
+STR_NAME    :小さなモノレール車両
 STR_DESC    :横の空いた小さなモノレールです
 STR_CPTY    :各車両4名
 
 [MONO3]
-STR_NAME    :Retro-style Monorail Trains
+STR_NAME    :レトロスタイル・モノレール車両
 STR_DESC    :オープンキャビンを持つモノレールです
 STR_CPTY    :各車両4名
 
 [NEMT]
-STR_NAME    :Inverted Roller Coaster
+STR_NAME    :インバーテッド・ジェットコースター
 STR_DESC    :コースの下にぶら下がった座席があり、コースには巨大ループ、ひねり、急降下があります
 STR_CPTY    :各車両4名
 
 [NRL]
-STR_NAME    :Steam Trains
+STR_NAME    :蒸気機関車
 STR_DESC    :レプリカの蒸気機関車と炭水車、屋根なしの木製客車からなるミニチュア列車です
 STR_CPTY    :各車両6名
 
 [NRL2]
-STR_NAME    :Steam Trains with Covered Cars
+STR_NAME    :屋根の蒸気機関車
 STR_DESC    :レプリカの蒸気機関車と炭水車、布製の屋根の木製客車からなるミニチュア列車です
 STR_CPTY    :各車両6名
 
@@ -4880,7 +4880,7 @@ STR_NAME    :ピザショップ
 STR_DESC    :ピザを売る売店です
 
 [PMT1]
-STR_NAME    :Mine Ride
+STR_NAME    :マイン・ライド
 STR_DESC    :動力付きの鉱山列車がスムーズでひねりのあるコースを進む乗物です
 STR_CPTY    :各車両2名または4名
 
@@ -4898,17 +4898,17 @@ STR_NAME    :プレッツェル・ショップ
 STR_DESC    :サクサクのプレッツェルを売る売店です
 
 [PTCT1]
-STR_NAME    :Wooden Roller Coaster Trains
+STR_NAME    :木のコースター・トレーン
 STR_DESC    :膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターです
 STR_CPTY    :各車両4名
 
 [PTCT2]
-STR_NAME    :Wooden Roller Coaster Trains (6 seater)
+STR_NAME    :木のコースター・トレーン (6人乗り)
 STR_DESC    :膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターです
 STR_CPTY    :各車両6名
 
 [PTCT2R]
-STR_NAME    :Wooden Roller Coaster Trains (6 seater, Reversed)
+STR_NAME    :木のコースター・トレーン (6人乗り, 逆走)
 STR_DESC    :膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターで、座席が後ろ向きになっています
 STR_CPTY    :各車両6名
 
@@ -4923,81 +4923,81 @@ STR_DESC    :乗客が自分で漕ぐ手漕ぎボートです
 STR_CPTY    :各ボート2名
 
 [RCKC]
-STR_NAME    :Rocket Cars
+STR_NAME    :ロケットカー
 STR_DESC    :車両をロケットに見立てたローラーコースターです
 STR_CPTY    :各車両4名
 
 [RCR]
-STR_NAME    :Racing Cars
+STR_NAME    :レーシングカー
 STR_DESC    :レーシングカーの形をした、動力付きの車両です
 STR_CPTY    :各車両1名
 
 [REVCAR]
-STR_NAME    :Reverser Roller Coaster
+STR_NAME    :逆向きジェットコースター
 STR_DESC    :特殊な反転ターンがある木製のコースをボギー車両が走行するコースターです
 STR_CPTY    :各車両6名
 
 [REVF1]
-STR_NAME    :Reverse Freefall Car
+STR_NAME    :逆向きフリーフォールカー
 STR_DESC    :逆向きフリーフォールのある、大型コースターです
 STR_CPTY    :各車両8名
 
 [RFTBOAT]
-STR_NAME    :River Rafts
-STR_DESC    :いかだの形のボートが、ゆるやかに曲がりくねった川のコースを進む乗物です
+STR_NAME    :川いかだ
+STR_DESC    :川いかだの形のボートが、ゆるやかに曲がりくねった川のコースを進む乗物です
 STR_CPTY    :各ボート4名
 
 [RSAUS]
-STR_NAME    :Roast Sausage Stall
-STR_DESC    :中華風のロースト?ーセージを売る売店です
+STR_NAME    :ローストソーセージショップ
+STR_DESC    :中華風のローストソーセージを売る売店です
 
 [SBOX]
-STR_NAME    :Soap Box Derby Racers
+STR_NAME    :石鹸箱ダービーレース
 STR_DESC    :石鹸入れの形をした車両の、シングルレールコースのローラーコースターです
 STR_CPTY    :各車両4名
 
 [SCHT1]
-STR_NAME    :Roller Coaster Trains
-STR_DESC    :垂直ループが可?な、膝の安全バーが付いたローラーコースターです
+STR_NAME    :ジェットコースター車両
+STR_DESC    :垂直ループが可能な、膝の安全バーが付いたローラーコースターです
 STR_CPTY    :各車両4名
 
 [SFRIC1]
-STR_NAME    :Wooden Side-Friction Cars
+STR_NAME    :木造のサイドフリクション車両
 STR_DESC    :ベーシックな車両の、サイドフリクションローラーコースターです
 STR_CPTY    :各車両4名
 
 [SIMPOD]
-STR_NAME    :Motion Simulator
+STR_NAME    :動くシミュレーター
 STR_DESC    :映像に合わせて油圧可動式のポッドが動くシミュレーターです
 STR_CPTY    :定員8名
 
 [SKYTR]
-STR_NAME    :Mini Suspended Flying Coaster
+STR_NAME    :ミニ・サスペンデッド・フライング・コースター
 STR_DESC    :シングルレールコースの特殊なデザインの車両から乗客がうつぶせにぶら下がり、コーナーでは左右に振られるコースターです
 STR_CPTY    :各車両1名
 
 [SLCFO]
-STR_NAME    :Inverted Shuttle Coaster
+STR_NAME    :インバーテッド・シャトル・コースター
 STR_DESC    :乗客は前後に向かい合って座り、きつい反転やループ、ひねりのあるコースを走行するコースターです
 STR_CPTY    :各車両4名
 
 [SLCT]
-STR_NAME    :Compact Inverted Coaster
+STR_NAME    :コンパクト・インバーテッド・コースター
 STR_DESC    :乗客はペアになってコースの下にぶら下がり、きつい反転やループ、ひねりのあるコースを走行するコースターです
 STR_CPTY    :各車両2名
 
 [SMC1]
-STR_NAME    :Mouse Cars
+STR_NAME    :ネズミ車両
 STR_DESC    :各車両がネズミの形をした乗物です
 STR_CPTY    :各車両4名
 
 [SMC2]
-STR_NAME    :Mine Cars
+STR_NAME    :マイン・カー
 STR_DESC    :木製のトロッコ型の個別の車両です
 STR_CPTY    :各車両4名
 
 [SMONO]
-STR_NAME    :Suspended Monorail Trains
+STR_NAME    :サスベンデッド・モノレール・トレーン
 STR_DESC    :大定員のモノレールです
 STR_CPTY    :各車両8名
 
@@ -5098,7 +5098,7 @@ STR_NAME    :リンゴ飴店
 STR_DESC    :棒にさしたリンゴアメを売る、リンゴ形の売店です
 
 [TOGST]
-STR_NAME    :Stand-up Roller Coaster
+STR_NAME    :立ち乗りローラーコースター
 STR_DESC    :立ち乗りの、ループローラーコースターです
 STR_CPTY    :各車両4名
 
@@ -5142,7 +5142,7 @@ STR_DESC    :ハート形のひねりを持つローラーコースターです
 STR_CPTY    :各車両4名
 
 [UTCARR]
-STR_NAME    :ツイスト (starting reversed)
+STR_NAME    :ツイスト (逆走で始まる)
 STR_DESC    :ハート形のひねりを持つローラーコースター(逆向きスタート)です
 STR_CPTY    :各車両4名
 
@@ -5162,7 +5162,7 @@ STR_DESC    :乗客は特別なハーネスにより寝た状態で固定され�
 STR_CPTY    :各車両4名
 
 [VEKVAMP]
-STR_NAME    :Swinging Floorless Cars
+STR_NAME    :スイング・フロアレス車両
 STR_DESC    :チェアリフトタイプの座席に座ってぶら下がるローラーコースターで、コーナーで大きく揺れ動きます
 STR_CPTY    :各車両2名
 
@@ -5506,7 +5506,7 @@ STR_NAME    :家
 STR_NAME    :パゴダ
 
 [SPS]
-STR_NAME    :ガ?リンスタンド
+STR_NAME    :ガソリンスタンド
 
 [SPYR]
 STR_NAME    :ピラミッド
@@ -5861,13 +5861,13 @@ STR_NAME    :ポール
 STR_NAME    :ポール
 
 [SUPPW1]
-STR_NAME    :支持?造物
+STR_NAME    :支持構造物
 
 [SUPPW2]
-STR_NAME    :支持?造物
+STR_NAME    :支持構造物
 
 [SUPPW3]
-STR_NAME    :支持?造物
+STR_NAME    :支持構造物
 
 [TAC]
 STR_NAME    :アリゾナ糸杉
@@ -6230,7 +6230,7 @@ STR_NAME    :木
 STR_NAME    :木
 
 [TLC]
-STR_NAME    :ロー?ン糸杉
+STR_NAME    :ローソン糸杉
 
 [TLP]
 STR_NAME    :セイヨウハコヤナギ


### PR DESCRIPTION
This should make the translation cover most, if not all, of the game's base rides and attractions. The expansion pack's rides will probably be introduced after the rest of the file is done.

NB: from now on, I'll be translating 'landscape' with 地形 (terrain) instead of 景色 (landscape/scenery) to prevent any confusion with 景色物 (scenery).