### PR TITLE
pt-BR: Correct string 5551 (y/m/d should be y/d/m)

### DIFF
--- a/data/language/pt-BR.txt
+++ b/data/language/pt-BR.txt
@@ -2908,7 +2908,7 @@ STR_5547    :{SMALLFONT}{BLACK}Rosa claro
 STR_5548    :Exibir todos os modos operacionais
 STR_5549    :Ano/Mês/Dia
 STR_5550    :{POP16}{POP16}Ano {COMMA16}, {PUSH16}{PUSH16}{MONTH} {PUSH16}{PUSH16}{STRINGID}
-STR_5551    :Ano/Mês/Dia
+STR_5551    :Ano/Dia/Mês
 STR_5552    :{POP16}{POP16}Ano {COMMA16}, {PUSH16}{PUSH16}{PUSH16}{STRINGID} {MONTH}
 STR_5553    :Pausar jogo quando a Steam estiver sobrepondo
 STR_5554    :{SMALLFONT}{BLACK}Habilitar ferramenta de montanha


### PR DESCRIPTION
Was the same as 5549 making it appear as if there was a redundant option in the date format dropdown.