### PR TITLE
ja-JP: translations for ride construction; apply #1349

### DIFF
--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -828,7 +828,7 @@ STR_0823    :Missing or inaccessible data file
 STR_0824    :{BLACK}{CROSS}
 STR_0825    :Chosen name in use already
 STR_0826    :Too many names defined
-STR_0827    :Not enough cash - requires {CURRENCY2DP}
+STR_0827    :資金不足です！{CURRENCY2DP}が必要です。
 STR_0828    :{SMALLFONT}{BLACK}ウィンドウを閉める
 STR_0829    :{SMALLFONT}{BLACK}ウィンドウのタイトル - これをドラッグさせる
 STR_0830    :{SMALLFONT}{BLACK}ズームアウト
@@ -894,53 +894,53 @@ STR_0888    :トラックデザイナーを閉める
 STR_0889    :トラックデザインマネージャを閉じる
 STR_0890    :<removed string - do not use>
 STR_0891    :スクリーンショット
-STR_0892    :Screenshot saved to disk as '{STRINGID}'
-STR_0893    :Screenshot failed !
+STR_0892    :スクリーンショットが「{STRINGID}」でセーブしました。
+STR_0893    :スクリーンショット失敗しました!
 STR_0894    :Landscape data area full !
 STR_0895    :Can't build partly above and partly below ground
 STR_0896    :{POP16}{POP16}{STRINGID}の建設
 STR_0897    :方向
-STR_0898    :{SMALLFONT}{BLACK}Left-hand curve
-STR_0899    :{SMALLFONT}{BLACK}Right-hand curve
-STR_0900    :{SMALLFONT}{BLACK}Left-hand curve (small radius)
-STR_0901    :{SMALLFONT}{BLACK}Right-hand curve (small radius)
-STR_0902    :{SMALLFONT}{BLACK}Left-hand curve (very small radius)
-STR_0903    :{SMALLFONT}{BLACK}Right-hand curve (very small radius)
-STR_0904    :{SMALLFONT}{BLACK}Left-hand curve (large radius)
-STR_0905    :{SMALLFONT}{BLACK}Right-hand curve (large radius)
+STR_0898    :{SMALLFONT}{BLACK}左手にカーブ
+STR_0899    :{SMALLFONT}{BLACK}右手にカーブ
+STR_0900    :{SMALLFONT}{BLACK}左手にカーブ (小さい半径)
+STR_0901    :{SMALLFONT}{BLACK}右手にカーブ (小さい半径)
+STR_0902    :{SMALLFONT}{BLACK}左手にカーブ (非常に小さい半径)
+STR_0903    :{SMALLFONT}{BLACK}右手にカーブ (非常に小さい半径)
+STR_0904    :{SMALLFONT}{BLACK}左手にカーブ (大きい半径)
+STR_0905    :{SMALLFONT}{BLACK}右手にカーブ (大きい半径)
 STR_0906    :{SMALLFONT}{BLACK}直線トラック
 STR_0907    :傾斜
 STR_0908    :カーブとバンク
-STR_0909    :Seat Rot.
-STR_0910    :{SMALLFONT}{BLACK}Roll for left-hand curve
-STR_0911    :{SMALLFONT}{BLACK}Roll for right-hand curve
-STR_0912    :{SMALLFONT}{BLACK}No roll
-STR_0913    :{SMALLFONT}{BLACK}Move to previous section
-STR_0914    :{SMALLFONT}{BLACK}Move to next section
-STR_0915    :{SMALLFONT}{BLACK}Construct the selected section
-STR_0916    :{SMALLFONT}{BLACK}Remove the highlighted section
+STR_0909    :席の回転角
+STR_0910    :{SMALLFONT}{BLACK}左手にカーブのロール
+STR_0911    :{SMALLFONT}{BLACK}右手にカーブのロール
+STR_0912    :{SMALLFONT}{BLACK}ロールなし
+STR_0913    :{SMALLFONT}{BLACK}前のセクションに進む
+STR_0914    :{SMALLFONT}{BLACK}次のセクションに進む
+STR_0915    :{SMALLFONT}{BLACK}選んだセクションを建設する
+STR_0916    :{SMALLFONT}{BLACK}選んだセクションを削除する
 STR_0917    :{SMALLFONT}{BLACK}バーティカル・ドロップ
