### PR TITLE
ja-JP: add translations for WW/TT scenarios

### DIFF
--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -4341,3 +4341,164 @@ STR_DTLS    :不足しているシックスフラッグスの乗物を設置す�
 STR_SCNR    :シックスフラッグス・オーバーテキサス
 STR_PARK    :Six Flags over Texas
 STR_DTLS    : 不足しているシックスフラッグスの乗物を設置するか、またはご自分でオリジナルデザインの乗物を作成して遊園地を改良してください!しかし、本来の最終目標である、遊園地
+
+###############################################################################
+## Wacky Worlds Scenarios
+###############################################################################
+<Africa - African Diamond Mine>
+STR_SCNR    :アフリカ ・ ダイヤモンド鉱山
+STR_PARK    :アフリカの鉱山
+STR_DTLS    :You inherited a disused diamond mine, and find a valuable diamond.  You decide to invest that money to build a world-famous theme park.
+
+<Africa - Oasis>
+STR_SCNR    :アフリカ ・ オアシス
+STR_PARK    :ミラージュ・マッドネス
+STR_DTLS    :A desert Oasis has been discovered and would provide a beautiful location for a park. Transport to the oasis has been provided.
+
+<Africa - Victoria Falls>
+STR_SCNR    :アフリカ ・ ヴィクトリアの滝
+STR_PARK    :オーバー・ザ・エッジ
+STR_DTLS    :A dam has been built offering abundant, cheap hydroelectric power with which to run a park. You need to reach a high park value to help repay the loan for the dam.
+
+<Antarctic - Ecological Salvage>
+STR_SCNR    :南極 ・ 生態学的なサルベージ
+STR_PARK    :氷の冒険
+STR_DTLS    :The environment agency has turned to you to transform an old oil refinery ecological eyesore into a top tourist attraction. Land is cheap but loan interest is high. You can sell the old buildings for salvage.
+
+<Asia - Great Wall of China Tourism Enhancement>
+STR_SCNR    :アジア ・ 万里の長城ツーリズムの強化
+STR_PARK    :万里の長城
+STR_DTLS    :The authorities have decided to enhance tourism around the Great Wall by building a theme park on the adjacent land. Money is no object!
+
+<Asia - Japanese Coastal Reclaim>
+STR_SCNR    :アジア ・ 日本の沿岸再生
+STR_PARK    :沖縄海岸
+STR_DTLS    :An existing park has run out of space. Your only option is to build out into the sea, and so you have taken out a loan. Height restrictions on your building are enforced due to foundations and earthquake risk.
+
+<Asia - Maharaja Palace>
+STR_SCNR    :アジア ・ マハラジャのパレス
+STR_PARK    :パーク・マハラジャ
+STR_DTLS    :You have been commissioned by the Maharaja to bring entertainment to the large local population. Build a park inspired by the Maharaja's palace.
+
+<Australasia - Ayers Rock>
+STR_SCNR    :オーストラリア ・ エアーズロック
+STR_PARK    :エアーズ・アドベンチャー
+STR_DTLS    :You are helping Aboriginal people to build a park as part of a cultural awareness program. You need to get a large number of guests to educate them in the unique heritage of the Aboriginal people.
+
+<Australasia - Fun at the Beach>
+STR_SCNR    :オーストラリア ・ ビーチの楽しみ
+STR_PARK    :ビーチ・バーベキュー
+STR_DTLS    :A local entrepreneur's sealife park has gone bust. You already operate a small park and buy the other park from the construction company. Develop a big combined park.
+
+<Europe - European Cultural Festival>
+STR_SCNR    :ヨーロパ ・ ヨーロッパ文化祭
+STR_PARK    :ヨーロッパ文化祭
+STR_DTLS    :You have been brought in to take over a European Cultural Visitor Attraction and must increase the number of guests in order to pay back the EU subsidy by the end of the current European parliament term.
+
+<Europe - Renovation>
+STR_SCNR    :ヨーロパ ・ レノベーション
+STR_PARK    :灰の中から
+STR_DTLS    :An old park has fallen into disrepair. You gain a European Union grant to return this deprived area to its former glory! You need to renovate the park and repay the grant.
+
+<N. America - Extreme Hawaiian Island>
+STR_SCNR    :北アメリカ ・ ハワイ島
+STR_PARK    :ワッキー・ワイキキ
+STR_DTLS    :The people of Hawaii are bored of surfing and are looking for something more intense. You need to build a park with this in mind to keep the area's tourist attraction rating high.
+
+<North America - Grand Canyon>
+STR_SCNR    :北アメリカ ・ グランドキャニオン
+STR_PARK    :キャニオン・カラミティー
+STR_DTLS    :You have to build a park on limited land either side of this natural treasure - you do have the opportunity to buy neighbouring land from the Native American Indians. You need to complete the objective to sustain the local town's population.
+
+<North America - Rollercoaster Heaven>
+STR_SCNR    :北アメリカ ・ ジェットコースター天国
+STR_PARK    :ジェットコースター天国
+STR_DTLS    :You are a successful business tycoon on long sabbatical who desires to use this time transforming the city park into Rollercoaster Heaven. Money is no object!
+
+<South America - Inca Lost City>
+STR_SCNR    :南アメリカ ・ インカの失われた都市
+STR_PARK    :ロスト・シティ
+STR_DTLS    :To further boost local tourism you must construct a park that is in tune with its surroundings, and has height restrictions.
+
+<South America - Rain Forest Plateau>
+STR_SCNR    :南アメリカ ・ 熱帯雨林高原
+STR_PARK    :熱帯雨林高原
+STR_DTLS    :Space is limited in the precious rainforest - you must cram as much as possible into the existing clearing, in order to provide a viable alternative to the local timber industry.
+
+<South America - Rio Carnival>
+STR_SCNR    :南アメリカ ・ リオカーニバル
+STR_PARK    :シュガーローフ・ショアーズ
+STR_DTLS    :You run a small park near Rio but the bank has called in your loan. You need to quickly increase your earning capacity to repay this unexpected debt.
+
+###############################################################################
+## Time Twister Scenarios
+###############################################################################
+<Dark Age - Castle>
+STR_SCNR    :暗黒時代 ・ 崖側の城
+STR_PARK    :崖側の城
+STR_DTLS    :Local members of the battle re-enactment society are rather serious about their hobby. They've entrusted you with the job of constructing a Dark Age theme park on the grounds of Cliffside Castle.
+
+<Dark Age - Robin Hood>
+STR_SCNR    :暗黒時代 ・ ロビン・フッド
+STR_PARK    :シャーウッドの森
+STR_DTLS    :To liberate wealth from the rich and distribute it to the needy, you and your Merry Men have decided to build a theme park in Sherwood Forest.
+
+<Future - First Encounters>
+STR_SCNR    :未来 ・ 最初の出会い
+STR_PARK    :地球外な壮観
+STR_DTLS    :Life has been discovered on a distant planet Build an alien theme park to cash in on the unprecedented wave of interest.
+
+<Future - Future World>
+STR_SCNR    :未来 ・ 未来の世界
+STR_PARK    :ジェミニ・シティ
+STR_DTLS    :Show off your inventive, utopian vision of the future - come up with a futuristic park design that incorporates state-of-the-art attractions.
+
+<Mythological - Animatronic Film Set>
+STR_SCNR    :神話 - アニマトロニクス撮影現場
+STR_PARK    :アニマトロ・アンティクス
+STR_DTLS    :You have been given the task of running and improving an existing theme park, which has been built on an old film set. Build a tribute to the pioneering stop-motion animators who first brought mythical creatures to life on the silver screen.
+
+<Mythological - Cradle of Civilisation>
+STR_SCNR    :神話 - 世界四大文明
+STR_PARK    :神話の狂気
+STR_DTLS    :You own an island of particular archaeological value. You've decided to fund its preservation by constructing a theme park based on the area's rich Mythological heritage.
+
+<Prehistoric - After the Asteroid>
+STR_SCNR    :前史時代 ・ 小惑星の後
+STR_PARK    :クレーターの大虐殺
+STR_DTLS    :You own a dusty old meteor crater. In the true entrepreneurial spirit, you've decided to construct an asteroid theme park and convert your seemingly worthless land into a sizeable fortune.
+
+<Prehistoric - Jurassic Safari>
+STR_SCNR    :前史時代 ・ ジュラシックサファリ
+STR_PARK    :コースターサウルス
+STR_DTLS    :You've been given the task of constructing a Jurassic era theme park. To optimize your visitors' access to the exotic plant and animal exhibits, you will need to build rides going over and into the valley.
+
+<Prehistoric - Stone Age>
+STR_SCNR    :前史時代 ・ 石器文化
+STR_PARK    :ロッキー・ランブル
+STR_DTLS    :To thwart the highway developers and preserve the mysterious ancient stone circles, you will need to construct a Stone Age theme park and turn a profit. However, attracting visitors may pose a challenge, as the terrain is a tad inhospitable.
+
+<Roaring Twenties - Prison Island>
+STR_SCNR    :1920時代 - アルカトラズ島
+STR_PARK    :アルカトラズ
+STR_DTLS    :The infamous Prison Island - whose population once swelled with bootleggers and racketeers - is now up for sale. You've decided to convert it into a top tourist attraction, and money is no object
+
+<Roaring Twenties - Schneider Cup>
+STR_SCNR    :1920時代 - シュナイダー・レース
+STR_PARK    :シュナイダー・ショーズ
+STR_DTLS    :The 75th anniversary of your grandfather's Schneider Cup victory is coming up in a few years. You're going to honour his achievement by building a theme park based on the famous seaplane race.
+
+<Roaring Twenties - Skyscrapers>
+STR_SCNR    :1920時代 - 高層ビル
+STR_PARK    :メトロポリス
+STR_DTLS    :You own an empty lot near the low-rise part of town. To squeeze the most out of your urban property, build a skyscraper theme park inspired by the soaring art deco architecture of the twenties.
+
+<Rock 'n' Roll - Flower Power>
+STR_SCNR    :ロックンロール - フラワーパワー
+STR_PARK    :ウッドストック
+STR_DTLS    :A large annual music festival takes place on your land. Build a hip theme park to keep the free-spirited audience entertained.
+
+<Rock 'n' Roll - Rock 'n' Roll>
+STR_SCNR    :ロックンロール - ロックンロール
+STR_PARK    :ロックンロール・リバイバル
+STR_DTLS    :This aging theme park has seen better days. Help the owner give it a retro rock 'n' roll makeover and turn the place into a successful venue.


### PR DESCRIPTION
This adds Japanese translations for the Wacky Worlds and Time Twister scenario titles and park names. The descriptions have been left for a rainy day…