### PR TITLE
pl-PL: Fix month names (revert to previous naming)

### DIFF
--- a/data/language/pl-PL.txt
+++ b/data/language/pl-PL.txt
@@ -1588,18 +1588,18 @@ STR_2232    :Wyciągarka linowa
 STR_2233    :{SMALLFONT}{BLACK}Informacje o parku
 STR_2234    :Najnowsze wiadomości
 STR_2235    :{SMALLFONT}{STRINGID} {STRINGID}
-STR_2236    :Stycznia
-STR_2237    :Lutego
-STR_2238    :Marca
-STR_2239    :Kwietnia
-STR_2240    :Maja
-STR_2241    :Czerwca
-STR_2242    :Lipca
-STR_2243    :Sierpnia
-STR_2244    :Września
-STR_2245    :Października
-STR_2246    :Listopada
-STR_2247    :Grudnia
+STR_2236    :Styczeń
+STR_2237    :Luty
+STR_2238    :Marzec
+STR_2239    :Kwiecień
+STR_2240    :Maj
+STR_2241    :Czerwiec
+STR_2242    :Lipiec
+STR_2243    :Sierpień
+STR_2244    :Wrzesień
+STR_2245    :Październik
+STR_2246    :Listopad
+STR_2247    :Grudzień
 STR_2248    :Nie można zburzyć atrakcji...
 STR_2249    :{BABYBLUE}Nowa atrakcja dostępna:{NEWLINE}{STRINGID}
 STR_2250    :{BABYBLUE}Nowa sceneria dostępna:{NEWLINE}{STRINGID}


### PR DESCRIPTION
I've decided to revert my changes with month naming to a "less bad" version. 

The issue is that there are two word variations depending on usage.

January translates to "Styczeń", but "1st January" translates to "1 Stycznia". 

In the game month names are used to display the current date (bottom right corner) and in a few other places like financial reports. Using "Stycznia" instead of "Styczeń" in this context just seems wrong.  For the current day "1 Styczeń" syntactically incorrect, but it's a common mistake and shouldn't look as bad.