-STR_0918    :{SMALLFONT}{BLACK}Steep slope down
-STR_0919    :{SMALLFONT}{BLACK}Slope down
-STR_0920    :{SMALLFONT}{BLACK}Level
-STR_0921    :{SMALLFONT}{BLACK}Slope up
-STR_0922    :{SMALLFONT}{BLACK}Steep slope up
-STR_0923    :{SMALLFONT}{BLACK}Vertical rise
-STR_0924    :{SMALLFONT}{BLACK}下の螺旋
-STR_0925    :{SMALLFONT}{BLACK}上の螺旋
-STR_0926    :Can't remove this...
-STR_0927    :Can't construct this here...
-STR_0928    :{SMALLFONT}{BLACK}Chain lift, to pull cars up slopes
+STR_0918    :{SMALLFONT}{BLACK}下り急なスロープ
+STR_0919    :{SMALLFONT}{BLACK}下りスロープ
+STR_0920    :{SMALLFONT}{BLACK}平準
+STR_0921    :{SMALLFONT}{BLACK}上りスロープ
+STR_0922    :{SMALLFONT}{BLACK}上り急なスロープ
+STR_0923    :{SMALLFONT}{BLACK}垂直ライズ
+STR_0924    :{SMALLFONT}{BLACK}下り螺旋
+STR_0925    :{SMALLFONT}{BLACK}上り螺旋
+STR_0926    :それを削除できません。
+STR_0927    :ここでそれを建設できません。
+STR_0928    :{SMALLFONT}{BLACK}チェーン・リフト、スロープに上るために
 STR_0929    :S字カーブ (左)
 STR_0930    :S字カーブ (右)
-STR_0931    :Vertical Loop (left)
-STR_0932    :Vertical Loop (right)
-STR_0933    :Raise or lower land first
-STR_0934    :Ride entrance in the way
-STR_0935    :Ride exit in the way
-STR_0936    :Park entrance in the way
-STR_0937    :{SMALLFONT}{BLACK}View options
-STR_0938    :{SMALLFONT}{BLACK}Adjust land height and slope
+STR_0931    :垂直ループ (左)
+STR_0932    :垂直ループ (右)
+STR_0933    :土地を上げたり下げたりするが必要です。
+STR_0934    :途中でライドの入り口があります！
+STR_0935    :途中でライドの出口があります！
+STR_0936    :途中でパークの入口があります！
+STR_0937    :{SMALLFONT}{BLACK}設定の表示
+STR_0938    :{SMALLFONT}{BLACK}土地の高さと勾配を調整する
 STR_0939    :地形の穴を表示する
 STR_0940    :地形透明度の切り替え
 STR_0941    :垂直面透明度の切り替え
@@ -957,7 +957,7 @@ STR_0951    :ゲームを閉じる
 STR_0952    :ゲームを閉じる
 STR_0953    :景色をロードする
 STR_0954    :
-STR_0955    :{SMALLFONT}{BLACK}Select seat rotation angle for this track section
+STR_0955    :{SMALLFONT}{BLACK}このトラックセクションの席の回転角を選択する
 STR_0956    :-180{DEGREE}
 STR_0957    :-135{DEGREE}
 STR_0958    :-90{DEGREE}
@@ -994,10 +994,10 @@ STR_0988    :Can't create new ride/attraction...
 STR_0989    :{STRINGID}
 STR_0990    :{SMALLFONT}{BLACK}建設
 STR_0991    :乗り場
-STR_0992    :{SMALLFONT}{BLACK}Demolish entire ride/attraction
+STR_0992    :{SMALLFONT}{BLACK}全てのライドを解体する
 STR_0993    :ライド/アトラクションを解体します
 STR_0994    :解体する
