### PR TITLE
Keep user list for notifications sorted by language

### DIFF
--- a/.github/ISSUE_TEMPLATE/changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/changed_field_template.md
@@ -37,4 +37,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert @tellovishous @JasperGray
+@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @JasperGray @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert

--- a/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
@@ -43,4 +43,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert @tellovishous @JasperGray
+@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @JasperGray @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert

--- a/.github/ISSUE_TEMPLATE/new_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_field_template.md
@@ -37,4 +37,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert @tellovishous @JasperGray
+@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @JasperGray @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @Nubbie @BobbyS38 @izhangfei @daihakken @marcinkunert


### PR DESCRIPTION
When I tidied up the list, I listed the usernames in the same order as they appear in the readme, which might make things a little easier to maintain/change in the long term (idk)