### PR TITLE
Improve translation_check.py usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,21 @@ Anyone can still contribute to the languages.
 ### Questions & Support
 
 If you have any question or issues, you can always ask us on [Discord](https://discord.gg/sxnrvX9).
+
+### Checking Translation Integrity
+
+We have an action that automatically runs on every Pull Request and reports, for every supported language:
+
+- If there are any strings left to translate
+- If there are any strings that do not need translation
+- If there are any strings that might not have been translated, as they are the same
+
+The script is on the repository and can be run locally if one wants to anticipate the results, by doing:
+
+```
+python .github\workflows\translation_check.py -r <path to en-GB.txt> -m <path to data/language folder on master branch> -b <path to data/language folder on your branch>
+```
+
+Note that `-b` and `-m` can use the same argument if you don't want differential analysis.
+
+You can use the `--help` switch to read more about what each switch does.


### PR DESCRIPTION
Ping @marcinkunert 

This adds some quality of life improvements to `translation_check`, along with some minor refactors:
- Extracts hardcoded path to `en-GB.txt`
- Sorts the language list, so that the output of the check and the comments always list languages alphabetically
- Adds an argparser, so it can be run locally by doing, for example:
`python3 translation_check.py -r data/language/en-GB.txt -m data/language -b data/language`
The default values of the arguments are the hardcoded ones, so that we don't have to use the switches in the workflow. Also note that having this provides an easy way to run the script locally, which makes it a lot faster to validate changes in the script