-STR_0995    :{WINDOW_COLOUR_1}Are you sure you want to completely demolish {STRINGID}?
+STR_0995    :{WINDOW_COLOUR_1}{STRINGID}を全て解体したいですか?
 STR_0996    :全体を見る
 STR_0997    :{SMALLFONT}{BLACK}View selection
 STR_0998    :No more stations allowed on this ride
@@ -1406,7 +1406,7 @@ STR_1400    :入口
 STR_1401    :出口
 STR_1402    :{SMALLFONT}{BLACK}Build or move entrance to ride/attraction
 STR_1403    :{SMALLFONT}{BLACK}Build or move exit from ride/attraction
-STR_1404    :{SMALLFONT}{BLACK}Rotate 90{DEGREE}
+STR_1404    :{SMALLFONT}{BLACK}90{DEGREE}で回転
 STR_1405    :{SMALLFONT}{BLACK}Mirror image
 STR_1406    :{SMALLFONT}{BLACK}Toggle scenery on/off (if available for this design)
 STR_1407    :{WINDOW_COLOUR_2}これを建設
@@ -1414,8 +1414,8 @@ STR_1408    :{WINDOW_COLOUR_2}コスト: {BLACK}{CURRENCY}
 STR_1409    :Entry/Exit Platform
 STR_1410    :垂直の塔
 STR_1411    :{STRINGID} in the way
-STR_1412    :{WINDOW_COLOUR_3}Data logging not available for this type of ride
-STR_1413    :{WINDOW_COLOUR_3}Data logging will start when next {STRINGID} leaves {STRINGID}
+STR_1412    :{WINDOW_COLOUR_3}データロギングはこのライドには利用できません。
+STR_1413    :{WINDOW_COLOUR_3}{STRINGID}が{STRINGID}出発時にデータロギングが始まります。
 STR_1414    :{SMALLFONT}{BLACK}{DURATION}
 STR_1415    :{WINDOW_COLOUR_2}速度
 STR_1416    :{WINDOW_COLOUR_2}高度
@@ -2278,9 +2278,9 @@ STR_2270    :{WINDOW_COLOUR_2}進歩: {BLACK}{STRINGID}
 STR_2271    :{WINDOW_COLOUR_2}予定: {BLACK}{STRINGID}
 STR_2272    :{WINDOW_COLOUR_2}ライド／アトラクション:{NEWLINE}{BLACK}{STRINGID}
 STR_2273    :{WINDOW_COLOUR_2}景観とテーマ:{NEWLINE}{BLACK}{STRINGID}
-STR_2274    :{SMALLFONT}{BLACK}Show details of this invention or development
-STR_2275    :{SMALLFONT}{BLACK}Show funding and options for research & development
-STR_2276    :{SMALLFONT}{BLACK}Show research & development status
+STR_2274    :{SMALLFONT}{BLACK}この発明の詳細の表示
+STR_2275    :{SMALLFONT}{BLACK}研究資金の設定の表示
+STR_2276    :{SMALLFONT}{BLACK}研究ステータスの表示
 STR_2277    :未知
 STR_2278    :輸送ライド
 STR_2279    :ゲントルライド
