### PR TITLE
Fix typo in nl-NL translations

### DIFF
--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -224,7 +224,7 @@ STR_0822    :Kan bestand met grafische gegevens niet openen
 STR_0823    :Ontbrekend of ontoegankelijk gegevensbestand
 STR_0824    :{BLACK}❌
 STR_0825    :Gekozen naam is al in gebruik
-STR_0826    :Teveel namen gedefinieerd
+STR_0826    :Te veel namen gedefinieerd
 STR_0827    :Onvoldoende geld - {CURRENCY2DP} benodigd
 STR_0828    :{SMALLFONT}{BLACK}Venster sluiten
 STR_0829    :{SMALLFONT}{BLACK}Venstertitel - Sleep dit om het venster te verplaatsen
@@ -365,7 +365,7 @@ STR_0983    :Onderzoek & Ontwikkeling
 STR_0984    :{WINDOW_COLOUR_2}▲{BLACK}  {CURRENCY2DP}
 STR_0985    :{WINDOW_COLOUR_2}▼{BLACK}  {CURRENCY2DP}
 STR_0986    :{BLACK}{CURRENCY2DP}
-STR_0987    :Teveel attracties
+STR_0987    :Te veel attracties
 STR_0988    :Kan geen nieuwe attractie aanmaken…
 STR_0989    :{STRINGID}
 STR_0990    :{SMALLFONT}{BLACK}Constructie
@@ -1076,7 +1076,7 @@ STR_1695    :{SMALLFONT}{BLACK}Inkomsten en kosten
 STR_1696    :{SMALLFONT}{BLACK}Klantinformatie
 STR_1697    :Dit kan niet op wachtrijen worden geplaatst
 STR_1698    :Dit kan alleen op wachtrijen worden geplaatst
-STR_1699    :Teveel personen in het spel
+STR_1699    :Te veel personen in het spel
 STR_1700    :Klusjesman aannemen…
 STR_1701    :Monteur aannemen…
 STR_1702    :Bewaker aannemen…
@@ -1084,7 +1084,7 @@ STR_1703    :Entertainer aannemen…
 STR_1704    :Kan geen nieuwe werknemer aannemen…
 STR_1705    :{SMALLFONT}{BLACK}Deze werknemer ontslaan
 STR_1706    :{SMALLFONT}{BLACK}Deze persoon naar een andere locatie verplaatsen
-STR_1707    :Teveel werknemers in dit park
+STR_1707    :Te veel werknemers in dit park
 STR_1708    :{SMALLFONT}{BLACK}Werkgebied van deze werknemer instellen
 STR_1709    :Werknemer ontslaan
 STR_1710    :Ja
@@ -2234,7 +2234,7 @@ STR_2976    :{SMALLFONT}{BLACK}Met het geselecteerde kleurenschema een onderdeel
 STR_2977    :Naam werknemer
 STR_2978    :Voer een nieuwe naam in voor deze werknemer:
 STR_2979    :Kan de naam van deze werknemer niet veranderen…
-STR_2980    :Teveel lichtkranten in dit park
+STR_2980    :Te veel lichtkranten in dit park
 STR_2981    :{RED}Geen toegang
 STR_2982    :Lichtkranttekst
 STR_2983    :Voer een nieuwe tekst in voer deze lichtkrant:
@@ -2403,7 +2403,7 @@ STR_3164    :{BLACK}{COMMA16} geselecteerd (maximum: {COMMA16})
 STR_3167    :{WINDOW_COLOUR_2}Bevat {BLACK}{COMMA16} objecten
 STR_3169    :Data voor de volgende objecten niet gevonden: 
 STR_3170    :Niet genoeg ruimte voor graphics.
-STR_3171    :er zijn teveel objecten van dit type geselecteerd.
+STR_3171    :er zijn te veel objecten van dit type geselecteerd.
 STR_3172    :De volgende objecten moeten eerst geselecteerd worden:
 STR_3173    :dit object is momenteel in gebruik.
 STR_3174    :een ander object is afhankelijk van dit object.
@@ -2458,7 +2458,7 @@ STR_3223    :{SMALLFONT}{BLACK}Instellen welk land gekocht kan worden door het p
 STR_3224    :{SMALLFONT}{BLACK}Instellen voor welk land bouwrechten te koop zijn
 STR_3225    :{SMALLFONT}{BLACK}Een willekeurig cluster van dit object neerzetten rondom de geselecteerde plek
 STR_3226    :{SMALLFONT}{BLACK}Parkingang bouwen
-STR_3227    :Teveel parkingangen!
+STR_3227    :Te veel parkingangen!
 STR_3228    :{SMALLFONT}{BLACK}Geef startposities voor bezoekers aan
 STR_3229    :Blokremmen kunnen niet direct na het station geplaatst worden
 STR_3230    :Blokremmen kunnen niet direct achter elkaar gebruikt worden
@@ -2574,7 +2574,7 @@ STR_3343    :Opgeslagen spel omzetten naar scenario
 STR_3344    :Baanontwerper
 STR_3345    :Baanontwerpbeheer
 STR_3346    :Kan baanontwerp niet opslaan
-STR_3347    :Attractie is te groot, bevat teveel elementen of het decor is te ver verspreid
+STR_3347    :Attractie is te groot, bevat te veel elementen of het decor is te ver verspreid
 STR_3348    :Hernoemen
 STR_3349    :Verwijderen
 STR_3350    :Naam baanontwerp
@@ -2599,7 +2599,7 @@ STR_3370    :{BLACK}= Informatiekiosk
 STR_3371    :{BLACK}= Eerste hulp
 STR_3372    :{BLACK}= Geldautomaat
 STR_3373    :{BLACK}= Toilet
-STR_3374    :Waarschuwing: teveel objecten geselecteerd!
+STR_3374    :Waarschuwing: te veel objecten geselecteerd!
 STR_3375    :Niet alle objecten in deze decorgroep kunnen worden geselecteerd
 STR_3376    :Installeren…
 STR_3377    :{SMALLFONT}{BLACK}Bestand met nieuw baanontwerp installeren


### PR DESCRIPTION
The translation of "too many" is incorrectly spelled as "teveel", the correct spelling is "te veel".

Source (in dutch):
https://onzetaal.nl/taaladvies/teveel-te-veel
