### PR TITLE
Fix new_and_changed issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
@@ -2,7 +2,7 @@
 name: New and Changed Strings
 about: Advertise new strings and updates on pre-existing ones that were merged on OpenRCT2
 title: 'String XXXX'
-labels: 'changed field', 'new field'
+labels: changed field, new field
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
@@ -2,7 +2,7 @@
 name: New and Changed Strings
 about: Advertise new strings and updates on pre-existing ones that were merged on OpenRCT2
 title: 'String XXXX'
-labels: changed field, new field
+labels: ['changed field', 'new field']
 assignees: ''
 
 ---


### PR DESCRIPTION
This is the only template that wasn't recognized, you can see that the header formatting is broken at
https://github.com/OpenRCT2/Localisation/blob/master/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md

But is not at this one:
https://github.com/tupaschoal/Localisation/blob/a4e61b39dfe3d8358abb09510294fe06a3ac3a0e/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md

So I guess this will make it work :D