### PR TITLE
nl-NL: Apply #1630

### DIFF
--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -3739,7 +3739,7 @@ STR_6272    :Stations
 STR_6273    :Muziek
 STR_6274    :Kan kleurenschema niet instellen...
 STR_6275    :{WINDOW_COLOUR_2}Stationsstijl:
-STR_6276    :{RED} Bezoekers komen vast te zitten in {STRINGID}, mogelijk door een ongeldig attractietype of bedrijfsmodus.
+STR_6276    :{RED}Bezoekers komen vast te zitten in {STRINGID}, mogelijk door een ongeldig attractietype of bedrijfsmodus.
 
 #############
 # Scenarios #

--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -3739,6 +3739,7 @@ STR_6272    :Stations
 STR_6273    :Muziek
 STR_6274    :Kan kleurenschema niet instellen...
 STR_6275    :{WINDOW_COLOUR_2}Stationsstijl:
+STR_6276    :{RED} Bezoekers komen vast te zitten in {STRINGID}, mogelijk door een ongeldig attractietype of bedrijfsmodus.
 
 #############
 # Scenarios #

--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -3739,7 +3739,7 @@ STR_6272    :Stations
 STR_6273    :Muziek
 STR_6274    :Kan kleurenschema niet instellen...
 STR_6275    :{WINDOW_COLOUR_2}Stationsstijl:
-STR_6276    :{RED}Bezoekers komen vast te zitten in {STRINGID}, mogelijk door een ongeldig attractietype of bedrijfsmodus.
+STR_6276    :{RED}Bezoekers komen vast te zitten in {STRINGID}, mogelijk door een ongeldig attractietype of ongeldige bedrijfsmodus.
 
 #############
 # Scenarios #


### PR DESCRIPTION
Applying for issue(s):
- #1630

Multiple translations for "operating mode" are currently in use, "werkmodus" and "bedrijfsmodus". I used "bedrijfsmodus" here since the cheat for unlocking all operating modes currently uses the same translation. Not sure if y'all have a preference for one or the other and if they should all be changed to the same translation.