@@ -2329,8 +2329,8 @@ STR_2321    :{WINDOW_COLOUR_2}ライド／アトラクションの数: {BLACK}{C
 STR_2322    :{WINDOW_COLOUR_2}スタッフ: {BLACK}{COMMA16}
 STR_2323    :{WINDOW_COLOUR_2}パークサイズ: {BLACK}{COMMA32}m{SQUARED}
 STR_2324    :{WINDOW_COLOUR_2}パークサイズ: {BLACK}{COMMA32}sq.ft.
-STR_2325    :{SMALLFONT}{BLACK}Buy land to extend park
-STR_2326    :{SMALLFONT}{BLACK}Buy construction rights to allow construction above or below land outside the park
+STR_2325    :{SMALLFONT}{BLACK}パーク敷地を購入する
+STR_2326    :{SMALLFONT}{BLACK}土地の上または下に建設を許可するために、土地利用権を購入する
 STR_2327    :設定
 STR_2328    :{WINDOW_COLOUR_2}通貨:
 STR_2329    :{WINDOW_COLOUR_2}距離と速力:
@@ -3464,15 +3464,15 @@ STR_5124    :<removed string - do not use>
 STR_5125    :All destructible
 STR_5126    :ランダムのタイトル音楽
 STR_5127    :{SMALLFONT}{BLACK}While dragging, paint landscape instead of changing elevation
-STR_5128    :Selection size
-STR_5129    :Enter selection size between {COMMA16} and {COMMA16}
+STR_5128    :選択範囲
+STR_5129    :{COMMA16}と{COMMA16}の間に選択範囲を入力して下さい。
 STR_5130    :マップサイズ
-STR_5131    :Enter map size between {COMMA16} and {COMMA16}
+STR_5131    :{COMMA16}と{COMMA16}の間にマップサイズを入力して下さい。
 STR_5132    :Fix all rides
-STR_5133    :{SMALLFONT}{BLACK}Adjust smaller area of land rights
-STR_5134    :{SMALLFONT}{BLACK}Adjust larger area of land rights
-STR_5135    :{SMALLFONT}{BLACK}Buy land rights and construction rights
-STR_5136    :Land rights
+STR_5133    :{SMALLFONT}{BLACK}パーク敷地のもっと小量の調整
+STR_5134    :{SMALLFONT}{BLACK}パーク敷地のもっと大量の調整
+STR_5135    :{SMALLFONT}{BLACK}パーク敷地や土地利用権を購入する
+STR_5136    :パーク敷地
 STR_5137    :Unlock operating limits
 STR_5138    :{SMALLFONT}{WINDOW_COLOUR_2}{STRINGID}
 STR_5139    :{WHITE}{STRINGID}
@@ -3519,10 +3519,10 @@ STR_5179    :{SMALLFONT}{BLACK}ゲストのカニング
 STR_5180    :{SMALLFONT}{BLACK}パクのカニング
 STR_5181    :{SMALLFONT}{BLACK}ライドのカニング
 STR_5182    :{INT32}
-STR_5183    :Base height
-STR_5184    :Enter base height between {COMMA16} and {COMMA16}
-STR_5185    :Water level
-STR_5186    :Enter water level between {COMMA16} and {COMMA16} 
+STR_5183    :基地の高さ
+STR_5184    :{COMMA16}と{COMMA16}の間基地の高さを入力して下さい。
+STR_5185    :水位
+STR_5186    :{COMMA16}と{COMMA16}の間水位を入力して下さい。
 STR_5187    :財務表
 STR_5188    :新しいキャンペーン
 STR_5189    :研究
@@ -4435,10 +4435,10 @@ STR_6125    :オブジェクトのタイプ
 STR_6126    :タイプ未知
 STR_6127    :ファイル: {STRING}
 STR_6128    :The file could not be loaded as some of the objects referenced in it are missing or corrupt. A list of these objects is given below.
-STR_6129    :Copy selected item to clipboard
-STR_6130    :Copy entire list to clipboard
+STR_6129    :このアイテムをクリップボードにコッピーする
+STR_6130    :全てをクリップボードにコッピーする
 STR_6131    :オブジェクト源
-STR_6132    :Ignore research status
+STR_6132    :研究のステータスを無視する
 STR_6133    :{SMALLFONT}{BLACK}Access rides and scenery that have not yet been invented
 STR_6134    :景色物をクリアする
 STR_6135    :Client sent invalid request
@@ -4477,6 +4477,9 @@ STR_6167    :{SMALLFONT}{BLACK}先行制御
 STR_6168    :タイトルシーケンス
 STR_6169    :シナリオ選択
 STR_6170    :微調整
+STR_6171    :検索
+STR_6172    :{SMALLFONT}{BLACK}検索
+STR_6173    :検索の名を入力して下さい。
 
 
 #####################


### PR DESCRIPTION
Adding translations for the ride construction window, and some miscellaneous smaller windows. Also applying #1349.

(I love how 'Seat rotation' can just be translated with 席の回転角, which doesn't need shortening in the interface — cf. 'Seat rot.')