### PR TITLE
Check against fork master instead of upstream master

### DIFF
--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -21,11 +21,21 @@ jobs:
           ref: develop
           path: OpenRCT2
 
-      - name: Get translations master (for comparsion)
+      - name: Checkout translations before PR changes (for comparsion)
         uses: actions/checkout@v2
         with:
-          ref: master
           path: master
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      - name: Checkout commit before branch changes
+        run: |
+          cd master
+          git fetch origin master:refs/remotes/origin/master
+          git merge-base refs/remotes/origin/master HEAD
+          git checkout $(git merge-base refs/remotes/origin/master HEAD)
+          cd ..
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
The translation check will be now done against the fork master branch and not the upstream master. This should prevent showing changes in case a not fully rebased branch is send to a PR. Resolves #1991

![image](https://user-images.githubusercontent.com/2963232/96365808-7fd3cc80-1143-11eb-804e-aa776e26c7df.png)