### PR TITLE
Add JSON object dumps for supported languages

### DIFF
--- a/objects/ar-EG.json
+++ b/objects/ar-EG.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "صواريخ 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "مُجرد"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "مياة حمضية خضراء"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "ممشي رماد"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "سيارات بارنستورمينغ",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "مقعد"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "مقعد"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "مقعد"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "قطارات الموت الأسود",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "سائل من الفضاء الخارجي",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "ممشي بُني مُعبد"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "قرميد ممشي بُني"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "اعشاب البرك"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candy style"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "خيمة قماشية"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "قلعة (بني)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "قلعة (رمادي)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "كلاسيكية / رومانية"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "علامة بنمط كلاسيكي"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 راكبين لكل عربة"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 راكبين لكل عربة"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster train with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "ممشي مجنون مرصوف"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "مصباح أقحوان"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "ممشي ترابي"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "قوارب الدلوفين",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "سيارات التانين الطائرة",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "علامة علي الطراز المصري"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptian style"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy style"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "القوارب الطائرة",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "قطارات كرة القدم",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "سيارات العصابات",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gentle style"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "الباندا العملاق"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "ممشي أخضر مُعبد"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "مياة خضراء"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "قرميد ممشي أخضر وبني"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "قرميد ممشي رمادي"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "غواصات الهيبو",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horror style"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "سيارات الطرق السريعة",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "العجلات الحوامة",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "السيارات الحوامة",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "الألواح الحوامة",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ice style"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "سيارات الطائرات النفاثة",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "النوافير القافزة"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "كرات الثلج القافزة"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "الادغال"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "علامة بنمط الغابة"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle drums style"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "علامة بطابع العصر الجوراسي"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "غواصات الحوت القاتل",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "مصباح"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "مصباح"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "مصباح"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "مصباح"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "مصباح"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "سيارات الأسد",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "سلة المهملات"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "سلة المهملات"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "سلة المهملات"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "سلة المهملات"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "كوخ خشبي"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck shaped boat, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a Manta Ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Martian style"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanical style"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medieval style"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern style"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "سيارات الوحش",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "شاحنات عملاقة رباعية العجلات يمكنها تسلق المنحدرات العالية",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "ركبان لكل شاحنة"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Indivual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "مياة طبيعية"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "لا مدخل"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "لا مدخل، لا منصة"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "براميل السنديان",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental style"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "باغودا"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "علامة بشكل باغودا"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "صندوق بريد الباندا"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "قطارات الباندا",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "قطار أفعوانية مع عربات بشكل الباندا المحبب",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "راكب واحد لكل عربة"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "مبني مدخل الحديقة"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "سيارات بيجسوس",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "قطارات البطريق",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "مياه وردية"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates style"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "عادي"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "قطار سيارات الشرطة",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "سيارات الشرطة",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "طابور إنتظار التلفزيون"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "قرميد ممشي أحمر وبني"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "قطارات وحيد القرن",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock style"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock style 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock style 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "سيارات صواريخ",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "سيارات أفعوانية بشكل صواريخ",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "أربعة ركاب لكل عربة"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "مترو سان فرنسيسكو",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "مقاعد"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "علامة"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "ثلج / جليد"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "علامة مغطاة بالثلج"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snow style"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "فضاء"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "ممشي بشكل فضائي"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "علامة بشكل فضائي"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Space style"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "مقعد حجري"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Summer style"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "سيارات الطائرة المائية المُعلقة",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "ممشي مُعبد"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno style"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "المقصورة المتنقلة",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "حمامات",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "حمامات عادية موضوعة في مباني أسمنتية مسبقة الصنع"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "اللفة العالية",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 راكبين"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Toyland style"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "مدخل حديقة تقليدي"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "A spacious train with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban style"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Water style"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wild west style"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "خشبي"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "سياج خشبي"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "علامة خشبية"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "قطارات سيارات التاكسي الصفراء",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/ca-ES.json
+++ b/objects/ca-ES.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Estil caramel"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "El còndor",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Els passatgers, lligats amb subjeccions per baix de la via, experimenten la sensació de volar mentre cauen en picat per l'aire en vagons en forma de còndor.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passatgers per vagó"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Peça personalitzada 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Peça personalitzada 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Estil cotxes de xoc"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Estil egipci"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Estil orgue de fira"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Estil fantàstic"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Estil suau"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Estil de pel·lícula de por"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Estil gèlid"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Estil tambors de la jungla"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Estil juràssic"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Estil marcià"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Estil mecànic"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Estil medieval"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Estil modern"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Sense entrada"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Estil orgue"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Estil oriental"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Estil pirata"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Estil ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Estil rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Estil rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Estil rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Estil fanfàrria romana"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Estil nevat"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Estil espacial"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Estil estival"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Estil tecno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Les cabines on estan els passatgers estan suspeses per braços que dirigeixen les cabines girant-les, balancejant-les i movent-les cap endavant i cap enrere.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passatgers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Estil de joguines"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Estil urbà"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Estil aquàtic"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Estil salvatge oest"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -1,0 +1,9582 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliáš' cedule"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medúza' cedule"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' cedule"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' cedule"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Motokáry z 20. let",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Benzínové ovladatelné motokáry ve stylu 20. let",
+    "reference-capacity": "Single-seater",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Auto z 50. let"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Auto z 50. let"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Raketa z 50. let"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Raketová jízda z 50. let",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Vozy vyrazí vstříc jednomu konci trati, poté prosviští pozpátku stanicí a vyletí až na druhý konec trati",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Kino",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Kin promítající 3D filmy uvnitř duté kulovité konstrukce",
+    "reference-capacity": "20 guests",
+    "capacity": "20 návštěvníků"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D cedule"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D cedule"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Čtyřmístná zavěšená horská dráha",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Vozy jsou zavěšeny na kolejnicích se zatáčkami, pády a loopingy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Létající zatáčky",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Návštěvníci v šestimístných vozech sedí vedle sebe po dvou ve třech řadách",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Umění domorodců"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Domorodecká obyčejná dlaždice"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Domorodecké umění"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Domorodecké umění"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstraktní kulisy"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Jedovatě zelená voda"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Aktivní sopka"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Dospělý slon"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Dospělá panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africký vstup do parku"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Afrika"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Svislá dráha na stlačený vzduch",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Po mocném startu na stlačený vzduch se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Jednokolejné vlaky připomínající vzducholoď",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Velkokapacitní jednokolejné vlaky s aerodynamickou přídí a zádí",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 míst v každém vagónu"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Borovice"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Mimozemská historická struktura"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Mimozemská historická struktura"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Mimozemská Rostlina"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Mimozemská Rostlina"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Mimozemské světlo"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Mimozemské světlo"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Mimozemská velká struktura"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Mimozemská velká struktura"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Mimozemská velká struktura"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mimozemská stavba"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mimozemská stavba"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mimozemská stavba"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Mimozemská věž - dolní díl"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Mimozemská věž - střední díl"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Mimozemská věž - vrchní díl"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Mimozemský strom"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Mimozemský strom"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Strom ve tvaru aligátora"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Americký fotbal"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Americký fotbal"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Helma na americký fotbal"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Americké parní vlaky",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny s plátěnými střechami",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 míst v každém vagónu"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anakonda",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Prostorné vozy s opěrkou v klíně",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Pečeně na rožni"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animované balónky"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animovaný táborák"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Pohybující se vše-vidící oko"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Pohyblivá chobotnice"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Pohyblivá chobotnice"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Pohyblivá chobotnice"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Pohyblivý astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Pohybující se jeskynní muž zapalující oheň"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Pohybující se Andromeda (spoutaná žena)"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Pohybující se člen klanu"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Pohybující se temný rytíř"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Pohybující se temný rytíř"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Pohybující se vážky"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Pohybující se orel na kleci"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Pohybující se ďábelský mimozemšťan"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Pohybující se ďábelský mimozemšťan"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Pohybující se ďábelský mimozemšťan"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Pohybující se hasič"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Pohybující se vystřelující kanón"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Pohybující se Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Pohybující se hodný mimozemšťan"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Pohybující se hodný mimozemšťan"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Pohybující se hodný mimozemšťan"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Pohybující se rytíř"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Pohybující se rytíř"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Pohybující se Medúza"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Pohybující se policista"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Pohybující se Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Pohybující se armáda kostlivců"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Pohybující se armáda kostlivců"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Pohybující se armáda kostlivců"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Pohybující se Vesmírný kovboj"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Pohybující se stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Pohybující se T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Pohybující se triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Pohybující se mávající král"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Pohybující se útočící škorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Pohybující se útočící škorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Pohybující se letící pterodaktyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarktida"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antilopa - samice"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antilopa - samec"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antilopí pár"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antigravitační LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antigravitační LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Terč"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Cypřiš"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco rohová část"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco roh se zábradlím"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco roh se zábradlím"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco roh s okny"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco roh s okny"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco roh s okny"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco stánek",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Malý stánek s nudlemi a čerstvou limonádou"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco roh"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco roh"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco střešní část"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco vrchní rohová část"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco vrchní rohová část"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco vrchní rohová část"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco vrchní část"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco vrchní část"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco stěna"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco dveřní rám"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco stěna se zábradlím"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco stěna se zábradlím"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco stěna se zábradlím"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco stěna se zábradlím"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco okno"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco okno"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Horská dráha s malými vozy",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Horská dráha s dvoumístnými vozy bez předků",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Popelavá cesta"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Jasan s bludičkami"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asie"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Osika"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Socha Atlase"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australský vstup do parku"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Austrálie"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australská fontána"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australská fontána"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobilové vozy",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Horská dráha s vozy, které připomínají automobily",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Béčková obrovská chobotnice"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Béčkový obrovský pavouk"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Béčková pavoučí jízda",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo velkého pavouka z béčkového filmu uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Malý slon"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Malá panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Raketa na badminton"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badmintonová raketa"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Čínské lampióny"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Čínské lampióny"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Stánek s balónky",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Stánek se suvenýry - balónky, plněnými héliem"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bambus"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Sloup z bambusu"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bambusová střecha"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bambusová střecha"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bambusová střecha"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambusová zeď"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Člen kapely"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Člen kapely"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Člen kapely"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Člen kapely"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Banka"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Stodolní střela",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Vozy jsou zavěšeny na kolejnicích s ostrými zatáčkami a ostrými pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Základní blok"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Základní blok"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Základní blok"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Základní blok"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Beranidlová horská dráha",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Malá ocelová horská dráha se spirálovitým profilem a vozy se sedadly za sebou",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Stánek s hovězími nudlemi",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Stánek prodávající čínské hovězí nudle"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Lavička"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Lavička"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Lavička"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Lavičky"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Horská dráha bengálských tygrů",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Horská dráha, která se točí dokola tak, že návštěvníci jsou pořád na stejném místě",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Jízdní kola",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Po ocelové kolejnici jezdí speciální jízdní kola, ovládané šlapáním návštěvníků",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 místo na každém kole"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben a parlament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Velká geosféra"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Cyklista"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Černý střelec"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Autodráha s Londýnskými taxíky",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Vozy ve tvaru Londýnských taxíků jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Morová horská dráha",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Návštěvníci jedou po propletené bobové dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Černý král"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Černý kůň"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Černý pěšák"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Topol"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Černá královna"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Černá věž"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Mimozemská hmota",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Tématická vyhlídková věž s kabinou, která postupně vyjede až na vrchol a zpět dolů",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 návštěvníků"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Horská bobová dráha",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Návštěvníci sedí za sebou ve dvojmístných vozech",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Hrnec s horkou vodou"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Kost"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Plot z kostí"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Kosti"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Bumerang",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Po mocném startu na stlačený vzduch se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Cihlová stěna"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Cihlová stěna"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Cihlová stěna"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Britská poštovní schránka"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Britská telefonní budka"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Rozbitá socha"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Rozbité kolo"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Hnědá asfaltová cesta"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bublající bažina"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Kbelík"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Stavba"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Budova"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Šinkansen",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Horská dráha s vozy, které vypadají jako vozy Šinkansenu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Rákos"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Malé čluny",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Malé čluny s motorovým pohonem ovládaným návštěvníky",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Bóje"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Bóje"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Stánek s burgery",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Stánek ve tvaru burgeru podávající burgery"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Křoví"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Motýl"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda u chaty"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Vršek chaty"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Vršek chaty"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Vršek chaty"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Vršek chaty"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stěna chaty"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Zelný strom"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Jilm"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Cukroví"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Cukroví"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Cukroví"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Sladká tyčinka"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Strom sladkostí"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Strom sladkostí"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Strom sladkostí"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Sladkosti"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Stánek s cukrovou vatou",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Stánek prodávající cukrovou vatu"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Kanón"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Kanón"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Kanónové koule"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Kánoe",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Dlouhé kánoe, u kterých musí návštěvníci pádlovat",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Plátěná střecha"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Motýlková autodráha",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Vozy ve tvaru motýlů jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Žabí autodráha",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Vozy ve tvaru žab jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Ještěrčí autodráha",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Vozy ve tvaru ještěrek jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Povoz"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Bankomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Bankomat pro návštěvníky, kterým by došla hotovost"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Hradní rohová část"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Hradní rohová část"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Hradní brána"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Hradní obrácený roh"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Hradní padací most"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Hradní opevnění"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Hradní opevnění - roh"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Hradní opevnění - roh"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Hradní opevnění - roh"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Hradní opevnění - obrácený roh"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Hradní věž"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Hradní věž - roh"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Hradní věž - roh"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Hradní věž - střední část"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Hradní věž - rovná část"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Hradní věž - T-křižovatka"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Hradní věž - T-křižovatka"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Hradní stěna"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Zvířecí lebka"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Jedle"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Kotel"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Vstup do jeskyně"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Prehistorické motokáry",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Benzínové ovladatelné motokáry ve stylu pravěku",
+    "reference-capacity": "Single-seater",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Libanonský cedr"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Kerberosova horská dráha",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Horská dráha s dlouhými pády, velkou rychlostí a pohodlnými vlaky, kde se jezdí s opěrkou v klíně, která přelétává vrcholky kopců",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Kryté sedačkové lanovky",
+    "reference-description": "Open cars for chairlift",
+    "description": "Lanovka se sedačkami se střechou",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa na jedné sedačce"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Blok šachovnice"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Autodráha",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Malá autíčka jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Stánek s kuřecími nugety",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Stánek prodávající kuřecí nugety"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Cedr"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Čínský drak"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Čínská dračí hlava",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Autodrom s vozy ve tvaru dračích hlav",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Čínská loď",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Loď je připevněna na podpěru, která se chová jako protizávaží a otáčí se o 360 stupňů",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 návštěvníků"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Stánek s hranolkami",
+    "reference-description": "A hut selling chips",
+    "description": "Stánek prodávající hranolky"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Stánek s hranolkami",
+    "reference-description": "A stall selling chips",
+    "description": "Stánek prodávající hranolky"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Tabulka čokolády"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Elektronická cesta"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Cirkus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Zvířecí představení uvnitř velkého stanu",
+    "reference-capacity": "30 guests",
+    "capacity": "30 návštěvníků"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Cirkus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Cedule v klasickém stylu"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Klasické/Římské kulisy"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Kleopatřina jehla"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Vinná réva"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Hodiny"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Strom ve tvaru kyje"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Lodě horské dráhy",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Lodě ve tvaru vozů horské dráhy",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 míst v každé lodi"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Jízda v šálku kávy",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo kávomlýnku uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Stánek s kávou",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Hezky vypadající stánek prodávající kávu"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Ozubené kolo"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Ozubené kolo"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Ozubené kolo"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Ozubené kolo"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Gumové cukrovinky"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Kolonáda"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Jalovec"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Dub"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Tis"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Malá zavěšená horská dráha",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Návštěvníci sedí po dvou zavěšení pod tratí a jedou skrze loopingy a ostré zatáčky",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Jízda kondorů",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Návštěvníci jsou zavěšeni vleže hlavou napřed pod tratí a během jízdy mají pocit volného letu kondora",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Mořští úhoři",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Horská dráha, na které vozy s ramenními opěrkami připomínající mořské úhoře",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Živý plot"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Živý plot"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Roh dopravního pásu"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Roh dopravního pásu"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Konec dopravního pásu"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Dopravní pás"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Dopravní pás"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Stánek se sušenkami",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Stánek prodávající gigantické sušenky"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Frajer"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Vývrtková horská dráha",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Horská dráha s vozy vybavenými ramenními opěrkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Vlnitá střecha"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Kovová stěna"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Kovová střecha"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Vlnitá zeď"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Borovice"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Kovboj 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Kovboj 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Šílená cesta"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Strašidelné kulisy"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Krokodýlí jízda",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Lodě ve tvaru krokodýlů se plaví po vodním kanálu a cákají. Nikdo nezůstane suchý",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 místa na každé lodi"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Křivý dům",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Budova s pokřivenými místnostmi a nakloněnými chodbami, které dezorientují návštěvníky",
+    "reference-capacity": "5 guests",
+    "capacity": "5 návštěvníků"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Fontána amorka"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Zatočený blok"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Zatočený blok"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Zaoblená zeď z bahna"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Zaoblená zeď z bahna"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Zaoblená zeď z bahna"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Zatočená střecha"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Zatočená střecha"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Zatočená stěna"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Zatočená stěna"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Vlastní hudba 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Vlastní hudba 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Kyklopský autodrom",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Autodrom s elektrickými autíčky ve tvaru oka gigantického kyklopa",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Socha kyklopa"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Květinová lampa"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Přehradní věž"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Starodávný vstup"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Starodávné časy"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Starodávná vesnice - rohová střecha"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Starodávná vesnice - rohová střecha"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Starodávná vesnice - obrácená střecha"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Starodávná vesnice - obrácená střecha"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Starodávná vesnice - dolní roh"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Starodávná vesnice - dolní stěna"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Starodávná vesnice - střecha"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Starodávná vesnice - střecha"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Starodávná vesnice - střecha"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Starodávná vesnice - střecha"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Starodávná vesnice - střecha s komínem"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Starodávná vesnice - horní roh"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Starodávná vesnice - horní stěna"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Starodávná vesnice - horní stěna"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Starodávná vesnice - horní stěna"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Starodávná vesnice - horní stěna"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Starodávná vesnice - horní stěna"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Starodávná vesnice - okno"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Starodávná vesnice - okno"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Starodávná vesnice - střešní okno"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Starodávná vesnice - střešní okno"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Starodávná vesnice - střešní okno"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Starodávná vesnice - střešní okno"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Starodávný hostinec"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Uschlý strom"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Uschlý strom"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Uschlý strom"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Plachetnice",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Ozdobné plachetnice, u kterých musí návštěvníci pádlovat",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 místa na každé lodi"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamantový košík"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamantová jízda",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo diamantu uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamantový sloup"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Strom ve tvaru diamantu"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Didgeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Nafukovací čluny",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Návštěvníci jedou v nafukovacích člunech po tobogánu",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Jízda dinsouřích vajec",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Návštěvníci sedí po dvou ve vejcích, které se otáčejí okolo dinosauří matky uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Blátivá cesta"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Autodrom",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Autodrom s elektrickými autíčky",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Autodrom"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Delfíní jízda",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Lodě ve tvaru delfínů, které mohou návštěvníci ovládat",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 místo v každé lodi"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Fontána delfína"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Socha delfína"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Brána"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Brána"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Brána"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Dvoupatrový kolotoč",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Klasický dvoupatrový kolotoč s vyřezávanými koníky",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 návštěvníků"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Dvoupatrová vyhlídková věž",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Otáčející se dvoupatrová vyhlídková věž, která postupně vyjíždí na vysokou věž",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 návštěvníků"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Stánek s koblížky",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Stánek prodávající americké koblížky"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Velká věž"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Velká věž"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Velká věž"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Velká věž"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Minaret 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Minaret 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Minaret 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Střecha 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Střecha 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Střecha 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Střecha 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Základna malé věže"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Základna malého minaretu"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Střední část malého minaretu"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Khaki set - část 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Khaki stěna - část 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Khaki stěna - část 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Khaki stěna - část 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Khaki stěna - část 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Khaki stěna - část 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Khaki stěna - část 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Khaki stěna - část 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Khaki stěna - část 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Khaki stěna - část 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Khaki stěna - část 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Khaki stěna - část 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Khaki stěna - část 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Útočící drak"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dračí horská dráha",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Horská dráha s vozy ve tvaru draků",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Šídlí horská dráha",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Návštěvníci jedou na jednokolejné trati zavěšeni ve speciálním voze, který se v zatáčkách houpe",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Stánek s pitím",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Stánek ve tvaru plechovky prodávající perlivé nápoje"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Socha Velikonočního ostrova"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptský sloup"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptská socha"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Cedule v egyptském stylu"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptské motivy"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptská stěna"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egypt"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffelova věž"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Elektrický ohradník"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Elektrický ohradník - rozbitý"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Elektrický ohradník - roh"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Elektrický plot - obrácená rohová část"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Elektrický ohradník se světlem"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Fontána slona"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Prázdný košík"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Loď Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Otáčející se kolo se zavěšenými kabinami, které se napřed roztočí a pak se zvedne na pomocné podpěře",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eukalyptus"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Evropa"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Modřín"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Evropský vstup do parku"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Ďábelský samuraj"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Jízda Fabergého vejce",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo Fabergého vejce uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Tvář-rvoucí zavěšená horská dráha",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Návštěvníci sedí po dvou zavěšení pod tratí a vidí dopředu nebo dozadu podle toho, jak zrovna jedou skrze loopingy a ostré zatáčky",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Tržnice"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farmářské náčiní"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Stůl (hody)"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Plot"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Plot"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Ploty a stěny"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ruské kolo",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Velké otáčející se kolo s otevřenými sedadly",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 návštěvníků"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Pochodeň / svíce"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Jízda papírového draka",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Rytířský autodrom",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Autodrom s elektrickými autíčky ve tvaru koní",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Jízda rachejtle",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Požární hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "První pomoc",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Místo pro návštěvníky, kterým by se udělalo nevolno, které napomáhá brzkému uzdravení"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Rybí díra"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Opravená socha"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Plameny"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Plameňák"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Plameňák"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Plameňák"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Zakroucená horská dráha bez podlahy",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Rozměrná horská dráha s vozy vybavenými ramenními opěrkami a s chybějící podlahou ve vozech, díky čemuž je jízda opravdu záživná",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Květina"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Květinová vznášedla",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Autodrom se vznášedly ve tvaru květů květin",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Hippie trička",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stánek prodávající batikovaná trička s hippie motivy"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Létající lodě",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Vozy ve tvaru létajících lodí jedou po trati horské dráhy, což umožňuje ostré zatáčky, strmé klesání a cákající zpomalení pro mírnější říční úseky",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 míst v každé lodi"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Létající horská dráha",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Návštěvníci sedí v pohodlných sedadlech pod tratí cestující skrze propletenou dráhu, poskytující pocit letu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Létající talíře",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Autodrom se vznášedly",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Fotbal"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Fotbalová horská dráha",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha s vozy připomínající fotbalové míče, které se houpají v zatáčkách",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Zakázané ovoce"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Stromy"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontána"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontána"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Čtyřmístná horská dráha",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Vozy jsou zavěšeny na kolejnicích s ostrými zatáčkami a ostrými pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Stánek se smaženým kuřetem",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Stánek prodávající kyblíky smaženého kuřete"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Stánek se smaženými nudlemi",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Stánek prodávající čínské rýžové smažené nudle"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Ovocné bonbony"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Ovocné bonbony"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Ovocný strom"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Ovocný strom"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Stánek s nanuky",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Stánek prodávající různé druhy nanuků"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Dům zábavy",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Budova s pohybujícími se zdmi a podlahou, což dezorientuje procházející návštěvníky",
+    "reference-capacity": "5 guests",
+    "capacity": "5 návštěvníků"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Stánek s palačinkami",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Stánek prodávající palačinky"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Budoucnost"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristický vstup do parku"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gilotina"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangsterská horská dráha",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Horská dráha s vozy ve stylu gangsterů 20. let, poháněnými elektromotorem, které sviští skrze propletenou dráhu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Zahrady"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Gejša"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Obchod se smíšeným zbožím"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Mírná hudba"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometrická fontána"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrická socha"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrická socha"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrická socha"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrická socha"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrická socha"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Gregoriánská plochá střecha"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Gregoriánská přízemní stěna - část 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Gregoriánská přízemní stěna - část 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Gregoriánská přízemní stěna - část 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Gregoriánská přízemní stěna - část 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Gregoriánská přízemní stěna - část 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Gregoriánská přízemní stěna - část 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Gregoriánská stěna přízemí"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Gregoriánská střecha 7"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Gregoriánská střecha 6"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Gregoriánská střecha"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Gregoriánská stěna - část 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Gregoriánská stěna - část 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Gregoriánská stěna - část 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Gregoriánská stěna - část 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Gregoriánská stěna - část 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Gregoriánská stěna - část 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Gejzíry"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Vlak duchů",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Vozy ve tvaru příšer jezdí po vícepatrovém okruhu okolo strašidelných kulis a speciálních efektů",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Obrovská baskytara"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Obrovský stonek"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Obrovský stonek"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Kulisy obrovského cukroví"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Obrovská mrkev"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Stopa velkého dinosaura"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Obrovské bubny"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Kulisy obrovských zahrad"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Obrovská tráva"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Obrovská kytara"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Mangrove"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Obrovská dýně"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Obrovská vločka"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Obrovská vločka"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Obrovská vločka"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga dráha",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Gigantická horská dráha schopna volných pádů a kopců přes 90 metrů dlouhých",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Žirafa 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Žirafa 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Socha žirafy"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Skleněná střecha"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Skleněná střecha"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Skleněná stěna"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Skleněná stěna"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Skleněná stěna"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Skleněná stěna"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Motokáry",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Benzínové ovladatelné motokáry",
+    "reference-capacity": "single-seater",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Zlatá lama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Zlatá socha 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Zlatá socha 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Zlatý Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Zlatá ovčí vlna"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Hinoki cypřiš"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Hodný samuraj"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilí horská dráha",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha s vozy připomínající gorily, které se houpají v zatáčkách",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Náhrobek"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Náhrobek"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Náhrobek"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Náhrobek"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Velký náhrobek"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Velký náhrobek"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Velký náhrobek"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Velká čínská zeď"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Velká čínská zeď"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Velká čínská zeď"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Velká čínská zeď - věž"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Velká čínská zeď - věž"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Žraločí horská dráha",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Horská dríha s vozy vybavenými ramenní opěrkou, které připomínají žraloka bílého",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 míst v každém voze"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Zelená asfaltová cesta"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Zelená voda"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Senzační tanečnice"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Socha Hadese"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Zrcadlové bludiště",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Budova s pokřivenými zrcadly",
+    "reference-capacity": "5 guests",
+    "capacity": "5 návštěvníků"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Přístav - dok"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Přístav - stěna"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Přístav - roh"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Přístav - roh"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Přístav - stěna s dokem"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Přístav - stěna s rybářským náčiním"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Přístav - stěna s vřesem"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Přístav - stěna s vřesem"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Přístav - stěna s vřesem"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Přístav - stěna s vřesem"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Horská dráha harpyjí",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Návštěvníci jedou v leže zavěšeni do speciálního držení, ve kterém na břiše nebo na zádech projedou trať s ostrými zatáčkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Stánek s čepicemi",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Stánek se suvenýry - pěnovými čepicemi"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Dům hrůzy",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Velká stará budova se strašidelnými chodbami a děsivými pokoji",
+    "reference-capacity": "15 guests",
+    "capacity": "15 návštěvníků"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Strašidelná věznice",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Budova s podzemím a figurínami vězňů straší procházející návštěvníky",
+    "reference-capacity": "16 guests",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Jízda domem hrůzy",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Vozy jezdí po vícepatrovém okruhu okolo strašidelných kulis a speciálních efektů",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Kopa sena"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Strom ve tvaru srdce"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Nebeská koupel - Podlaha"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Nebeská koupel - bazén"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Nebeská koupel - roh bazénu"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Nebeská koupel - hrana bazénu"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Nebeská koupel - schody do bazénu"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Nebeská koupel - střecha"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Nebeská koupel - střecha"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Nebeská koupel - střecha"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Nebeská koupel - střecha"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Nebeská koupel - Okno"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Nebeská koupel - Oblouk"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Nebeská koupel - Oblouk"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Nebeská koupel - Oblouk"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Nebeská koupel - Architektura"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Nebeská koupel - Architektura"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Nebeská koupel - Architektura"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Nebeská koupel - Architektura"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Nebeská koupel - fontána"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Nebeská koupel - fontána"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Nebeská koupel - Schodiště"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Nebeská koupel - Schodiště"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Živý plot"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Živý plot"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Heliport"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Herkules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Maďarský cypřiš"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hroch 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hroch 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hroší jízda",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 míst v každé ponorce"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Dřezovec trojtrnný"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horor"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Kůň"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Socha koně"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Socha jezdce"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Dostihy",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Vozy ve tvaru koní vozí návštěvníky po jednokolejné trati",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 místa na každém koni"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Stánek s horkou čokoládou",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Stánek prodávající horkou čokoládu"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Stánek s párky v rohlíku",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Stánek prodávající párky v rohlíku"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod auto"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod auto"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod horská dráha",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Po mocném startu na stlačený vzduch se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Dům"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Vznášedlová moto horská dráha",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Návštěvníci sedí na futuristických motorkách, která jedou po jednokolejné dráze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 místa na každé motorce"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Autodráha se vznášedly",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Vozy ve tvaru futuristických vznášedel jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Letící vznášedlo"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Letící vznášedlo"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Zaparkované vznášedlo"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Zaparkované vznášedlo"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Vznášedlová horská dráha",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Návštěvníci jezdí na futuristických vznášedlech, houpajících se v zatáčkách ze strany na stranu",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Letící vznášedlo"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Letící vznášedlo"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Zaparkované vznášedlo"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Zaparkované vznášedlo"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Autodráha se saněmi",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Vozy ve tvaru sněžných saní jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyperzakroucená dráha",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Prostorné vozy s jednoduchou opěrkou v klíně",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyperzakroucená dráha (široké vozy)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Široké 4-místné vozy s vystouplým sezením a jednoduchou opěrkou v klíně",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hyper horská dráha",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Horská dráha s pohodlnými vozy vybavenými opěrkou v klíně",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Stánek se zmrzlinou",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Stánek prodávající kornouty zmrzliny"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Kostka ledu"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ledová kreace"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ledová kreace"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ledový palác"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ledový vstup do parku"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ledová trubka"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ledová trubka"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Výdech ledové trubky"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ledová střecha"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ledová stěna"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Led"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Ledové barely"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Ledové barely"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Ledové barely"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Stánek s ledovým čajem",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Stánek prodávající různé druhy ledového čaje"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Iglú"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Střecha iglú"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Stěna iglú"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Horská dráha ve tvaru \"U\"",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Vozy vyrazí vstříc jednomu konci trati, poté prosviští pozpátku stanicí a vyletí až na druhý konec trati",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Cedr"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indická hedvábná vlajka"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indická hedvábná vlajka"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indická hedvábná vlajka"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indická hedvábná vlajka"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indická hedvábná vlajka"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriální střecha"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriální roh"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriální roh"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriální stěny - set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriální stěny - set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriální stěny - set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriální stěny - set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriální dveřní rám"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriální okno"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Kiosek",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Stínek s informacemi o parku, prodávající mapy a deštníky"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Eskymák"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Eskymák"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italský cypřiš"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italská policejní jízda",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo italských policistů",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguáří horská dráha",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Malá horská dráha, na které vozy po jednom projíždí trať s kroucenými pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Sakura"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Sakura"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japonský vstup do parku"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Borovice Thunbergova"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Čínská střecha"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Čínská střecha"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Čínská střecha"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japonská hedvábná vlajka"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Kalina řasnatá"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Člen jazzové kapely"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Člen jazzové kapely"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Člen jazzové kapely"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Člen jazzové kapely"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Želatinový medvídci"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Lentilka"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Lentilková stěna"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Stíhačka"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Stíhačka"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Stíhačka"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Návštěvníci sedí ve voze, který je vystřelen po kolmé dráze",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 míst v každém voze"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Stíhačková horské dráha",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Malá horská dráha, na které vozy po jednom projíždí trať s kroucenými pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Vodní lyže",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Návštěvníci jezdí na vodních lyžích",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 místo na každých lyžích"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Turnajová horská dráha",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Návštěvníci sedí na zádi vozů ve tvaru koní, které jedou po jednokolejné dráze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Skákající fontány"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Skákající sněhové koule"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle plot"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Cedule v jungle stylu"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle kulisy"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Strom z jungle"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle strom 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Strom z jungle s leopardy"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Strom z jungle s liánami"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle bubny"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Odpad"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Cedule v jurském stylu"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurské kulisy"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurský styl"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Klokat"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Zabijácká velryba",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce ve tvaru",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 míst v každé ponorce"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koalí dráha",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Velká dráha s vozem pro volný pád pozpátku",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlinská věž"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlinská věž"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlinská věž"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlinský Minaret díl 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlinský Minaret díl 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlinský Minaret díl 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlinská střecha díl 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlinská střecha díl 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlinská věž - základ"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlinská věž - střed"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlinská věž"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlinská stěna - část 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlinská stěna - část 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlinská stěna - část 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlinská stěna - část 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlinská stěna - část 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlinská stěna - část 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlinská stěna - část 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlinská stěna - část 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlinská stěna - část 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlinská stěna - část 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Horská dráha s elektromotorem",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Horská dráha s vozy poháněnými elektromotorem, které sviští skrze propletenou dráhu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Beruščiny vozy",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Horská dráha s vozy ve tvaru malých berušek",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Velký nahnutý mamutí plot"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Velký nahnutý mamutí plot"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Americký Jilm"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Velký mamutí plot"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Velký mamutí plot"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Velký kráter"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Velký dub"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Velký strom deštného pralesa"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Velký kráter"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Velký kouřící komín"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Velký reproduktor"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Totem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laserový plot"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laserový plot - roh"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Volný pád",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Vůz pro volný pád je pneumaticky vystřeleno vzhůru po vysoké ocelové věži a následně volně padá k zemi",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawsonův cypřiš"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Zavěšená horská dráha na \"ležáka\"",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Návštěvníci jedou na jednokolejné trati vleže hlavou dolů, zavěšeni ve speciálním voze, který se v zatáčkách houpe",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Horská dráha \"na ležáka\"",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Návštěvníci jedou v leže zavěšeni do speciálního držení, ve kterém na břiše projedou trať s ostrými zatáčkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Jarmarkový stánek s citronádou",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Stánek prodávající starou dobrou čerstvou citronádu"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Stánek s limonádou",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Stánek prodávající osvěžující citronádu"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Výtah",
+    "reference-description": "Steel lift cabin",
+    "description": "Výtah s ocelovou kabinou",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lilie"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limuzínová horská dráha",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Horská dráha s vozy, které vypadají jako limuzíny",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lev"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lví horská dráha",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Malá horská dráha, na které vozy po jednom projíždí trať s kroucenými pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Odpadkový koš"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Odpadkový koš"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Odpadkový koš"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Odpadkový koš"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Dřevostavba"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Střecha důlní chatrče"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Střecha důlní chatrče"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Střecha důlní chatrče"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Důlní chatrč s postranním komínem"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stěna důlní chatrče"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Kládové vozy",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Horská dráha s vozy ve tvaru klád",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Polena"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Divoká řeka",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Lodě ve tvaru klád se plaví po vodním kanálu a cákají. Nikdo nezůstane suchý",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 místa v každé lodi"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lízátko"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardský topol"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Horská dráha",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Horská dráha s loopingy, po které jezdí vozy s opěrkou v klíně",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Sloup Ztraceného města"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Sloup Ztraceného města"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Střecha Ztraceného města"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Střecha Ztraceného města"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Střecha Ztraceného města"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Schodiště Ztraceného města"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Schodiště Ztraceného města"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Schodiště Ztraceného města"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Schodiště Ztraceného města"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Schodiště Ztraceného města"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Rohová stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Rohová stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Rohová stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Rohová stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stěna Ztraceného města"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Nízké křoví"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxusní parník - loďka"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxusní parník - střední část"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxusní parník - záď"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Palicová jízda",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Návštěvníci sedí na židlích připevněných na otáčející se ramena",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 místo na každé židli"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Kouzelný koberec",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Velký vůz připomínající koberec se pohybuje krouživými pohyby hýbe nahoru a dolů za pomoci 4 ramen",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 návštěvníků"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magické brnění"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magická helma"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magický štít"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magický meč"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Mongolský strom"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Mahárádžův palác - věžička"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Mahárádžův palác - věžička"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Mahárádžův palác"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Mahárádžův palác"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Mahárádžův palác"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Mahárádžův palác"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Mahárádžův palác - věž"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Mahárádžův palác - věž"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Mahárádžův palác - věž"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Mahárádžova parní lokomotiva",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniaturní replika parní lokomotivy s tendrem táhne kryté dřevěné vagóny",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 míst v každém vagónu"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Čínské kachny",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Lodě ve tvaru kachen, ovládané šlapáním návštěvníků sedících vepředu",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 místa na každé lodi"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Rejnočí jízda",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Lodě ve tvaru rejnuků",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 míst na každé lodi"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Mramorová střecha"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Mramorová střecha"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Mramorová střecha"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Mramorová střecha"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras tanečnice"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras tanečnice"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Stan"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Maršmeloun"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Maršmeloun"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Marťanská stavba"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Marťanský objekt"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Marťanský objekt"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Marťanský objekt"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Marťanský objekt"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Marťanský objekt"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Marťanské kulisy"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Marťanská zeď"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marťan"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Bludiště",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Bludiště je postavené z 2 metrů vysokého živého plotu, nebo zdí. Návštěvníci v něm bloudí, dokud nenaleznou východ",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Stánek s polévkou",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Stánek prodávající čínskou knedlíčkovou polévku"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanické kulisy"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanika"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Středověké kulisy"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Středověk"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Člověk přeměněný na kámen"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Člověk přeměněný na kámen"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Člověk přeměněný na kámen"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Člověk přeměněný na kámen"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Kolotoč",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Klasický kolotoč s vyřezávanými koníky",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Drátěný plot"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Drátěný plot"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Kráter"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Roh kráteru"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Roh kráteru - obrácený"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Kráter - stěna"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Kráter - stěna s krystaly"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Kráter - stěna s krystaly"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Modrý jalovec"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Jízda v MicroBusu",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Návštěvníci sledují film uvnitř simulátoru pohybu, zatímco se simulátorem hýbe hydraulika",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Divoká důlní jízda",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Horská dráha s vozy, které připomínají klasické důlní vozy",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Důlní vozy",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Vozy ve tvaru dřevěných důlních vagónů",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Dulní jízda",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klíně",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Hornická chatrč"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Hornická chatrč"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Důlní výtah",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Výtah s ocelovou kabinou připomínající důlní výtah",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Důlní štola"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Důlní kulisy"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Důlní horská dráha",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Horská dráha ve stylu důlních vlaků jezdí po ocelové horské dráze maskované jako staré koleje",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 nebo 4 místa v každém voze"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Příjemná hra miniaturního golfu",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini vrtulníky",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Po ocelové kolejnici jezdí miniaturní helikoptéry, ovládané šlapáním návštěvníků",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Socha minotaura"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Máta"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Moderní"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Blahočet chilský"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Obří auta s pohonem 4x4, které jsou schopna vyjíždět velmi strmé svahy",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Montereyův cypřiš"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Borovice Montezumova"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Rozbitá monumentální stěna"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumentální fontána"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentální schodiště"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentální schodiště"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentální schodiště"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentální schodiště"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentální rohová stěna"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentální rohová stěna"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentální rohová stěna"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentální rohová stěna"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentální stěna"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Šťáva z Měsíce",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Stánek prodávající nejnovější slazené nápoje"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaická cesta"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Simulátor pohybu",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Návštěvníci sledují film uvnitř simulátoru pohybu, zatímco se simulátorem hýbe hydraulika",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Závody motorek",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Vozy ve tvaru motorek vozí návštěvníky po jednokolejné trati",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 místa na každé motorce"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorka"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorka"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Myší vozy",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Vozy ve tvaru myší",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Dřevěná divoká myš",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Horská dráha s vozy ve tvaru myší",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Střecha z bahna"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Stěna z bahna"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Vícerozměrná horská dráha",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Vozy se sedadly schopny otáčet návštěvníky vzhůru nohama",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mytologie"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indián"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Obyčejná voda"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Mořský roh střechy"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Mořská střecha"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Mořská střecha"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Mořská střecha"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Mořská střecha"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Mořská střecha"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Mořské střešní zábradlí"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Mořská zeď"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonová cedule jídelny"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonová cedule jídelny"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonová cedule jídelny"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonová cedule jídelny"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptunská jízda",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo suchy Neptuna uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptunův stánek s plody moře",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Stánek prodávající Neptunovy mořské dobroty"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York výplň rohu"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York vstup"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York obrácený roh"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York obrácený roh"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York obrácený roh"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York obrácený roh"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York - obrácený roh střechy"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York střecha"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York střecha"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York střecha"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York střecha"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York střecha"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York stěna s linkou"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York stěna s linkou"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York stěna"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York stěna"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Bez vstupu"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Vstup do parku ve stylu severní Ameriky"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Severní Amerika"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Smrk ztepilý"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Jízda v dubovém sudu",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Lodě ve tvaru dubových barelů se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 míst v každé lodi"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Mrakodrap ze sopečného skla - dveře"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Mrakodrap ze sopečného skla - střecha"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Mrakodrap ze sopečného skla - zaoblený roh"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Mrakodrap ze sopečného skla - nakloněný roh"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Mrakodrap ze sopečného skla - nakloněná stěna"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Mrakodrap ze sopečného skla - nakloněný roh"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mrakodrap ze sopečného skla - nakloněná stěna"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mrakodrap ze sopečného skla - nakloněná stěna"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mrakodrap ze sopečného skla - nakloněná stěna"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Mrakodrap ze sopečného skla - stěna"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Mrakodrap ze sopečného skla - okno"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Kancelářský blok"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Barel ropy"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Ropné čerpadlo"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Starý přerostlý strom"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Oranžová voda"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Varhany"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Orient"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornament"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornament"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornament"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamentální strom"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamentální strom"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamentální strom"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamentální strom"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamentální strom"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornamentální mramorová zeď"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Pštrosí jízda",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Horská dráha s loopingy, na které se jezdí ve stoje",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Loď s vahadly",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Dlouhé kánoe s postranními vahadly, u kterých musí návštěvníci pádlovat",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Cedule v pagoda stylu"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda kulisy"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda - věž"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Budova vstupu do parku"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Brány pro vstup do parku"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Rolnická chatrč"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Autodráha s Pegasem",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Vozy ve tvaru povozů tažených Pegasem jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Tučnáčí bobová dráha",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Návštěvníci jedou po propletené bobové dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Staré auto"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Staré auto"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Stará jídelna"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Stará vlajka"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Stará plachetnice"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Stará pouliční lampa"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Staré nákladní auto"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Staré nákladní auto"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Čerpací stanice"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickupy",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Vozy ve tvaru nákladních aut (pickupů)",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Trubka"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Část trubky"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Část trubky"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Část trubky"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirátská vlajka"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirátská loď",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Velká houpající se pirátská loď",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirátská loď"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirátské kulisy"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Piráti"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Stánek s pizzou",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Stánek prodávající kusy pizzy"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Obyčejná mramorová zeď"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Rostlina"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Rostlina"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Stěna z hracích karet"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Stěna z hracích karet"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Sloup"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Pluh"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Horská dráha polárního medvěda",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Návštěvníci sedí po dvou zavěšení pod tratí a vidí dopředu nebo dozadu podle toho, jak zrovna jedou skrze ostré zatáčky",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Tyč"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Tyč"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Tyče"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Policejní honička",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Horská dráha s loopingy, na které návštěvníci ve vozech sedí",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Horská dráha policejních vozů",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Po dřevěné dráze jedou vozy ve tvaru policejních aut 60. let, které se ve speciálních místech se otočí a jedou pozpátku",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Stánek s popcornem",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Stánek prodávající obrovské kelímky popcornu"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Padací brána"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Padací brána"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Sloup"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Důlní jízda",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Horská dráha s vozy ve stylu důlních vagónů, které jedou po hladkých kolejnicích skrze propletenou dráhu",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 nebo 4 místa v každém voze"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Pravěký vstup"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Pravěk"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Stánek s preclíky",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Stánek prodávající křupavé preclíky"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Prebiotická polévka"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Věznice - dveře"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Věznice - plot"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Věznice - obrácená část"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Věznice - roh"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Věznice - roh"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Věznice - stěna"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Věznice - střecha"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Věznice - Rozhledna"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Věznice - schodiště na rozhlednu"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Věznice - schodiště na rozhlednu"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Věznice - vodní věž"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodaktylská horská dráha",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Návštěvníci sedí v pohodlných sedadlech pod tratí cestující skrze propletenou dráhu, poskytující pocit prehistorického letu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Dýně"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Dýňový dům"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramida"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "TV ve frontě"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Závodní auta",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Vozy ve tvaru závodních aut",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Raptorská horská dráha",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Návštěvníci sedí na zádi vozů ve tvaru raptorů, které jedou po jednokolejné dráze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Závodní tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Říční rafty",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Rafty se plaví po meandrech na vodním kanále",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 místa na každém raftu"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Zábradlí"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Duhová cesta"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Rohová červená střecha"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Plochá rohová červená střecha"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Krajní červená střecha"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Obrácená červená střecha"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Červená střecha 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Červená střecha 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Červená střecha 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Zeď z červených cihel 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Zeď z červených cihel 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Zeď z červených cihel 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Zeď z červených cihel 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Zeď z červených cihel 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Zeď z červených cihel 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Zeď z červených cihel 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Zeď z červených cihel 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Zeď z červených cihel 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Jedle nádherná"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Jedle nádherná"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Kráter - roh"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Kráter - roh"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Kráter - obrácený roh"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Kráter - stěna"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Sequoioideae"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro jednokolejné vlaky",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Retro jednokolejné vlaky bez oken",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Volný pád pozpátku",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Velká dráha s vozem pro volný pád pozpátku",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Otáčivá horská dráha",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Horská dráha s vozy, které se ve speciálních místech se otočí a jedou pozpátku",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Nosorožec"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Nosorožčí jízda",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Malá ocelová horská dráha se spirálovitým profilem a vozy se sedadly za sebou",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Lanoví"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Divoká voda",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Kulaté lodě se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 míst v každé lodi"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Řeka Styx",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Rafty se plaví po meandrech na vodním kanále",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 místa na každém raftu"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Silnice"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Bouřlivá 20. léta - vstup do parku"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Bouřlivá 20. léta"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Bouřlivá 20. léta - stěny"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Stánek s klobásami",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Stánek prodávající grilované klobásy"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Kemp Robina Hooda"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Chata Robina Hooda"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Chata Robina Hooda"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll - vstup do parku"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Autobus rokové kapely"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Kamenná stěna"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Raketová auta",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Horská dráha s vozy vypadajícími jako rakety",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Kamenitá cesta"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Ocenění horské dráhy"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Bruslící číšnice"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Římské koloseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Římský sloup"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Stěna římských sloupů"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Římský palác - roh"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Římský palác - roh"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Římský palác - roh"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Římský palác - roh"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Římský palác - střední sekce"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Římský palác - střední část"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Římský palác - střední sekce"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Římský palác - střední část"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Římský palác - koncová část"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Římský palác - koncová část"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Římský palác - rovná část"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Římský palác - rovná část"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Římský palác - rovná část"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Římský palác - rovná část"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Římská socha"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Římská socha"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Římský palác"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Římská zeď"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Římská zeď"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Římská fanfára"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Střecha"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-pád",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Kruh sedadel je za pomalé rotace vytažen na vrchol vysoké věže, spuštěn volným pádem k zemi a opatrně zastaven pomocí magnetických brzd",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Silnice 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Tramvaj ve tvaru Londýnského autobusu",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Repliky červených dvoupatrových londýnských autobusů",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 míst v každém voze"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Veslice",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Veslice, u kterých musí návštěvníci veslovat",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Rozbitá socha"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Ranvej"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Ranvej"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Ranvej"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Ranvej"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Ranvej"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Ranvej"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Salón"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Tramvaj ze San Francisca",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Repliky tramvají",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 míst v každém voze"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Pískovcový mrakodrap - dolní roh"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Pískovcový mrakodrap - dolní roh"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Pískovcový mrakodrap - dolní zaoblená část"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Pískovcový mrakodrap - dolní obrácený roh"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Pískovcový mrakodrap - zaoblený spodek"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Pískovcový mrakodrap - zaoblený vršek"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Pískovcový mrakodrap - horní zaoblená část"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Pískovcový mrakodrap - zaoblený vršek"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Pískovcový mrakodrap - dok"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Pískovcový mrakodrap - dveřní rám"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Pískovcový mrakodrap - výplň"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Pískovcový mrakodrap - výplň"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Pískovcový mrakodrap - obrácený vrchní roh"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Pískovcový mrakodrap - střední roh"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Pískovcový mrakodrap - střední roh"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pískovcový mrakodrap - střední zaoblená část"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pískovcový mrakodrap - zaoblený střed"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Pískovcový mrakodrap - roh"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Pískovcový mrakodrap - střední stěna"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Pískovcový mrakodrap - střední stěna"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Pískovcový mrakodrap - střední stěna"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Pískovcový mrakodrap - střední stěna"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Pískovcový mrakodrap - střední stěna"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Pískovcový mrakodrap - střecha"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Pískovcový mrakodrap - střešní díl"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Pískovcový mrakodrap - střešní díl"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Pískovcový mrakodrap - brána"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Pískovcový mrakodrap - brána"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Pískovcová brána - roh"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Pískovcová brána - středová část"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Pískovcová brána - koncová sekce"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Pískovcová brána - T-křižovatka"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satelit"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satelit"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Americký školní autobus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Školní autobus - tramvaj",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Replika amerických žlutých školních autobusů",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 míst v každém voze"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Borovice lesní"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Posuvná cedule"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Posuvná cedule"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Socha"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Socha"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Stánek s plody moře",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Stánek prodávající smažená chapadla"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplán"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Tulení horská dráha",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Malá ocelová horská dráha, na které vozy připomínající tuleně jezdí skrze loopingy a jezdí ve vývrtce",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hydroplán"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hydroplán"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Pátrací světlo"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Sedadla"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Keř"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Keř"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Keře a ornamenty"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Pérák"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Pérák"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Čínská zeď"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Chodník"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Cedule"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Cedule a věci na cesty"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Bříza bělokorá"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Zpěvák s patkou"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Vyhlídková věž",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Otáčející se vyhlídková kabina, která postupně vyjíždí na vysokou věž",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 návštěvníků"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags kulisy"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Šestimístná zakroucená horská dráha",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extra-široké vozy letí dolů po zcela kolmé dráze a poskytují tím pocit volného pádu",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Kostlivec"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Sedačkové lanovky",
+    "reference-description": "Open cars for chairlift",
+    "description": "Lanovka se sedačkami",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa na jedné sedačce"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Sněžné vozy",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Autodrom s vozy ve tvaru sněžných vozů",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Lebka"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Lebka"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Kovový mrakodrap - stěna"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Kovový mrakodrap - stěna"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Kovový mrakodrap - výtah"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk cesta"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Konkávní díl mrakodrapu"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Konkávní střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Konvexní střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Konvexní střecha mrakodrapu"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Výtah mrakodrapu"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Výtah mrakodrapu"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Kovový výtah mrakodrapu"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Kovový mrakodrap - výtah"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Kovový výtah mrakodrapu"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Kovový set mrakodrapu 1 - konkávní díl"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Kovový set mrakodrapu 1 - konvexní díl"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Kovový set mrakodrapu 1 - stěna"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Kovový set mrakodrapu 2 - konkávní díl"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Kovový set mrakodrapu 2 - konkávní díl"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Kovový set mrakodrapu 2 - konvexní díl"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Kovový set mrakodrapu 2 - stěna"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Kovový set mrakodrapu 1 - stěna"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Střecha mrakodrapu"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Vrcholek mrakodrapu"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Lenochodí jízda",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha s vozy připomínající lenochody, které se houpají v zatáčkách",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Malý nahnutý mamutí plot"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Malý nahnutý mamutí plot"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Malé ozubené kolo"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Malé ozubené kolo"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Malé ozubené kolo"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Malé ozubené kolo"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Malá geosféra"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Malý kráter"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Malé jednokolejné vozy",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Malé jednokolejné vozy bez dveří",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Strom z deštného pralesa 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Strom z deštného pralesa 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Malý kráter"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Malý reproduktor"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Velký kouřící komín"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Velký kouřící komín"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Šnek"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Zasněžená cedule"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Sněhové kalíšky",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Návštěvníci sedí po dvou v kalíšcích, které se otáčejí okolo sněhuláka uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Ledové a sněhové kulisy"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Sníh"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Zasněžená Jedle"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Zasněžený smrk ztepilý"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Zasněžená jedle nádherná"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Zasněžená jedle nádherná"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Sněhová koule"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Sněhulák"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Závodní krabičky od mýdla",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Návštěvníci jezdí v závodních vozech ve tvaru dávných krabiček od mýdla",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Stánek s plyšáky-dinosaury",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Stánek prodávající roztomilé plyšáky-dinosaury"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Jižní Amerika"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Vstup do parku ve stylu jižní Ameriky"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Stánek se suvenýry",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Stánek prodávající suvenýry - plyšáky a deštníky"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Stánek s mlékem",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Stánek prodávající kelímky sojového mléka"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Vesmírná loď"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Vesmírná loď"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Vesmírné objekty"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Vesmírné kruhy",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Tři v sobě zasazené rotující kruhy dají návštěvníkům možnost volného pohybu ve všech třech rozměrech",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 místo v každém kruhu"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Vesmírná raketa"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Vesmírná loď - nákladní sekce"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Vesmírná loď - komunikační sekce"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Vesmírná loď - kontrolní panel"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Vesmírná loď - střední část"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Vesmírná loď - dok"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Vesmírná loď - motory"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Vesmírná loď - palivová sekce"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Vesmírná loď - gravitační sekce"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Vesmírná loď - obývací část"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Vesmírná loď - vědecká sekce"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Vesmírná loď - solární panely"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Vesmírná loď - solární sekce"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Cesta ve vesmírném stylu"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Cedule ve vesmírném stylu"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Vesmírné kulisy"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Vesmír"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Strom ve tvaru listu"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sfinga"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Pavouk"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Ostnatý plot"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Točící se divoká myš",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Vozy ve tvaru myší jedou po dřevěné trati a pro dezorientaci návštěvníků se točí, zatímco se naklání v ostrých zatáčkách a drsných pádech",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spirální horská dráha",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Malá ocelová horská dráha se spirálovitým profilem a vozy se sedadly za sebou",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Točitá skluzavka",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Dřevěná budova se schodištěm uvnitř a venkovní točitou skluzavkou, na které se jezdí s podložkami",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Cákající lodě",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Velkokapacitní lodě se plaví po vodním kanále, poháněny do pásem do strmých úseků, zrychlují sjížděním svahů a namočí návštěvníky pořádným šplouchnutím",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 míst na každé lodi"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Strašidelné kulisy"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sportovní auta",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Vozy ve tvaru sportovních aut",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sportovní kulisy"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Návštěvníci jedou na jednokolejné trati vleže hlavou dolů, zavěšeni ve speciálním voze, který se v zatáčkách houpe",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Strom ve tvaru veverky"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Dostavníková horská dráha",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klíně",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Horská dráha splašeného stáda",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Horská dráha s loopingy a vozy ve tvaru splašeného stáda dinosaurů",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Horská dráha \"na stojáka\"",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Návštěvníci jedou po horské dráze ve stoje",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Zakroucená horská dráha \"na stojáka\"",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Návštěvníci jedou ve stoje ve vozech vybavenými ramenními opěrkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Stánek s džusy",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Stánek prodávající ovocné nápoje"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Socha"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Socha"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Socha"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Socha svobody"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Parní vlaky",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 míst v každém vagónu"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Parní vlaky s krytými vozy",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny s plátěnými střechami",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 míst v každém vagónu"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Kouřící kanály"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Ocelový blok"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Ocelový blok"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Ocelový plot"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Ocelová konstrukce"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Ocelová stěna"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Chrám doby kamenné"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Kamenná lavička"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Kamenný blok"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Kamenné schodiště mrakodrapu"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Zeď kamenného mrakodrapu"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Zeď kamenného mrakodrapu"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamenný mrakodrap - stěna"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamenný mrakodrap - stěna"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamenný mrakodrap - stěna"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Kamenná stěna"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Kamenná stěna"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Kamenná stěna"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Kamenná stěna"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stolička"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stoličky"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Aerodynamické jednokolejné vlaky",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Velkokapacitní jednokolejné vlaky s aerodynamickou přídí a zádí",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 nebo 10 míst v každém vagónu"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Stánek se sendviči",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Stánek prodávající čerstvé sendviče"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Ponorky",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 návštěvníci v každé ponorce"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Stánek s suzungkwa",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Stánek prodávající suzungkwa"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Letní hudba"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Stánek s brýlemi",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Stánek prodávající mnoho různých druhů slunečních brýlí"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Potopená loď"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Superpočítač"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Superpočítač"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Podpěra"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Podpěra"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Podpěra"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surferská horská dráha",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Návštěvníci jedou ve stoje v širokých vozech se speciálně navrženým držením po propletené dráze s pády",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Zavěšené jednokolejné vlaky",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Velkokapacitní jednokolejné vlaky",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 míst v každém vozu"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Hydroplánská horská dráha",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha z volné zavěšených vozů, které se naklání při jízdě do zatáček",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Zavěšené houpající se aeroplány",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha z volné zavěšených vozů ve tvaru aeroplánu, které se naklání při jízdě do zatáček",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Zavěšené houpající se vozy",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha z volné zavěšených vozů, které se naklání při jízdě do zatáček",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Zavěšený most"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Zavěšený most"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Bažina - Tráva"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Bažina"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Bažina - Rostlina"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Bažina - Rostlina"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Bažina - Rostlina"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Labutě",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Lodě ve tvaru labutí, ovládané šlapáním návštěvníků",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 místa na každém raftu"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Houpající se vozy",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Malé houpající se vozy zavěšené na kolejnici",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Houpající se vozy bez podlahy",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Zavěšená horská dráha připomínající sedačkovou lanovku, houpající se v zatáčkách",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Houpající se obrácená loď",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Loď je připevněna na podpěru, která se chová jako protizávaží a otáčí se o 360 stupňů",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 návštěvníků"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Meč v kameni"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Stánek s tričky",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Stánek se suvenýry - tričky"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV horská dráha",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Horská dráha s vozy poháněnými elektromotorem, které sviští skrze propletenou dráhu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Barel dynamitu"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Bedna dynamitu"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Rozbuška"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Dynamit"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Vysoká lucerna"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Vysoká lucerna"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Vysoký dřevěný plot"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Cíl"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Asfaltová cesta"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Hospoda"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Týpí"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleportér",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Návštěvníci jsou transportování z jednoho patra do druhého",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 návštěvníků"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Rozbitá stěna chrámu s hlavou"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Střecha chrámu"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Chrámové schody"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Chrámové schody"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Rohová stěna chrámu"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Rohová stěna chrámu"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Rohová stěna chrámu"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Rohová stěna chrámu"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stěna chrámu"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Stěna chrámu s hlavou"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Činžovní dům"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tenisový míček"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Síť na tenis"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Síť na tenis"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Stan"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Týpí"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termitiště"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Řadový dům"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terakotová armáda"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Stroj času",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Návštěvníci sedí ve speciálně navržené kruhovité konstrukci a zažívají pocit cestování časem",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 místo v každém stroji času"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Muchomůrka"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Tobogánová horská dráha",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Horská dráha ve stylu tobogánu s vozy se sedačkami za sebou",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Jarmarkový stánek s jablky v županu",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Stánek prodávající jablka v županu"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Stánek s jablky v županu",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Stánek prodávající jablka v županu na tyčce"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Toalety v betonové zástavbě"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toalety v dřevěné zástavbě"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Toalety v betonové zástavbě"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Jízda s Thompsonem",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo velké repliky samopalu Thompson uprostřed",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Návštěvníci sedí v gondole zavěšené na podpěrách, otáčející se dopředu a dozadu vzhůru nohama",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Radnice"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Země hraček"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Moskvičová horská dráha",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Horská dráha s Ruskými vozy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Zatáčka na trati"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Rozbitá trať"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Konec tratě"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Rozpůlení tratě"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Rovná trať"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Traktor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Tradiční brána pro vstup do parku"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Tramvaje",
+    "reference-description": "Old-timer replica trams",
+    "description": "Retro repliky tramvají",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 míst v každém vozu"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Cestovatelský vůz"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Truhla s pokladem"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Truhla s pokladem"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Truhla s pokladem"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Katapultující jízda",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Návštěvníci sedí v gondole zavěšené na podpěrách, otáčející se dopředu a dozadu vzhůru nohama, která vypadá jako obléhací zbraň z dávných dob",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 návštěvníků"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Strom"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Stromy"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Autodrom s Triceratopsem",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Autodrom s vozy ve tvaru Triceratopsů",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 místo v každém voze"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobití lodě",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Vozy ve tvaru trilobitů jedou po trati horské dráhy, což umožňuje ostré zatáčky, strmé klesání a cákající zpomalení pro mírnější říční úseky",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 míst v každé lodi"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudorská stěna"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudorská přízemní stěna - část 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudorská přízemní stěna - část 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudorská přízemní stěna - část 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudorská přízemní stěna - část 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudorská přízemní stěna - část 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudorská přízemní stěna - část 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudorská přízemní stěna - část 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudorská přízemní stěna - část 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudorská přízemní stěna - část 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudorská přízemní stěna - část 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudorská přízemní stěna - část 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudorská přízemní stěna - část 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudorská přízemní stěna - část 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudorská střecha"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudorská střecha"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudorská střecha"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudorská střecha"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudorská střecha"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudorská stěna - část 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudorská stěna - část 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudorská stěna - část 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudorská stěna - část 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Želví jízda",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Malé čluny ve tvaru mořských želv s motorovým pohonem ovládaným návštěvníky",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 místa v každé lodi"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Návštěvníci sedí po dvou v jedné ze tří kabin, které kolem sebe rotují",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 návštěvníků"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Zatočené vozy",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Horská dráha, která se točí dokola tak, že návštěvníci jsou pořád na stejném místě.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Zatočené vozy (pozpátku)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Horská dráha, která se točí dokola tak, že návštěvníci jsou pořád na stejném místě.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Zakroucená horská dráha",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Rozměrná horská dráha s vozy vybavenými ramenními opěrkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO havárie"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Socha jednorožce"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban kulisy"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkýra"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkýra"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkýrská horská dráha",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extra-široké vozy letí dolů po zcela kolmé dráze a poskytují tím pocit volného pádu",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "vertikální 3D cedule"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Zavěšená svislá dráha",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Návštěvníci sedí ve vozech zavěšených pod tratí, jedou pozpátku vzhůru po svislé dráze, padají dolů a jezdí skrze loopingy s ostrými zatáčkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vinná réva"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Veteráni",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Vozy ve tvaru veteránů jezdí po postavené dráze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém vozu"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginský moták",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Kulaté vozy se točí během jízdy po cik-cak dřevěné trati",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Sopka"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Sopka s malými stromy"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Štědřenec"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Vagón"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Vagón"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Kolo vagónu"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Stěna"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Stěna"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Stěny a střechy"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Ořešák královský"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Socha Washingtona"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Vosa"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Vodní kulisy"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Vodní proud"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Vodní chrlič"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Vodní tricykly",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Šlapadla ve tvaru tricyklů s velkými plovoucími koly",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 místa na každém kole"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Vodní"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Vodopád"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Hliněná střecha"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Hliněná střecha"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Hliněná střecha"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Hliněná zeď"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Set zbraní"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Vrba"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Kola"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky barel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky barely"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Bílý střelec"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Bílý král"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Bílý kůň"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Bílá pěšák"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Topol bílý"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Bílá královna"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Bílá věž"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Kulisy divokého západu"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Divoký západ"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Roh větrem ošlehané střechy"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Roh větrem ošlehané stěny"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Roh větrem ošlehané stěny"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Konvexní roh větrem ošlehané střechy"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Konvexní roh větrem ošlehané stěny"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Konvexní roh větrem ošlehané stěny"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Podlaha větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Podlaha větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Základna větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Základna větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Střední část větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Střední část větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Střední část větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Střední část větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Vršek větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Vršek větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Střecha větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Střecha větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Střecha větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Stěna větrem ošlehaného kamene"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Stěna větrem ošlehaného kamene"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Větrem ošlehaná stěna - část"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Větrem ošlehaná stěna - část"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Větrem ošlehaná stěna - část"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Větrem ošlehaná stěna - část"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Větrný mlýn"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Čarodějnický kotlík",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Stánek prodávající hustou polévku"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Čarodějnice s kotlíkem"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Červí jízda",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Horská dráha s vozy ve tvaru červů",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 místa v každém voze"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Kulisy říše divů"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Stánek s čínskou polévkou",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Stánek prodávající čínskou knedlíčkovou polévku"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Dřevěný plot s vinou révou"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Dřevěný plot s vinou révou"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Dřevěný plot s révou"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Dřevěný plot s révou"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Dřevěný plot s révou"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Dřevěný plot s mužem, který jí rostlinu"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Dřevěný blok"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Dřevěný povoz"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Dřevěný plot"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Stěna ze dřevěného plotu"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Dřevěná cesta"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Dřevěný sloup v plotě"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Zeď dřevěných sloupů"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Dřevěný sloup v plotě"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Zeď dřevěných sloupů"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Dřevěná horská dráha",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Dřevěná horská dráha (6 sedadel)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Dřevěná horská dráha (6 sedadel, pozpátku)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína, na které se jezdí pozpátku",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 míst v každém voze"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Horská dráha s bočním uchycením",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Po dráze jezdí vozy, které mají kola horizontálně uložená pod podlahou a opírají se jimi o stěny dráhy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Dřevěná cedule"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Dřevěná stěna"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Dřevěná stěna"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Dřevěná stěna"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Dřevěná stěna"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Rozbitý hydroplán"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Taxi horská dráha",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Gigantická ocelová horská dráha schopna volných pádů a kopců přes 90 metrů dlouhých",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 místa v každém voze"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Tis"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Socha Dia"
+  }
+}

--- a/objects/da-DK.json
+++ b/objects/da-DK.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Slik stil"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Valgfrit musik 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Valgfrit musik 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Radiobil musik stil"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptisk stil"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Karnevalsmusik stil"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy stil"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Rolig stil"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Gyser stil"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Is stil"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungletrommer stil"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic stil"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Maritim stil"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mekanisk stil"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Middelalder stil"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Moderne stil"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Ingen indgang"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgel stil"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Orientalsk stil"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirat stil"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime stil"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock stil"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock stil 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock stil 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Romersk fanfare stil"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Sne stil"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Rum stil"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Sommer stil"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno stil"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Legetøjs land stil"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Undergrunds stil"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Vand stil"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Western stil"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/de-DE.json
+++ b/objects/de-DE.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "„Goliath“-Schild"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "„Medusa“-Schild"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "„Nitro“-Schild"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "„Texas Giant“-Schild"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Rennwagen der Zwanziger",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Go-Karts im Stil der 1920er",
+    "reference-capacity": "Single-seater",
+    "capacity": "Einsitzer"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Auto aus den 50ern"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Auto aus den 50ern"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "50er-Jahre-Rakete"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "50er-Jahre-Raketen",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Hängende raketenförmige Achterbahnzüge, die aus Wagen bestehen, die frei schwingen können, wenn der Zug um die Kurven fährt",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D-Kino",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Kino, in dem 3D-Filme in einer geodätischen Kugelstruktur gezeigt werden",
+    "reference-capacity": "20 guests",
+    "capacity": "20 Besucher"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D-Schild"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D-Schild"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Umgekehrte seitl. Viersitzer-Achterbahnzüge",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Aufgehängte Züge, in denen die Fahrgäste in Sitzreihen Platz nehmen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-Sitzer-Bobs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobwagen mit drei Sitzreihen, mit Platz für jeweils zwei Leuten",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aborigine-Kunst - Bauteil"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aborigine-Kunst - Schlichte Kachel"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aborigine-Kunst - Schlangen-Kunstwerk"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aborigine-Kunst - Geister-Kunstwerk"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstrakt"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstraktes Thema"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Säuregrünes Wasser"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Aktiver Vulkanschlot"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Erwachsener Indischer Elefant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Erwachsener Pandabär"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Afrika-Parkeingang"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Afrika-Thema"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Luftbetriebene Vertikalbahnzüge",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Achterbahnzüge, die luftbetrieben gestartet werden",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Einschienenzüge im Luftschiffstil",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Einspurbahnen mit großem Fassungsvermögen und stromlinienförmigen Wagen an beiden Enden",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 Fahrgäste pro Wagen"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppokiefer"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Außerirdische historische Gebäude"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Außerirdische historische Gebäude"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Außerirdische Pflanze"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Außerirdische Pflanze"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Außerirdisches Oberlicht, groß"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Außerirdisches Oberlicht, klein"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Außerirdisches Gebäude, groß"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Außerirdisches Gebäude, groß"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Außerirdisches Gebäude, groß"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Außerirdisches Gebäude, klein"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Außerirdisches Gebäude, klein"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Außerirdisches Gebäude, klein"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Außerirdischer Turm, unten"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Außerirdischer Turm, Mitte"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Außerirdischer Turm, oben"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Außerirdischer Baum"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Außerirdischer Baum"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligatorförmiger Baum"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American-Football-Helm"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Dampfzüge im amerik. Stil",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Mini-Dampfzüge bestehend aus nachgemachter Dampflok und Tender mit Holzwagons mit Stoffdächern",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 Fahrgäste pro Wagon"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anakonda-Züge",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Geräumige Züge mit einfachen Beckenhalterungen",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pro Wagen"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Tier auf dem Spieß"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animierte Ballons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animiertes Lagerfeuer"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic Das Allmächtige Auge"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic feuermachender Höhlenmensch"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Jungfrau in Ketten"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clanmitglied"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dunkler Ritter"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dunkler Ritter"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Libellen"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Adler auf Käfig"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Böser Außerirdischer"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Böser Außerirdischer"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Böser Außerirdischer"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Feuerwehrmann"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Feuernde Kanone"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Guter Außerirdischer"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Guter Außerirdischer"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Guter Außerirdischer"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Ritter"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Ritter"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Polizist"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Armee der Skelette"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Armee der Skelette"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Armee der Skelette"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Weltraumaufsicht"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Winkender König"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic Skorpionangriff"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic Skorpionangriff"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flatternder Pterodaktylus"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarktis-Thema"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antilope (weiblich)"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antilope (männlich)"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antilopenpaar"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Schwerkraft-LCD-Reklametafel"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Schwerkraft-LCD-Reklametafel"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Bogenschießen-Zielscheibe"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona-Zypressenbaum"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Déco - Eckabschnitt"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Déco - Ecke mit Geländer"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Déco - Ecke mit Geländer"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Déco - Ecke mit Fenstern"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Déco - Ecke mit Fenstern"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Déco - Ecke mit Fenstern"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art-Déco-Essensstand",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Ein Stand, der Nudeln und frische Limonade verkauft"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Déco - umgedrehter Eckabschnitt"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Déco - umgedrehter Eckabschnitt"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Déco - Dachabschnitt"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Déco - oberer Eckabschnitt"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Déco - oberer Eckabschnitt"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Déco - oberer Eckabschnitt"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Déco - oberer Abschnitt"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Déco - oberer Abschnitt"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Déco - Mauerabschnitt"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Déco - Mauer mit Tür"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Déco - Mauer mit Geländer"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Déco - Mauer mit Geländer"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Déco - Mauer mit Geländer"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Déco - Mauer mit Geländer"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Déco - Mauer mit Fenstern"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Déco - Mauer mit Fenstern"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Gelenkverbundene Züge",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Achterbahnzüge mit kurzen einreihigen Wagen und offenen Fronten",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Aschefußweg"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Aschenbaum mit Nymphen"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asien-Thema"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asiatischer Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Espe"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas-Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasischer Parkeingang"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australien-Thema"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australisches Brunnen-Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australisches Brunnen-Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobil-Wagen",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Achterbahnwagen in Form von Pkws",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie-Riesenoktopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie-Riesenspinne"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie-Riesenspinnen-Fahrt",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Die Fahrer sitzen zu zweit in thematisch gestalteten Sitzen, die sich um eine große B-Movie-Spinne drehen",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Indisches Elefantenbaby"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby-Pandabär"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton-Schläger"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton-Schläger"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Chinesische Laterne"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Chinesische Laterne"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Ballonstand",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Ein Souvenirstand, an dem mit Helium gefüllte Luftballons verkauft werden"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bambus-Busch"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bambussockel"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bambusdach"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bambusdach"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bambusdach"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bambussprossen"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambuswand"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Bandmitglied"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Bandmitglied"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Bandmitglied"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Bandmitglied"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Himmelsstürmer-Wagen",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Umgekehrte Achterbahnzüge für die umgekehrte Impuls-Bahn, in der Form von Doppeldeckerflugzeugen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Fass"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Fass"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Fass"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Fass"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Basisblock"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Basisblock"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Basisblock"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Basisblock"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Rammbockzüge",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Kompakte Achterbahnzüge mit Wagen mit Sitzen in einer Reihe, mit dem Aussehen von Rammböcken aus dem finsterem Mittelalter",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Fleischnudelstand",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Ein Stand, an dem chinesische Fleischnudeln verkauft werden"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Bänke"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengalischer-Tiger-Wagen",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Achterbahnwagen, die sich um ihre Mittelachse drehen können, mit dem Aussehen von Bengalischen Tigern",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Fahrräder",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Spezielle Fahrräder, die auf einer Einschienenstrecke fahren und von den Passagieren mit Pedalen angetrieben werden",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 Person pro Fahrrad"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben und die Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Große Geosphäre"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Fahrradfahrer"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Schwarzer Läufer"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Londoner Taxis",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Fahrzeuge mit Eigenantrieb und dem Aussehen von Londoner Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Schwarzer-Tod-Züge",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rattenförmige Züge, die aus Zweisitzerwagen bestehen, in denen die Fahrgäste hintereinander sitzen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Schwarzer König"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Schwarzer Springer"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Schwarzer Bauer"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Schwarze Pappel"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Schwarze Königin"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Schwarzer Turm"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob aus dem Weltall",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Eine thematisch gestaltete rotierende Aussichtskabine, die wie ein Blob aus einem Science-Fiction-B-Movie aussieht",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 Fahrgäste"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobzüge",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Züge mit Zweisitzerwagen, in denen die Fahrgäste hintereinander sitzen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Siedekessel"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Knochen"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Knochenzaun"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Knochen"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Bumerangzüge",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Bumerangförmige Achterbahnzüge, die luftbetrieben gestartet werden",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Ziegel"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Ziegelmauer"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Ziegelmauer"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Ziegelmauer"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Britischer Briefkasten"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Britische Telefonzelle"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Beschädigte Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Gebrochenes Rad"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brauner Makadam-Fußweg"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brauner Mosaikfußweg"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Brodelnde Teergrube"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Eimer"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Gebäude"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Gebäude"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet-Züge",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Achterbahnzüge im Stil japanischer Schnellzüge (sogenannter Bullet Trains)",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Rohrkolben"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Scooter-Boote",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Kleine, runde Schlauchboote, die von einem zentralen Motor angetrieben werden, der von den Fahrgästen gesteuert wird",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 Fahrgäste pro Boot"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boje"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boje"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger-Laden",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Ein Gebäude in Burger-Form, in dem Burger verkauft werden"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Busch"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Schmetterling"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana-Vorbau"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana-Vorbau"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabanadach-Bauteil"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabanadach-Bauteil"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabanadach-Bauteil"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana-Spitze"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabanawand-Bauteil"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Rote Angelin"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown-Ulme"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Kanarische Palme"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Süßigkeit"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Süßigkeit"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Süßigkeit"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Zuckerstange"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Süßigkeitenbaum"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Süßigkeitenbaum"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Süßigkeitenbaum"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candyland-Stil"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Zuckerwattestand",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Ein Stand in Zuckerwatte-Form, an dem pinkfarbene Zuckerwatte verkauft wird"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Kanone"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Kanone"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Kanonenkugeln"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Kanus",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lange Kanus, in denen die Passagiere selbst rudern",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 Passagiere pro Kanu"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Zeltdach"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Zelt"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Karnevalsschmetterlingswagen",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Schmetterlingsförmige Karnevalswagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Karnevalsfroschwagen",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Froschförmige Karnevalswagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Karnevalsechsenwagen",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Echsenförmige Karnevalswagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Wagenschacht"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Geldautomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Ein Geldautomat für Besucher, falls ihnen das Bargeld ausgeht"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Burg (braun)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Burg (grau)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Schloss-Eckstück"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Schloss-Eckstück"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Schlosseingang"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Umgedrehte Schlossecke"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Schloss-Fallgitter"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Schlosswall"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Schlosswall-Ecke"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Schlosswall-Ecke"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Schlosswall-Ecke"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Umgedrehte Schlosswall-Ecke"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Burgturm"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Schlossturm-Eckstück"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Schlossturm-Eckstück"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Schlossturm-Querstück"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Gerades Schlossturm-Stück"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Schlossturm-T-Stück"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Schlossturm-T-Stück"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Burgmauer"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Schlossmauer"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Schlossmauer"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Schlossmauer"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Rinderschädel"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Kaukasische Tanne"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Kessel"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Höhleneingang"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Höhlenmenschenwagen",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Selbstbetriebene Go-Karts im Steinzeitstil",
+    "reference-capacity": "Single-seater",
+    "capacity": "Einsitzer"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Libanonzeder"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Zerberus-Züge",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Geräumige Züge mit einfachen Beckenhalterungen mit Wagen, die wie der mehrköpfige Hund aus der Unterwelt geformt sind",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Sesselliftwagen",
+    "reference-description": "Open cars for chairlift",
+    "description": "Offene Wagen für Sessellift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Schachbrettblock"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Schachbrett"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Grinsekatzen",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Angetriebene Fahrzeuge in Katzenform",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 Fahrgäste pro Katze"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken-Nuggets-Stand",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Ein Stand, an dem Chicken Nuggets verkauft werden"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinesische Zeder"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinesischer Drache"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinesische Drachenkopffahrt",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Die Gäste liefern sich Gefechte in drachenkopfförmigen Autoscootern",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Fahrgast pro Wagen"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinesische Dschunken-Schaukel",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Das Schiff ist an einem Arm angebracht, an dessen gegenüberliegenden Ende ein Gegengewicht ist. Es schwingt komplett um 360 Grad",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 Fahrgäste"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Pommesbude",
+    "reference-description": "A hut selling chips",
+    "description": "Ein Häuschen, in dem Pommes Frites verkauft werden"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Pommesstand",
+    "reference-description": "A stall selling chips",
+    "description": "Ein Stand, an dem Pommes Frites verkauft werden"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Schokoriegel"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Elektronischer Fußweg"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Zirkus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Zirkustiershow in einem großen Zelt",
+    "reference-capacity": "30 guests",
+    "capacity": "30 Besucher"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Zirkus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Klassisch / Römisch"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Klassisches Schild"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Klassisches/römisches Thema"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Kleopatras Nadel"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Rankender Rebenbaum"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Uhr"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Kreuzförmiger Baum"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Achterbahnboote",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Bootsförmige Achterbahnwagen",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 Fahrgäste pro Boot"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Kaffeetassenbahn",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Die Fahrgäste fahren paarweise in Sitzen, die um eine große animierte Kaffeemühle rotieren",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Kaffeeladen",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Ein Laden im Art-Deco-Stil, in dem Kaffee verkauft wird"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Zahnrad"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Zahnrad"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Zahnrad"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Zahnrad"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola-Fruchtgummi"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Säulengang"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Wacholderbaum"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Eiche"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Eibe"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Kompakte umgekehrte Bahnzüge",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Die Fahrgäste hängen in Sitzpaaren unterhalb der Strecke",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Kondorzüge",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Die Passagiere fahren, in speziellen Gurten hängend, unterhalb der Strecke. In den kondorförmigen Wagen erleben sie dabei ein Gefühl des Fliegens",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger-Aal-Züge",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Aalförmige Züge mit Schulterhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Nadelbaumhecke"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Nadelbaumhecke"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Laufband-Ecke"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Laufband-Umkehrkurve"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Laufband-Ende"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Laufband-Anstieg"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Laufband-Gerade"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Keksladen",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Ein Stand, an dem riesige Kekse verkauft werden"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cooler Typ"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Korkenzieher-Achterbahnzüge",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Achterbahnzüge mit Schulterhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Gewelltes Dach-Bauteil"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Wellblechbasis"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Wellblechdach"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Wellblechwand"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Gewelltes Wand-Bauteil"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Korsische Kiefer"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Fußweg mit verrücktem Belag"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Gruselthema"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Krokodilsboote",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Krokodilsförmige Boote, die für die Fahrt in Wasserkanälen ausgelegt sind",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pro Boot"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Schiefes Haus",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Gebäude mit verzerrten Räumen und verwinkelten Korridoren, in denen die Besucher die Orientierung verlieren",
+    "reference-capacity": "5 guests",
+    "capacity": "5 Besucher"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Amor-Springbrunnen"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Gebogener Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Gebogener Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogenes Schlammwand-Bauteil"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogenes Schlammwand-Bauteil"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogenes Schlammwand-Bauteil"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Gebogenes Dach"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Gebogenes Dach"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Gebogene Wand"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Gebogene Wand"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Eigene Musik 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Eigene Musik 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Zyklopenfahrt",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Die Fahrer fahren im Auge eines Riesenzyklopen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Person pro Wagen"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Zyklopen-Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Gänseblümchen-Lampe"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dammturm"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Eingang zum Finsteren Mittelalter"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Finsteres-Mittelalter-Thema"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Mittelalterdorf - Dacheckstück"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Mittelalterdorf - Dacheckstück"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Mittelalterdorf - Umgedrehtes Dachstück"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Mittelalterdorf - Umgedrehtes Dachstück"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Mittelalterdorf - Unteres Eckstück"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Mittelalterdorf - Unteres Mauerstück"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Mittelalterdorf - Dachstück"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Mittelalterdorf - Dachstück"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Mittelalterdorf - Dachstück"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Mittelalterdorf - Dachstück"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Mittelalterdorf - Dach mit Kamin"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Mittelalterdorf - Oberes Eckstück"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Mittelalterdorf - Oberes Mauerstück"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Mittelalterdorf - Oberes Mauerstück"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Mittelalterdorf - Oberes Mauerstück"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Mittelalterdorf - Oberes Mauerstück"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Mittelalterdorf - Oberes Mauerstück"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Mittelalterdorf - Balkonkasten"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Mittelalterdorf - Balkonkasten"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Mittelalterdorf - Balkonkastendach"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Mittelalterdorf - Balkonkastendach"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Mittelalterdorf - Balkonkastendach"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Mittelalterdorf - Balkonkastendach"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Schenke des Finsteren Mittelalters"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Toter Baum"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Toter Baum"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Toter Baum"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhau-Boote",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Dekorative Fischerboote, die die Fahrgäste selbst durch Paddeln bewegen",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pro Boot"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamantenwagen"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamantenbahn",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Die Fahrgäste fahren paarweise in Sitzen, die um einen großen Diamanten rotieren",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamantenschacht"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Karoförmiger Baum"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Didjeridu"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Schlauchboote",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Aufblasbare Schlauchboote, die eine sich windende, halbkreisförmige oder komplett in sich geschlossene Rohrstrecke herunterrutschen können",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 Fahrgäste pro Schlauchboot"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurier"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurier"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurier"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurier"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurier"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaurier-Eier-Fahrt",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Die Fahrgäste fahren zu zweit in Sitzen, die um eine animierte Dinosauriermama rotieren",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Erde"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dreckfußweg"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Autoscooter",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Die Fahrer kollidieren miteinander in selbstgesteuerten elektrischen Wagen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Person pro Wagen"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Autoscooter-Beat-Stil"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Delfinboote",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Einsitzige delfinförmige Fahrzeuge, die die Passagiere selbst steuern können",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 Fahrgast pro Fahrzeug"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Delfinspringbrunnen"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Delfinstatue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Eingang"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Eingang"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Eingang"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Zweistöckiges Karussell",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditionelles, geschlossenes zweistöckiges Karussell mit geschnitzten Holzpferden",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 Fahrgäste"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Doppeldeckkabine",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Rotierende zweistöckige Aussichtskabine",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 Fahrgäste"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Donut-Laden",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Ein Stand, an dem ringförmige Donuts verkauft werden"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Düsterer Großer Turm - Basis"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Düsterer Großer Turm - Beschädigte Basis"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Düsterer Großer Turm - Mitte"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Düsterer Großer Turm - Spitze"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Düsteres Zwiebelkuppel-Bauteil 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Düsteres Zwiebelkuppel-Bauteil 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Düsteres Zwiebelkuppel-Bauteil 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Düsteres Dach-Bauteil 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Düsteres Dach-Bauteil 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Düsteres Dach-Bauteil 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Düsteres Dach-Bauteil 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Düsterer Kleiner Turm - Basis"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Düsterer Kleiner Turm - Zwiebelkuppel-Basis"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Düsterer Kleiner Turm - Spitze oder Mitte"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Düsteres Treppen-Bauteil 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Düsteres Treppen-Bauteil 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Düsteres Wand-Bauteil 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Düsteres Wand-Bauteil 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Düsteres Wand-Bauteil 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Düsteres Wand-Bauteil 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Düsteres Wand-Bauteil 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Düsteres Wand-Bauteil 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Düsteres Wand-Bauteil 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Düsteres Wand-Bauteil 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Düsteres Wand-Bauteil 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Düsteres Wand-Bauteil 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Düsteres Wand-Bauteil 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Drachenangriff"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Drachenzüge",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Achterbahnwagen im Drachenstil",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Libellenwagen",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Libellenförmige Wagen, welche, an der obigen Schiene hängend, hin- und her schwingen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Getränkestand",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Ein dosenförmiger Stand, an dem kohlensäurehaltige Getränke verkauft werden"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Osterinselstatue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Ägyptsiche Säule"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Ägyptische Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Ägyptisches Schild"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Ägyptisches Thema"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Ägyptische Mauer"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Ägyptischer Stil"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffelturm"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Elektrozaun"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Kaputter Elektrozaun"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Elektrozaun-Eckstück"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Umgedrehtes Elektrozaun-Eckstück"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Elektrozaun mit Licht"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elefantenspringbrunnen"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Leerer Wagen"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotierendes Rad mit hängenden Passagierkapseln, das sich zuerst dreht und dann von einem Hebearm hochgekippt wird",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eukalyptusbaum"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europa-Thema"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Europäische Lärche"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Europäischer Parkeingang"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Böser Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé-Eierbahn",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Die Fahrgäste fahren paarweise in Sitzen, die um ein großes Fabergé-Ei-Replikat rotieren",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Plandrehwagen",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Die Fahrgäste sitzen sich paarweise gegenüber oder Rücken an Rücken, während sie durch enge Kurven, Schleifen und Wendungen fahren",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Jahrmarktsorgelstil"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy-Stil"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Ackergeräte"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Dicker Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Festtisch"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Zaun"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Zaun"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Zaun"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Zäune und Mauern"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Riesenrad",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotierendes Riesenrad mit offenen Sitzen",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 Fahrgäste"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Leuchtfeuer"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Kampfdrachenbahn",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Die Fahrgäste nehmen auf rotierenden Sitzpaaren Platz, die sich an den Enden dreier langer kreisender Arme befinden",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Kampfritter-Autoscooter",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Die Fahrer kämpfen im Autoscooter auf Pferdewagen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Person pro Wagen"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Feuerwerkskörper",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotierendes Rad mit hängenden Passagierkapseln, das sich zuerst dreht und dann von einem Hebearm hochgekippt wird",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Erste Hilfe",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Ein Raum für Besucher, denen nicht gut ist, damit sie sich schnell besser fühlen"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Angelloch"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Reparierte Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flammen"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo (fressend)"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo (Ausschau haltend)"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo (beim Putzen)"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Bodenlose Twister-Züge",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Ein geräumiger Zug mit Schulterhalterungen und ohne Boden, was für eine aufregendere Fahrt sorgt",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Blume"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower-Power-Fahrt",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Die Fahrer fahren in blumenförmigen Luftkissenfahrzeugen, die sie selbst steuern",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 Fahrgast pro Wagen"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower-Power-T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stand, der T-Shirts mit Blumenmotiven verkauft"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Fliegende Schiffe",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Achterbahnzüge in der Form von fliegenden Schiffen",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 Fahrgäste pro Boot"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Züge für Fliegende Achterbahn",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Die Passagiere sind in komfortablen Sitzen unter den Schienen und fahren entlang einer gewundenen Strecke, was ihnen das Gefühl gibt, zu fliegen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Fliegende Untertassen",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Die Gäste fahren in untertassenförmigen Luftkissenfahrzeugen, die sie selbst steuern",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Person pro Wagen"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Fußball"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Fußballzüge",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Hängender Achterbahnzug mit Wagen, die Fußbällen nachempfunden sind und in Kurven frei schwingen können",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Baum der verbotenen Früchte"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Waldbäume"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Springbrunnen"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Springbrunnen"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Viersitzer-Wagen",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Einzelne Achterbahnwagen, die für Strecken mit Haarnadelkurven und steilen Gefällen ausgelegt sind",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Brathähnchenstand",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Ein Stand, an dem Brathähnchen verkauft werden"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Reisnudelstand",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Ein Stand, an dem chinesische Reisnudeln verkauft werden"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruchtdrop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruchtdrop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Obstbaum"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Obstbaum"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruchteis-Stand",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Ein Themenstand, an dem Fruchtspeiseeis verkauft wird"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Spaßhaus",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Haus mit beweglichen Wänden und Fußböden, um die Besucher zu verwirren",
+    "reference-capacity": "5 guests",
+    "capacity": "5 Gäste"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Kuchenladen",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Ein Stand, an dem Kuchen verkauft wird"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Zukunftsthema"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristischer Parkeingang"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Galgen"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Fluchtwagen",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Die Gangster-Fluchtwagen aus den 1920ern werden aus der Station heraus mit Linearmotoren beschleunigt und rasen durch verdrehte Loopings",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Beete"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Gemischtwarenhandlung"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gemäßigter Stil"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometrischer Springbrunnen"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrische Skulptur"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrische Skulptur"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrische Skulptur"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrische Skulptur"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrische Skulptur"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgianische Flachdachecke"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgianische Flachdachkante 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgianische Flachdachkante 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgianisches Erdgeschoss-Wandbauteil 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgianisches Dach-Bauteil 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgianisches Dachende-Bauteil 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgianisches Dachende-Bauteil 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgianisches Dach-Bauteil 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgianisches Dach-Bauteil 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgianisches Dach-Bauteil 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgianisches Dach-Bauteil 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgianisches Dach-Bauteil 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgianisches Dach-Bauteil 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgianisches Wand-Bauteil 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgianisches Wand-Bauteil 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgianisches Wand-Bauteil 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgianisches Wand-Bauteil 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgianisches Wand-Bauteil 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgianisches Wand-Bauteil 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysire"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Geisterbahnwagen",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Angetriebene Wagen in Monsterform, die auf einer Geisterbahnstrecke fahren",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Riesige Bassgitarre"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Riesiger Bohnenstängel"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Riesiger Bohnenstängel"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Süßwarenland-Thema"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Gigantische Karotte"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Gigantischer Dinosaurier-Fußabdruck"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Riesiges Schlagzeug"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Gigantischer Farn"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Riesengarten-Thema"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Gigantisches Gras"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Riesige Gitarre"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Gigantischer Mangrovenbaum"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Riesenpanda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Gigantischer Kürbis"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische Schneeflocke"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische Schneeflocke"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische Schneeflocke"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga-Bahn-Züge",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Achterbahnzüge für die Giga-Bahn, geeignet für gemäßigte Gefälle",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffenstatue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glasdach"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glasdach"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Selbstbetriebene Benzin-Go-Karts",
+    "reference-capacity": "single-seater",
+    "capacity": "Einsitzer"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Goldenes Lama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Goldene Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Goldene Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Goldener Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Das Goldene Vlies"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Goldene Hinoki-Zypresse"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Guter Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorillazüge",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Aufgehängte Achterbahnzüge, deren gorillaförmige Wagen frei schwingen können, wenn der Zug in die Kurven geht",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Gras"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grasbüschel"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grabstein"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grabstein"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grabstein"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grabstein"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Friedhofsmonument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Friedhofsmonument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Friedhofsmonument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Chinesische Mauer - Vordersektion"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Chinesische Mauer - Rückwand-Abschnitt"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Chinesische Mauer - Treppen-Wandabschnitt"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Chinesische Mauer - Ecktürmchen"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Chinesische Mauer - Geradentürmchen"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Weißhai-Züge",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Züge mit Schulterhalterungen, in der Form von Weißhaien",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Grüner Makadam-Fußweg"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Grünes Wasser"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Grüner und brauner Mosaikfußweg"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grauer Mosaikfußweg"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Gitter (grün)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Gitter (lila)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Gitter (rot)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Gitter (gelb)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Cooler Tänzer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades-Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Spiegelhalle",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Ein Gebäude mit verzerrten Spiegeln, in denen der Betrachter sich neu entdecken lernt",
+    "reference-capacity": "5 guests",
+    "capacity": "5 Gäste"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Hafendock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Hafenmauer"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Hafenmauer-Eckstück"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Hafenmauer-Eckstück"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Hafenmauer mit Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Hafenmauer mit Anglerausrüstung"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hafenmauer mit Anlegeplatz"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hafenmauer mit Anlegeplatz"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hafenmauer mit Anlegeplatz"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hafenmauer mit Anlegeplatz"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpyien-Züge",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Achterbahnzüge in der Form von mythischen Vogelwesen. Die Passagiere befinden sich in speziellen Haltevorrichtungen in liegender Position und fahren entweder auf dem Rücken oder dem Bauch",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hutstand",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Ein Souvenirladen, der große Hüte verkauft"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Spukhaus",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Großes Themengebäude mit gruseligen Gängen und spukigen Räumen",
+    "reference-capacity": "15 guests",
+    "capacity": "15 Besucher"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Spukgefängnis",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Haus mit eingekerkerten Figuren, die die Besucher erschrecken sollen",
+    "reference-capacity": "16 guests",
+    "capacity": "16 Gäste"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Spukvillawagen",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Kleine angetriebene Wagen, die auf einer Geisterbahnstrecke fahren",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Heuballen"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Herzförmiger Baum"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Boden des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Pool des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Poolecke des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Poolkante des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Poolstufen des Himmlischen Bades"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach des Himmlischen Bades"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach des Himmlischen Bades"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach des Himmlischen Bades"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Fenster des Himmlischen Bades"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Gewölbe der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Gewölbe der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Gewölbe der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektur der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektur der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektur der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektur der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Brunnen der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Brunnen der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Treppe der Himmlischen Bäder"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Treppe der Himmlischen Bäder"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hecke"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hecke"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Hubschrauberlandeplatz"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Herkules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba-Baum"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Nilpferd 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Nilpferd 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Nilpferd-U-Boote",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Die Passagiere fahren in einem nilpferdförmigen U-Boot durch eine Unterwasserstrecke",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 pro Wagen"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Johannisbrotbaum"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horrorstil"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Pferd"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Pferdestatue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Reiterstatue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Pferde",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Einzelfahrzeuge in Form von Pferden",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 Fahrgäste pro Pferd"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Heiße-Schokolade-Stand",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Ein Stand, an dem heiße Schokolade verkauft wird"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot-Dog-Stand",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Ein Stand, an dem Hot Dogs verkauft werden"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hotrod-Auto"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hotrod-Auto"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hotrod-Wagen",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Achterbahnzüge, die luftbetrieben gestartet werden. Sie sehen aus wie Hotrod-Wagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Haus"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Schweberäder",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristische fahrradartige Einzelwagen",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 Fahrer pro Wagen"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Schwebewagen",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Magnetschwebe-Technologie für die Illusion futuristischer Schwebewagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Fliegendes Schweberad"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Fliegendes Schweberad"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Geparktes Schweberad"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Geparktes Schweberad"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Schwebebretter",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Die Gäste fahren auf einem futuristischen Schwebebrett und schwingen in den Kurven frei hin und her",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Fliegender Schwebewagen"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Fliegender Schwebewagen"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Geparkter Schwebewagen"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Geparkter Schwebewagen"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Husky-Wagen",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Huskyschlittenförmige Fahrzeuge mit Eigenantrieb",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister-Züge",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Geräumige Züge mit einfachen Beckenhalterungen",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister-Züge (breite Wagen)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Breite Wagen mit einfachen Beckenhalterungen und erhöhten Sitzen, in denen 4 Personen nebeneinander sitzen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hyper-Achterbahnzüge",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Komfortable Züge, die lediglich Beckenhalterungen aufweisen",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Eis"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Eis"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Waffeleis-Stand",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Ein Stand, an dem Waffeleis verkauft wird"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Eiswürfel"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Eisformation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Eisformation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Eispalast"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Eis-Parkeingang"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Eisröhren-Basis"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Eisröhren-Sektion"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Eisröhren-Ventil"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Eisdach"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Eiswand"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Eis-Stil"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Vereiste Fässer"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Vereiste Fässer"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Vereiste Fässer"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Eistee-Stand",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Ein Stand, an dem Eistee verkauft wird"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Iglu"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igludach"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igluwand"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impuls-Züge",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Umgekehrte Achterbahnzüge für die umgekehrte Impuls-Bahn",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Weihrauchzeder"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische Seidenflagge"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische Seidenflagge"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische Seidenflagge"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische Seidenflagge"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische Seidenflagge"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriedach-Eckstück"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriedach-Eckstück"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriedachstück"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriemauer-Eckstück"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriemauer-Eckstück"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriemauer-Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriemauer-Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriemauer-Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriemauer-Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriemauer mit Eingang"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriemauer mit Fenster"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Informationskiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Ein Stand, an dem die Besucher Parkkarten bekommen und Schirme kaufen können"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Eisen"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italienische Zypresse"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italienische Polizeibahn",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Die Fahrgäste fahren paarweise in nachgebauten italienischen Polizeiautos im Kreis",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguarwagen",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Achterbahnwagen, die wie Jaguare aussehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Blühender japanischer Kirschbaum"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanischer Kirschbaum"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanischer Zaun"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanischer Zaun"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanischer Zaun"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanischer Parkeingang"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanische Kiefer"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanisches Dach"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanisches Dach"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanisches Dach"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanische Seidenflagge"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanisches Schneeballgewächs"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzband-Mitglied"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzband-Mitglied"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzband-Mitglied"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzband-Mitglied"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Baby-Fruchtgummi"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Geleebonbon"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Geleebonbon-Wand"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Düsenflugzeug"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Düsenflugzeug"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Düsenflugzeug"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet-Pack-Beschleuniger",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Großer Achterbahnzug in Form eines Jet-Packs für die umgekehrte Freefall-Bahn",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Düsenflugzeug-Wagen",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Achterbahnwagen in der Form von Düsenflugzeugen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jetskis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Einsitzige Jetskis, die die Passagiere selbst steuern können",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 Fahrer pro Fahrzeug"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Kämpfende Ritter",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Pferdeartige Einzelwagen",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 Fahrer pro Wagen"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Springbrunnen"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Springende Schneebälle"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Dschungel"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Dschungelzaun"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Dschungelschild"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Dschungelthema"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Dschungelbaum 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Dschungelbaum 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Dschungelbaum mit Leoparden"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Dschungelbaum mit Lianen"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Dschungeltrommelnstil"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Gerümpel"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic-Schild"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic-Thema"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic-Stil"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Känguru"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killerwal-U-Boote",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Die Passagiere fahren in einem walförmigen U-Boot durch eine Unterwasserstrecke",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 pro Wagen"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koalawagen",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Großer koalaförmiger Wagen für die umgekehrte Freefall-Bahn",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pro Wagen"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kreml - Großer Turm - Basis"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kreml - Großer Turm - Mitte"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kreml - Großer Turm - Spitze"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kreml - Zwiebelkuppel-Bauteil 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kreml - Zwiebelkuppel-Bauteil 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kreml - Zwiebelkuppel-Bauteil 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kreml - Dach-Bauteil 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kreml - Dach-Bauteil 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kreml - Kleiner Turm - Basis"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kreml - Kleiner Turm - Mitte"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kreml - Kleiner Turm - Zwiebelkuppel-Basis"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kreml - Treppen-Wandbauteil 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kreml - Treppen-Wandbauteil 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kreml - Wandbauteil 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kreml - Wandbauteil 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kreml - Wandbauteil 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kreml - Wandbauteil 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kreml - Wandbauteil 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kreml - Wandbauteil 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kreml - Wandbauteil 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kreml - Wandbauteil 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM-getriebene Achterbahnzüge",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Achterbahnzüge, die mit Hilfe von linearen Induktionsmotoren beschleunigt werden",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Marienkäferzüge",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Achterbahnzüge mit kleinen Marienkäferwagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampe"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampe"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampe"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampe"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampe"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Großer abgewinkelter Mammutzaun"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Großer abgewinkelter Mammutzaun"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Großer Ulmenbaum"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Großer Mammutzaun"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Großer Mammutzaun"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Großer Meteoritenkrater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Große Eiche"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Großer Regenwaldbaum"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Großer roter Meteoritenkrater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Großer rauchender Kamin"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Großer Lautsprecher"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Großer Totempfahl"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laserzaun"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laserzaun-Ecke"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Hochgeschossener Freefallwagen",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Der Freefall-Wagen wird mit Druckluft einen hohen Stahlturm hochgeschossen, von wo er dann im freien Fall nach unten saust",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Fahrgäste"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson-Zypresse"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Liegewagen",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Kleine hängende Wagen, in denen sich die Passagiere mit dem Gesicht nach unten in einer liegenden Position befinden und frei hin- und her schwingen",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 Fahrgast pro Wagen"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Liegeachterbahnzüge",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Die Passagiere befinden sich in speziellen Haltevorrichtungen in liegender Position und fahren entweder auf dem Rücken oder dem Bauch",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Limonadenmarktstand",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Ein thematischer Stand, der frische Limonade nach Omas Rezept verkauft"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Limonadenstand",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Ein Stand, an dem erfrischende Limonadengetränke verkauft werden"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Aufzugskabine",
+    "reference-description": "Steel lift cabin",
+    "description": "Stahlaufzugskabine",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Personen"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lilie"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousinenzüge",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Achterbahnwagen im Limousinenstil",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Löwe"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Löwenwagen",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Achterbahnwagen, die wie Löwen aussehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Abfalleimer"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Abfalleimer"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Abfalleimer"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Abfalleimer"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Blockhütte"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Blockhütte"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Holzhüttendach-Bauteil"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Holzhüttendach-Bauteil"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Holzhüttendach-Bauteil"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Holzhütte - Seitenkamin"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Holzhüttenwand-Bauteil"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Baumstammzüge",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Achterbahnzüge mit kleinen baumstammförmigen Wagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Baumstämme"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Baumstämme",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Baumstammförmige Boote, die für die Fahrt in Wasserkanälen ausgelegt sind",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 Fahrgäste pro Boot"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lutscher"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Pyramidenpappel"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping-Achterbahnzüge",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Achterbahnzüge mit Beckenhalterungen, die durch vertikale Schleifen fahren können",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Verlorene Stadt - Säulen-Bauteil"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Verlorene Stadt - Säulen-Bauteil"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Verlorene Stadt - Flachdach-Bauteil"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Verlorene Stadt - Flachdach-Bauteil"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Verlorene Stadt - Flachdach-Bauteil"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Verlorene Stadt - Treppen-Bauteil"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Verlorene Stadt - Treppen-Bauteil"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Verlorene Stadt - Treppen-Bauteil"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Verlorene Stadt - Treppen-Bauteil"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Verlorene Stadt - Treppen-Bauteil"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Verlorene Stadt - Eckbauteil"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Verlorene Stadt - Eckbauteil"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Verlorene Stadt - Eckbauteil"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Verlorene Stadt - Eckbauteil"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Verlorene Stadt - Wand-Bauteil"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Gestrüpp"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxusliner - Bug"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxusliner - Mittelteil"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxusliner - Heck"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Streitkolben",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Die Fahrgäste sitzen auf einem thematisch gestalteten Sessel, der an einem motorbetriebenen Dreharm befestigt ist",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 Fahrgast pro Sessel"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Fliegender Teppich",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Ein großer Wagen im „Fliegender-Teppich-Stil“, der sich zyklisch am Ende von 4 Armen auf und ab bewegt",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 Fahrgäste"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magische Rüstung"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magischer Helm"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magisches Schild"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magisches Schwert"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolie"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharadschapalast - Torbogen 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharadschapalast - Torbogen 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharadschapalast - Kuppel"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharadschapalast-Bauteil"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharadschapalast-Bauteil"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharadschapalast-Bauteil"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharadschapalast - Turmbasis"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharadschapalast - Turmsäule"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharadschapalast - Turmspitze"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharadscha-Dampfzüge",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniaturdampfzüge, bestehend aus je einer Dampflokomotive plus Tender und geschlossenen Holzwaggons",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pro Waggon"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarinentenboote",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Entenförmige Boote, die von den Fahrgästen auf den Vordersitzen mit Pedalen angetrieben werden",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pro Boot"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrovenbaum"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Mantarochenboote",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Achterbahnboote in der Form eines Mantarochens",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pro Boot"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marmordach"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marmordach"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marmordach"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marmordach"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi-Gras-Tänzer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi-Gras-Tänzer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Festzelt"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Mars"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Mars-Gebäude"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Marsobjekt"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Marsobjekt"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Marsobjekt"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Marsobjekt"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Marsobjekt"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Mars-Thema"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Mars-Wand"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Mars-Stil"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Irrgarten",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Der Irrgarten besteht aus 2 Meter hohen Hecken oder Wänden. Die Besucher irren im Labyrinth umher und kommen von dort nur heraus, wenn sie den Ausgang gefunden haben"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Fleischklößchen-Suppenstand",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Ein Stand, an dem Fleischklößchen-Suppe verkauft wird"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Maschinenthema"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Maschinenstil"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Mittelalterthema"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Mittelalterstil"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Versteinerte Menschen"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Versteinerte Menschen"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Versteinerte Menschen"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Versteinerte Menschen"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Karussell",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditionelles Drehkarussell mit geschnitzten Holzpferden",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Maschendrahtzaun"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Maschendrahtzaun"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteoritenkrater-Ecke"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteoritenkrater-Ecke"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Umgedrehte Meteoritenkrater-Ecke"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteoritenkrater-Mauer"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteoritenkrater-Mauer mit Kristallen"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteoritenkrater-Mauer mit Kristallen"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyers blauer Wacholderbaum"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Mikrobus-Fahrt",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Die Fahrer sehen in der Bewegungssimulatorkapsel im Flower-Power-Stil einen Film, während diese von einem hydraulischen Arm bewegt und gedreht wird",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Fahrgäste"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Mikrobus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Minenwagen",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Wagen, die wie alte Minenloren geformt sind",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Minenwagen",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Einzelne Wagen in Form von hölzernen Minenkarren",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Minenlorenzüge",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Holzachterbahnzüge mit gepolsterten Sitzen und Beckenhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Minenhütte"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Minenhütte"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Minenaufzugskabine",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Eine Stahlaufzugskabine, wie man sie üblicherweise im Tagebau verwendet",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Minenschacht"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Bergwerksthema"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Minenzüge",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Achterbahnzüge im Minenzugstil",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 oder 4 Fahrgäste pro Wagen"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Minigolf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Ein leichtes Minigolfspiel",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Minihubschrauber",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Helikopterförmige Wagen, die von den Pedaltritten der Fahrer angetrieben werden",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaurus-Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Pfefferminz"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Moderner Stil"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Chilefichte"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster-Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Angetriebene, gigantische Trucks mit Allradantrieb, die steile Hänge bezwingen können",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 Fahrgäste pro Truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey-Zypresse"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma-Kiefer"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentaldach-Bauteil 3"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumentaldach-Bauteil 1"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentaldach-Bauteil 4"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentaldach-Bauteil 4"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentaldach-Bauteil 4"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentaldach-Bauteil 4"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalwandecken-Bauteil"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalwandecken-Bauteil"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalwandecken-Bauteil"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalwandecken-Bauteil"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentaldach-Bauteil 2"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Mondsaft",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Ein Stand, der die neuesten Softdrinks verkauft"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaischer Fußweg"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Bewegungssimulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Die Passagiere sehen in einer Bewegungssimulationskapsel, die von einem hydraulischen Arm gedreht und herumbewegt wird, einen Film",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Passagiere"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorräder",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Einzelwagen, die wie Motorräder geformt sind",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 Fahrgäste pro Motorrad"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorrad"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorrad"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mauswagen",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Einzelne Wagen in Form von Mäusen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mauswagen",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Einzelne mausförmige Wagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Schlammdach-Bauteil"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Schlammwand-Bauteil"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Mehrdimensionale Achterbahnzüge",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Wagen mit Sitzen, bei denen die Passagiere kopfüber gekippt werden können",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythologischer Eingang"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythologiethema"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indianer"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natürliches Wasser"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautische Dacheckreling"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisches Dach-Bauteil"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisches Dach-Bauteil"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisches Dach-Bauteil"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisches Dach-Bauteil"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisches Dach-Bauteil"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautische Dachreling"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisches Wand-Bauteil"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonschild - Imbiss"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonschild - Imbiss"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonschild - Imbiss"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonschild - Imbiss"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptunfahrt",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Die Fahrgäste fahren zu zweit in Sitzen, die um eine animierte Neptunstatue rotieren",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptuns Stand der Meeresfrüchte",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Ein Stand, der Neptuns salzige Gaumenfreuden verkauft"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Eckenfüllstoff"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New-York-Eingang"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York umgedrehtes Eckstück"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York umgedrehtes Eckstück"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York umgedrehtes Eckstück"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York umgedrehtes Eckstück"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York umgedrehte Dachecke"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Dachstück"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Dachstück"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Dachstück"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Dachstück"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Dachstück"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Mauerstück"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Mauer mit Leitung"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Mauer mit Leitung"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Wäscheleine"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Wäscheleine"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Kein Eingang"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Kein Eingang, keine Plattform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Nordamerika-Parkeingang"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Nordamerika-Thema"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norwegische Fichte"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Eichenfässer",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Eichenfässer, die drehend und platschend durch die Stromschnellen gleiten",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 Fahrgäste pro Boot"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian-Wolkenkratzer Türstück"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian-Wolkenkratzer Dachstück"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian-Wolkenkratzer Flache Schrägenecke"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian-Wolkenkratzer Flache Schrägenecke"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian-Wolkenkratzer Flache Schräge Mauer"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian-Wolkenkratzer Steile Schrägenecke"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian-Wolkenkratzer Steile Schräge Mauer"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian-Wolkenkratzer Steile Schräge Mauer"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian-Wolkenkratzer Steile Schräge Mauer"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian-Wolkenkratzer Mauer"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian-Wolkenkratzer Mauer mit Fenster"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Bürogebäude"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Ölfass"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Ölpumpe"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Alter überwucherter Baum"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Wasser"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgelstil"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Orientstil"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Zierkonstruktion"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Zierkonstruktion"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Zierkonstruktion"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Zierbaum"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Zierbaum"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Zierbaum"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Zierbaum"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Zierbaum"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Verzierte Marmorwand"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Straußenzüge",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Achterbahnzüge, bei der sich die Fahrgäste in einer stehenden Position befinden und die Wagen wie Strauße aussehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Auslegerkanus",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lange Kanus, in denen die Passagiere selbst rudern",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 pro Kanu"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagodenschild"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagodenthema"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagodenturm"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palme"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palme"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palme"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palme"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palme"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda-Abfalleimer"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Pandathema"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Pandazüge",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Achterbahnzüge mit plüschtierartigen Pandawagen",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 Fahrgast pro Wagen"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Parkeingangsgebäude"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Parkeingangstore"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Bauernhütte"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus-Wagen",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Angetriebene Fahrzeuge in Form eines Pegasus, der einen Karren zieht",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Pinguinzüge",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Pinguinförmige Wagen, die aus Zweisitzerwagen bestehen, in denen die Fahrgäste hintereinander sitzen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Antikes Automobil"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Antikes Automobil"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Antikes Café"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Antike Flagge"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Antike Segelyacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Antike Straßenlaternen"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Antiker Karren"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Antiker Karren"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Tankstelle"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup-Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Angetriebene Fahrzeuge in Form von Pickup-Trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 Passagier pro Wagen"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Rosa Wasser"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Rohr"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Rohrabschnitt"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Rohrabschnitt"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Rohrabschnitt"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Piratenflagge"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratenschiff",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Großes schwingendes Piratenschiff",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratenschiff"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Piratenthema"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Piratenstil"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizzastand",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Ein Stand, an dem Pizzaportionen verkauft werden"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Schlicht"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Einfache Marmorwand"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Pflanze"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Pflanze"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Spielkartenwand"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Spielkartenwand"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Sockel"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Pflug"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Eisbärenzüge",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Eisbärenförmige hängende Achterbahnzüge, in denen die Fahrgäste paarweise sitzen und entweder nach vorne oder nach hinten blicken",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Stange"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Stange"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Stangen"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Polizeiautozüge",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Achterbahnzüge mit Beckenhalterungen, die durch Loopings fahren können, mit dem Aussehen von Polizeiautos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Polizeiautos",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Polizeiautos aus den 1960ern fahren über eine Holzstrecke und drehen sich an speziellen Wendeabschnitten",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcornstand",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Ein Stand, an dem riesige Popcorneimer verkauft werden"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Falltür"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Falltür"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Pfosten"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Elektrische Minenzüge",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Achterbahnzüge im Minenzugstil, mit Eigenantrieb",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 bzw. 4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prähistorischer Eingang"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Vorgeschichte-Thema"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Brezelstand",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Ein Stand, an dem knusprige Brezeln verkauft werden"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Ursuppe"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Gefängnistür"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Gefängniszaun"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Umgedrehtes Gefängnisstück"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Gefängnismauerecke"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Gefängnismauerecke"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Gefängnismauerstück"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Gefängnismauerdach"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Gefängniswachturm"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Gefängniswachturm-Treppen"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Gefängniswachturm-Treppen"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Gefängniswasserturm"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodaktylus-Züge",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Die Fahrer sitzen in bequemen Sitzen unterhalb der Strecke, um ihnen die ultimative prähistorische Flugerfahrung zu geben",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Kürbis"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Kürbishaus"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Warteschlangen-TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Rennwagen",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Angetriebene Fahrzeuge in Form von Rennwagen",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 Passagier pro Wagen"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Rasende Raptoren",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Raptorförmige Einzelwagen",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 Fahrer pro Wagen"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Rennlautsprecher"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radarschüssel"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Floße",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Floßförmige Boote, die für flache Flussstrecken ausgelegt sind",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 Fahrgäste pro Floß"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime-Stil"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Geländer"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Fußweg mit Regenbogen"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Backstein-Eckdachbauteil"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Backstein-Flachdachecke"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Backstein-Flachdach-Kantenbauteil"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Backsteindach-Bauteil, umgedreht"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Backsteindach-Bauteil 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Backsteindach-Bauteil 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Backsteindach-Bauteil 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Backsteinmauer-Bauteil 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Backsteinmauer-Bauteil 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Backsteinmauer-Bauteil 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Backsteinmauer-Bauteil 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Backsteinmauer-Bauteil 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Backsteinmauer-Bauteil 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Backsteinmauer-Bauteil 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Backsteinmauer-Bauteil 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Backsteinmauer-Bauteil 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Rotkiefer"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Rotkiefer"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Roter Meteoritenkrater - Ecke"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Roter Meteoritenkrater - Ecke"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Umgedrehte roter Meteoritenkrater-Ecke"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Roter Meteoritenkrater-Mauer"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Roter und brauner Mosaikfußweg"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Mammutbaum"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Einschienenzüge im Retro-Stil",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Einschienenzüge mit offenen Kabinen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Umgekehrter Freefall-Wagen",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Großer Wagen für die umgekehrte Freefall-Bahn",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Fahrgäste"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Umkehrwagen",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Wagen mit Drehgestell fahren auf einer Holzstrecke und rotieren dabei auf speziellen Umkehrabschnitten",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Nashorn"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Nashornzüge",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Kompakte Achterbahnzüge mit Wagen mit Sitzen in einer Reihe, mit dem Aussehen von Nashörnern",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pro Wagen"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Gut"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Stromschnellen-Boote",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Runde Boote, die drehend und platschend durch die Stromschnellen gleiten",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 Fahrgäste pro Boot"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Styx-Flussboote",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boote im Unterweltstil, die für flache Flussstrecken ausgelegt sind",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 Fahrgäste pro Boot"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Straße"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Wilde-Zwanziger-Parkeingang"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Wilde-Zwanziger-Thema"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Mauersätze Die wilden Zwanziger"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Bratwurststand",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Ein Stand, an dem Bratwürste verkauft werden"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hoods Lager"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods Hütte"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods Hütte"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Roboter"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Roboter"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Gestein"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Gestein"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock-'n'-Roll-Parkeingang"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock-'n'-Roll-Thema"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rockband-Tourbus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Felswand"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock-Stil"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock-Stil 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock-Stil 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Raketenwagen",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Achterbahnwagen, die wie Raketen aussehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Steiniger Fußweg"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Achterbahnpreis-Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollschuhfahrende Bedienung"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Römisches Kolosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Römische Säule"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Römische Säulenmauer"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Eckstück des Römischen Palastes"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Eckstück des Römischen Palastes"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Eckstück des Römischen Palastes"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Eckstück des Römischen Palastes"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kreuzung im Römischen Palast"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kreuzung im Römischen Palast"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kreuzung im Römischen Palast"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kreuzung im Römischen Palast"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Endstück des Römischen Palastes"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Endstück des Römischen Palastes"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Gerades Stück des Römischen Palastes"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Gerades Stück des Römischen Palastes"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Gerades Stück des Römischen Palastes"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Gerades Stück des Römischen Palastes"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Römische Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Römische Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Römischer Tempel"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Römische Wand"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Römische Wand"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Römischer Fanfarenstil"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Dach (grau)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Dach (rot)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Ein Ring mit Sitzen, der zur Spitze eines hohen Turms gezogen wird, während er sich leicht dreht, und dann im freien Fall heruntersaust, wobei er unten sanft von Magnetbremsen angehalten wird",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "„Route 66“-Schild"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Londoner Busse",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Nachbauten des berühmten Londoner Routemaster-Busses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pro Waggon"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Ruderboote",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Ruderboote, die von den Fahrgästen selbst gerudert werden",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 Fahrgäste pro Boot"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Zerstörte Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Landebahn-Eckstück"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Landebahn-Kantenstück"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Umgedrehtes Landebahn-Eckstück"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Landebahnstück"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Landebahnstück"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Landebahnstück"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rost"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San-Francisco-Straßenbahnen",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Nachgebaute Straßenbahnen",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pro Waggon"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (braun)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (rot)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstein (braun)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstein (grau)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Ecke"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Ecke"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstein-Wolkenkratzer Untere Gewundene Schräge"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstein-Wolkenkratzer Untere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstein-Wolkenkratzer Untere Schrägenbasis"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstein-Wolkenkratzer Obere Ecke"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstein-Wolkenkratzer Obere Gewundene Schräge"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstein-Wolkenkratzer Obere Gewundene Schräge"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstein-Wolkenkratzer Anlegebucht"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstein-Wolkenkratzer-Eingang"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstein-Wolkenkratzer Füllstoff"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstein-Wolkenkratzer Füllstoff"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstein-Wolkenkratzer Obere Umgedrehte Ecke"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Ecke"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Ecke"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Gewundene Schräge"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Gewundene Schräge"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Schrägenecke"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Mauer"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Mauer"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Mauer"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Mauer"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstein-Wolkenkratzer Mittelstück Mauer"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstein-Wolkenkratzer Dach"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstein-Wolkenkratzer Dachturm"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstein-Wolkenkratzer Dachturm"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstein-Wolkenkratzer Spazierweg"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstein-Wolkenkratzer Spazierweg"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstein-Spazierweg-Ecke"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstein-Spazierweg-Kreuzung"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstein-Spazierweg-Endabschnitt"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstein-Spazierweg-Gabelung"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellit"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellitenschüssel"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Schulbus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Schulbusstraßenbahnen",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniaturstraßenbahnen, die Schulbussen nachempfunden sind",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 Fahrgäste pro Wagen"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Föhre"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Laufschrift-Tafel"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Laufschrift-Tafel"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Skulptur"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Skulptur"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Meeresfrüchtestand",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Ein Stand, an dem Meeresfrüchte verkauft werden"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Wasserflugzeug"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Robbenzüge",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Achterbahnzüge mit Schulterhalterungen, in der Form von Robben",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Wasserflugzeug-Box"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Wasserflugzeug-Box"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Suchscheinwerfer"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Sitze"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Strauch"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Strauch"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Sträucher und Verzierungen"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Federball"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Federball"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-Wand"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Bürgersteig"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Schild"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Schilder und Objekte für Fußwege"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Weißbirke"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Sänger mit Tolle"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Einzeldeckkabine",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Rotierende einstöckige Aussichtskabine",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 Fahrgäste"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six-Flags-Thema"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "6-Sitzer-Twister-Züge",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Achterbahnzüge mit besonders breiten Wagen, für vertikale Gefälle ausgelegt",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skelett"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Skilift-Stühle",
+    "reference-description": "Open cars for chairlift",
+    "description": "Offene Wagen für Sessellift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Schlitterscooter",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Die Fahrgäste schlittern in selbstgesteuerten schlittenförmigen Fahrzeugen umher",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Fahrgast pro Wagen"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Schädel"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Schädel"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Wolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Wolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Wolkenkratzerwand-Bauteil"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Himmelsweg"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Wolkenkratzer (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Wolkenkratzer (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Wolkenkratzer - Konkaves Bauteil"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Wolkenkratzer - Konkaves Dach"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Wolkenkratzer - Konvexes Bauteil"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Wolkenkratzer - Konvexes Dach"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Wolkenkratzeraufzug-Bauteil"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Wolkenkratzeraufzug-Bauteil"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Wolkenkratzer-Aufzugssektions-Bauteil"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Wolkenkratzer-Aufzugssektions-Bauteil"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Wolkenkratzer-Aufzugssektions-Bauteil"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Metallwolkenkratzer Set 1 - Konkaves Bauteil"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Metallwolkenkratzer Set 1 - Konvexes Bauteil"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Metallwolkenkratzer Set 1 - Wand-Bauteil"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Metallwolkenkratzer Set 2 - Konkaves Bauteil"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Metallwolkenkratzer Set 2 - Konkaves Bauteil"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Metallwolkenkratzer Set 2 - Konvexes Bauteil"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Metallwolkenkratzer Set 2 - Wand-Bauteil"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Metallwolkenkratzer Set 2 - Wand-Bauteil"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Wolkenkratzerdach-Bauteil"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Wolkenkratzerspitze"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Faultierzüge",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Hängende Achterbahnzüge mit Wagen, die Faultieren nachempfunden sind und in Kurven frei schwingen können",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Kleiner abgewinkelter Mammutzaun"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Kleiner abgewinkelter Mammutzaun"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kleines Zahnrad"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kleines Zahnrad"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kleines Zahnrad"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kleines Zahnrad"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Kleine Geosphäre"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Kleiner Meteoritenkrater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Kleine Einschienenwagen",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Kleine Einschienenwagen mit offenen Seiten",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Regenwaldbaum 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Regenwaldbaum 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Kleiner roter Meteoritenkrater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Kleiner Lautsprecher"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Schornstein-Basis"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Schornstein-Mittelstück"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Schnecke"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Schnee / Eis"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Schneebedecktes Schild"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Schneeschalen",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Die Passagiere befinden sich in Sitzpaaren, die sich um einen Schneemann in der Mitte drehen",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Schnee- und Eisthema"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Schnee-Stil"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Schneebedeckte kaukasische Tanne"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Schneebedeckte norwegische Fichte"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Schneebedeckte Rotkiefer"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Schneebedeckte Rotkiefer"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Schneeball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Schneemann"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Seifenkisten",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Einzelwagen, die wie Seifenkisten geformt sind",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Stofftier-Stand",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Ein Stand, der süße Stoffdinosaurier verkauft"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Südamerika-Thema"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Südamerikanischer Parkeingang"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenirstand",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Ein Stand, an dem Souvenirplüschtiere und -regenschirme verkauft werden"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Sojamilch-Stand",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Ein Stand, an dem Sojamilch-Kartons verkauft werden"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Weltraum"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Weltraumkapsel"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Weltraumkapsel"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Weltraumkugeln"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Weltraumringe",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Konzentrische, rotierende Ringe ermöglichen den Passagieren, sich in alle Richtungen frei zu drehen",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "Jeweils 1 Fahrgast"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Weltraumrakete"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Raumschiff Ladetrakt"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Raumschiff Kommunikationstrakt"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Raumschiff Kontrolldeck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Raumschiff Kreuzung"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Raumschiff Anlegetrakt"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Raumschiff Motortrakt"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Raumschiff Treibstofftrakt"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Raumschiff Schwerkrafttrakt"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Raumschiff Wohntrakt"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Raumschiff Wissenschaftstrakt"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Raumschiff Sonnenkollektor"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Raumschiff Solartrakt"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Weltraumstil-Fußweg"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Weltraumschild"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Weltraumthema"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Weltraumstil"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Pikförmiger Baum"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spinne"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Stacheldrahtzaun"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Rotierende Mauswagen",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mausförmige Wagen rasen um enge Kurven und kurze Gefälle herunter, wobei sie sich sanft drehen, um die Fahrgäste zu desorientieren",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral-Achterbahn-Züge",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Kompakte Achterbahnzüge mit Wagen mit Sitzen in einer Reihe",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiralgleitbahn",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Holzgebäude mit einem inneren Treppenhaus und einer äußeren Spiralgleitbahn für Gleitmatten"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash-Boote",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Boote mit hoher Kapazität, gebaut für Wasserstrecken mit sehr steilen Gefällen",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 Fahrgäste pro Boot"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spukthema"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sportwagen",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Angetriebene Fahrzeuge in Form von Sportwagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sport-Thema"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik-Wagen",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russische satellitenförmige Wagen, die von der Schiene oberhalb schwingen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Eichhörnchenförmiger Baum"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Postkutschen",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Einzelne Achterbahnwagen in der Form einer Postkutsche, mit gepolsterten Sitzen und Beckenhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampedenherden-Züge",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Achterbahnzüge, in denen die Fahrgäste eine stehende Position einnehmen, mit dem Aussehen einer rasenden Dinosaurierherde",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stehachterbahnzüge",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Achterbahnzüge, bei der sich die Fahrgäste in einer stehenden Position befinden",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Steh-Twister-Züge",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Ein Zug mit Schulterhalterungen; die Fahrgäste stehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Fruchtsaft-Stand",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Ein Stand, an dem Fruchtsaftgetränke verkauft werden"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Freiheitsstatue"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Dampfzüge",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Mini-Dampfzüge bestehend aus nachgemachter Dampflok und Tender mit offenen Holzwagons",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 Fahrgäste pro Wagon"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Dampfzüge mit überdacht. Wagons",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Mini-Dampfzüge bestehend aus nachgemachter Dampflok und Tender mit Holzwagons mit Stoffdächern",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 Fahrgäste pro Wagon"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Dampfende Kanalisation"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Stahlblock"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Stahlblock"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Stahlzaun"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Stahlgitterwerk"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlmauer"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlmauer"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlwand"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlwand"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlwand"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Stahlwand"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Steinzeit-Tempel"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Steinbank"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Steinblock"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Steinwolkenkratzer-Treppenbasis"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Steinwolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Steinwolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Steinwolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Steinwolkenkratzerwand-Bauteil"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Steinwolkenkratzerwand-Bauteil"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Steinmauer"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Steinmauer"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Steinmauer"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Steinmauer"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Hocker"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Hocker"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Stromlinienf. Einschienenzüge",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Große Einschienenzüge mit stromlinienförmigen Wagen vorne und hinten",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 oder 10 Fahrgäste pro Wagen"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Gipsputz (grün)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Gipsputz (grau)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Gipsputz (lila)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Gipsputz (rot)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sandwich-Stand",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Ein Stand, an dem frische Sandwiches verkauft werden"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "U-Boote",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Die Passagiere fahren in einem U-Boot durch eine Unterwasserstrecke",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 Passagiere pro U-Boot"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa-Stand",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Ein Stand, an dem koreanische Sujeonggwa-Getränke verkauft werden"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Sommerstil"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sonnenbrillenstand",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Ein Stand, an dem alle Arten von Sonnenbrillen verkauft werden"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Versunkenes Schiff"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Supercomputer - Große Zentraleinheit"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Supercomputer-Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Supercomputer - Kleine Zentraleinheit"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Stützkonstruktion"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Stützkonstruktion"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Stützkonstruktion"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfzüge",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Breite Achterbahnzüge, in denen die Fahrgäste auf einem Surfbrett mit besonderen Haltevorrichtungen stehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Hängende Einschienenzüge",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Einschienenzug-Wagen mit großem Fassungsvermögen",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Hängende Wasserflugzeugwagen",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Aufgehängte Achterbahnzüge mit wasserflugzeugförmigen Wagen, die frei schwingen, wenn der Zug durch die Kurven fährt",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Flugzeug-Hängewagen",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Ein hängender Achterbahnzug, der aus flugzeugförmigen Wagen besteht, die in Kurven frei schwingen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Hängebahnwagen",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Hängende Achterbahnzüge, die aus Wagen bestehen, die frei schwingen können, wenn der Zug um die Kurven fährt",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Hängebrücke - Basisbauteil"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Hängebrücke - Basisdistanzstück"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Hängebrücke - Kabelsektion"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Hängebrücke - Mittelsektions-Bauteil"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Hängebrücke - Anfangsstück, Seite 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Hängebrücke - Anfangsstück, Seite 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Hängebrücke - Turm, Seite 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Hängebrücke - Turm, Seite 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Sumpffarn"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Sumpfschleim"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Sumpfpflanze"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Sumpfpflanze"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Sumpfpflanze"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Schwäne",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Schwanförmige Boote mit Pedalantrieb, die von den vorderen Passagieren getreten werden",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 Fahrgäste pro Boot"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Schwingwagen",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Kleine Wagen, die von der darüberliegenden Schiene schwingen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Bodenlose Wagen",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Hängende Achterbahnzüge mit sesselliftartigen Sitzen, die in Kurven frei schwingen können",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Schwingendes Überkopfschiff",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Das Schiff ist an einem Arm angebracht, an dessen gegenüberliegenden Ende ein Gegengewicht ist. Es schwingt komplett um 360 Grad",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 Fahrgäste"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Schwert im Stein"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt-Stand",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Ein Stand, an dem Souvenir-T-Shirts verkauft werden"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV-Züge",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Achterbahnzüge im Stil französischer Schnellzüge (TGV), die mithilfe von Linearmotoren beschleunigt werden",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT-Fässer"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT-Kisten"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT-Zünder"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT-Stapel"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Große Laterne"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Große Laterne"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Hoher Holzzaun"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Zielscheibe"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Makadam-Fußweg"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Schenke"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno-Stil"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Indianerzelt"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporterkabine",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristische Aufzugskabine, welche den Gästen die Illusion einer Teleportation gibt",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 Fahrgäste"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Beschädigtes Tempelwand-Bauteil mit Kopf"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeldach-Bauteil"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Tempeltreppen-Bauteil"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Tempeltreppen-Bauteil"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Tempelwandecken-Bauteil"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Tempelwandecken-Bauteil"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Tempelwandecken-Bauteil"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Tempelwandecken-Bauteil"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelwand-Bauteil"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Tempelwand-Bauteil mit Kopf"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Mietshaus"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennisball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnetzwand"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnetzwand"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Zelt"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tipi"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termitenhügel"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Reihenhaus"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terrakotta-Armee"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Zeitmaschine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Die Gäste sitzen in einer speziell dafür gebauten Kugel und erfahren die Illusion einer Zeitreise",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 pro Gast"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Giftpilz"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Schlittenwagen",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Schlittenförmige Achterbahnwagen mit hintereinander liegenden Sitzen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Karamellapfelmarktstand",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Ein thematischer Stand, der Karamelläpfel verkauft"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Karamellapfelstand",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Ein apfelförmiger Stand, an dem Karamelläpfel am Stiel verkauft werden"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Herkömmliche Toiletten in einem vorgefertigen Betongebäude"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toiletten in einer Art Blockhütte"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Herkömmliche Toiletten in einem vorgefertigen Betongebäude"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Maschinenpistolen-Fahrt",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Die Fahrer sitzen zu zweit in Sitzen, die sich um die Nachbildung einer großen Maschinenpistole drehen",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Die Passagiere sitzen in einer Gondel, die an großen sich drehenden Armen hängt und sich vorwärts und rückwärts überkopf dreht",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Fahrgäste"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totempfahl"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Rathaus"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Spielzeuglandstil"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant-Wagen",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Achterbahnwagen mit dem Aussehen von Trabantautos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Streckenkrümmung"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Beschädigte Strecke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Streckenende"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Streckenverzweigung"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Gerade Strecke"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Traktor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditioneller Parkeingang"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Straßenbahnen",
+    "reference-description": "Old-timer replica trams",
+    "description": "Nachgebaute Oldtimer-Straßenbahnen",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Reisevan"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatztruhe"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatztruhe"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatztruhe"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Tribock",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Die Fahrgäste fahren in einem Waggon, der von zwei langen Armen gehalten wird, basierend auf einer Belagerungswaffe aus dem finsteren Mittelalter",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 Fahrgäste"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Baum"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Bäume"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops-Autoscooter",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Die Fahrer liefern sich beim Autoscooter harte Gefechte in Triceratops-Wagen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 Person pro Wagen"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobitenboote",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Achterbahnwagen in der Form von Trilobiten",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 Fahrgäste pro Boot"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor-Erdgeschoss-Erkerwandbauteil"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor-Erdgeschoss-Wandbauteil 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor-Dach-Bauteil 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor-Dach-Bauteil 1 - Ausbauteil"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor-Dach-Bauteil 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor-Dach-Bauteil 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor-Dach-Bauteil 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor-Wand-Bauteil 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor-Wand-Bauteil 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor-Wand-Bauteil 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor-Wand-Bauteil 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Schildkrötenboote",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Kleine, runde Schlauchboote, die von einem zentralen Motor angetrieben werden, der von den Fahrgästen gesteuert wird",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pro Boot"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Die Fahrgäste befinden sich in Sitzpaaren am Ende von drei langen, rotierenden Armen",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 Fahrgäste"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister-Wagen",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Achterbahnwagen, mit denen Heartline-Twists möglich sind",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister-Wagen (m. umgek. Start)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Achterbahnwagen, mit denen Heartline-Twists möglich sind, mit umgekehrtem Start",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister-Züge",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Breite Achterbahnzüge mit Schulterhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Ufo-Unfall-Gelände"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Einhornstatue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Stadtthema"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Stadtstil"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Walküre"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Walküre"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Walküren-Züge",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Walkürenartige Achterbahnzüge mit besonders breiten Wagen, für vertikale Gefälle ausgelegt",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertikales 3D-Schild"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Umgekehrte vertikale Shuttlewagen",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Große Achterbahnwagen, in denen die Fahrgäste in unterhalb der Strecke aufgehängten Sitzen sitzen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Lianenbaum"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Oldie-Wagen",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Angetriebene Fahrzeuge in Form von Oldie-Wagen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 Fahrgäste pro Wagen"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia-Reel-Wagen",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Runde Wagen, die sich bei der Fahrt drehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Leere"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Vulkan"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Vulkan mit kleinen Bäumen"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss' Goldregenbaum"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagen"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagen"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Waggonrad"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wand"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wandbogen"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Mauer mit Durchgang"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Wände und Dächer"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnussbaum"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington-Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wespe"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Wasserthema"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Wasserstrahl"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Wasserspritzdüse"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Wasserdreiräder",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedaldreiräder mit großen Schwimmrädern",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 Fahrgäste pro Dreirad"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Wasserstil"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Wasserfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Lehmflechtwerk-Dach"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Lehmflechtwerk-Dach"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Lehmflechtwerk-Dach"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Lehmflechtwerk-Wand"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Waffensatz"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Trauerweide"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Räder"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whiskyfass"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whiskyfässer"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Weißer Läufer"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Weißer König"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Weißer Springer"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Weißer Bauer"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Weiße Pappel"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Weiße Königin"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Weißer Turm"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wildwest-Thema"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wildwest-Stil"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Erosionsfelsendach - Konkave Ecke"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Erosionsfelsenwand - Konkave Ecke"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Erosionsfelsenwand - Konkave Ecke"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Erosionsfelsendach - Konvexe Ecke"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Erosionsfelsenwand - Konvexe Ecke"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Erosionsfelsenwand - Konvexe Ecke"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Erosionsfelsen - Boden-Bauteil"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Erosionsfelsen - Boden-Bauteil"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Erosionsfelsen - Basis"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Erosionsfelsen - Basis"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Erosionsfelsen - Mitte"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Erosionsfelsen - Mitte"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Erosionsfelsen - Mitte"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Erosionsfelsen - Mitte"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Erosionsfelsen - Spitze"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Erosionsfelsen - Spitze"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Erosionsfelsendach - Flaches Bauteil"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Erosionsfelsendach - Flaches Bauteil"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Erosionsfelsendach - Flaches Bauteil"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Erosionsfelsen - Wandbasis"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Erosionsfelsen - Wandbasis"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Erosionsfelsenwand-Bauteil"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Erosionsfelsenwand-Bauteil"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Erosionsfelsenwand-Bauteil"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Erosionsfelsenwand-Bauteil"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmühle"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Fenster"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Fenster"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Fenster"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Hexensuppe",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Ein Stand, der eine dickflüssige Fleischbrühe verkauft"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Hexen um Kessel"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty-Maden-Züge",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Achterbahnwagen mit dem Aussehen von Maden",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pro Wagen"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wunderland-Thema"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton-Suppenstand",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Ein Stand, an dem Wonton-Suppe verkauft wird"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Holz"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Holz (schwarz)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Holz (rot)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Holzzaun mit Kletterranken"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Holzzaun mit Kletterranken"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Holzzaun mit toten Ranken"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Holzzaun mit toten Ranken"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Holzzaun mit toten Ranken"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Holzzaun mit menschenfressender Pflanze"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Holz"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Holzblock"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Holzwagen"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzzaun"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzzaun"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzwand"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzzaun"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzzaun"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Holzzaun"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Holzzaunwand"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Hölzerner Fußweg"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Holzpfostenzaun"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Holzpfahlwand"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Holzpfahlwand"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Holzpfahlwand"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Holzachterbahnzüge",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Holzachterbahnzüge mit gepolsterten Sitzen und Beckenhalterungen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Holzachterbahnzüge (6-Sitzer)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Holzachterbahnzüge mit gepolsterten Sitzen und Beckenhalterungen",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Holzachterbahnzüge (6-Sitzer, rückwärts)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Holzachterbahnzüge mit gepolsterten Sitzen und Beckenhalterungen, wobei die Sitze rückwärts sind",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 Fahrgäste pro Wagen"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Seitlich geführte Holzwagen",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basiswagen für die Achterbahn mit seitlicher Führung",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 Fahrgäste pro Wagen"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Holzschild"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Holzwand"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Holzwand"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Holzwand"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Holzwand"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wasserflugzeugwrack"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Gelbe Taxi-Züge",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Achterbahnzüge für die Giga-Bahn, die wie lange gelbe Taxis aussehen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pro Wagen"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Eibenbaum"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus-Statue"
+  }
+}

--- a/objects/en-GB.json
+++ b/objects/en-GB.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candy style"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptian style"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy style"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gentle style"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horror style"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ice style"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle drums style"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Martian style"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanical style"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medieval style"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern style"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "No entrance"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental style"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates style"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock style"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock style 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock style 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snow style"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Space style"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Summer style"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno style"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Toyland style"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban style"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Water style"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wild west style"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/en-US.json
+++ b/objects/en-US.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker airplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedaling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-movie",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Cattails"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candy style"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Cotton Candy Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A cotton candy shaped building selling pink cotton candy"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Gray)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-driven go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Checkerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped bumper cars",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Fries Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling fries"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Fries Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling fries"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster train with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Bumper Cars",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-driven electric bumper cars",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Donut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped donuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptian style"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy style"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Bumper Cars",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed bumper cars",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Soccer Ball"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of soccer ball-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gentle style"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-driven gas-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, traveling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horror style"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ice style"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle drums style"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, traveling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of traveling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a Manta Ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Martian style"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanical style"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medieval style"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedaling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern style"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Indivual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "No entrance"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental style"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Gas station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates style"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock style"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock style 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock style 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Gray)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Bumper Cars",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snow style"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Space style"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Summer style"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Airplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of airplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedaling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno style"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Candy Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky candy apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Candy Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling candy apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Restroom",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic restroom facilities housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Restroom",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Restroom facilities housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Restroom",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic restroom facilities housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Toyland style"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Bumper Cars",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops bumper cars",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "A spacious train with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban style"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Water style"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wild west style"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/eo-OO.json
+++ b/objects/eo-OO.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candy style"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptian style"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy style"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gentle style"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horror style"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ice style"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle drums style"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Martian style"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanical style"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medieval style"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern style"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "No entrance"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental style"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates style"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock style"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock style 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock style 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snow style"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Space style"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Summer style"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno style"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Toyland style"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban style"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Water style"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wild west style"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/es-ES.json
+++ b/objects/es-ES.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "Señal de Goliath"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Señal de medusa"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Señal de nitro"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Señal de Texas Giant"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Coches de carreras de los años 20",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Los usuarios compiten en karts con forma de coches de carreras de los años 20.",
+    "reference-capacity": "Single-seater",
+    "capacity": "Monoplaza"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Coche de los cincuenta"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Coche de los cincuenta"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Cohete de 1950"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Atracción Cohete de 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Trenes invertidos que aceleran al salir de la estación para subir por un tramo vertical de la vía, luego retroceden de vuelta a través de la estación para viajar hacia atrás y subir por otra vía vertical",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "Cine 3D",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cine que proyecta películas en 3D en una esfera geodésica",
+    "reference-capacity": "20 guests",
+    "capacity": "20 visitantes"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "Señal 3D"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "Señal 3D"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Montaña Rusa Invertida",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Los pasajeros se sientan en asientos suspendidos bajo la vía y corren por rizos gigantes, giros y grandes caídas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Curvas Locas",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Los pasajeros están sentados en vagones estilo bobsleigh guiados únicamente por la curvatura y los peraltes de la vía semicircular",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Pieza de conjunto de arte aborigen"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Baldosa sencilla aborigen"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Arte serpiente aborigen"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Arte espíritu aborigen"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstracto"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Temática abstracta"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Agua ácido verde"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Chimenea de volcán activo"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Elefante Indio adulto"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Panda adulto"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Entrada al parque África"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Temática africana"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Montaña Rusa Vertical de Aire",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Tras un excitante lanzamiento el vagón corre por una vía vertical hasta el tope y baja vertical por el otro lado",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Trenes monorraíl ambientados como naves aéreas",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Trenes monorraíl de gran capacidad con locomotora y vagón de cola aerodinámicos.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasajeros por coche"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Pino de Aleppo"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Estructuras históricas alienígenas"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Estructuras históricas alienígenas"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Planta alienígena"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Planta alienígena"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Claraboya alienígena grande"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Claraboya alienígena pequeña"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estructura alienígena grande"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estructura alienígena grande"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estructura alienígena grande"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estructura alienígena pequeña"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estructura alienígena pequeña"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estructura alienígena pequeña"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Fondo de torre alienígena"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Medio de torre alienígena"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Parte superior de torre alienígena"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Árbol alienígena"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Árbol alienígena"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Árbol con forma de caimán"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Fútbol americano"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Fútbol americano"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Casco de fútbol americano"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Trenes vapor estilo americano",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trenes de vapor en miniatura compuestos por una locomotora a réplica y vagones de madera con techos de tela",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Atracción de la Anaconda",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Espaciosos trenes con sencillas barras de sujeción",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cocinándose en espetón"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Globos"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Fogata de campamento animada"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatrónica Ojo que todo lo ve"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrónica Argonauta"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrónica Argonauta"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrónica Argonauta"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatrónica astronauta"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatrónica cavernícola haciendo fuego"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatrónica Doncella encadenada"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatrónica hombre del clan"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatrónica Caballero negro"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatrónica Caballero negro"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatrónica Libélulas"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatrónica Águila enjaulada"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrónica alienígena malvado"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrónica alienígena malvado"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrónica alienígena malvado"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatrónica bombero"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatrónica cañón disparando"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatrónico de gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrónica alienígena bueno"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrónica alienígena bueno"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrónica alienígena bueno"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatrónica caballero"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatrónica caballero"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatrónica Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatrónica oficial de policía"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatrónica Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrónica Ejército de esqueletos"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrónica Ejército de esqueletos"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrónica Ejército de esqueletos"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatrónica explorador espacial"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatrónica Estegosaurio"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatrónica T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatrónica Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatrónica rey gesticulante"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatrónica Escorpión al ataque"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatrónica Escorpión al ataque"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatrónica Pterodáctilo volador"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Temática antártica"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antílope hembra"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antílope macho"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Pareja de antílopes"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Cartelera LCD con sistema de anulación de gravedad"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Cartelera LCD con sistema de anulación de gravedad"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Campo de tira"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Ciprés de Arizona"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Sección de esquina Art Decó"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Esquina Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Esquina Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Esquina Art Decó con ventanas"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Esquina Art Decó con ventanas"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Esquina Art Decó con ventanas"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Puesto de comida de prisión",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Un puesto en el que se venden tallarines y limonada fresca"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Sección de esquina inversa Art Decó"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Sección de esquina inversa Art Decó"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Sección de tejado Art Decó"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sección superior de esquina Art Decó"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sección superior de esquina Art Decó"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sección superior de esquina Art Decó"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Sección superior Art Decó"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Sección superior Art Decó"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sección de muro Art Decó"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Muro Art Decó con puerta"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro Art Decó con balaustrada"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muro Art Decó con ventanas"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muro Art Decó con ventanas"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Tren Montaña Rusa Articulado",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Montaña rusa con pequeños vagones en una única fila",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Sendero de ceniza"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Fresno con ninfas"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Temática asiática"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gong asiático"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Árbol de Aspen"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Estatua de Atlas"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Entrada al parque Austral"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Temática australiana"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Conjunto fuente australiana 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Conjunto fuente australiana 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automóviles",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Montaña rusa con forma de coche",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Pulpo gigante de película de serie B"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Araña gigante de película de serie B"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Viaje en araña gigante de película de serie B",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Los usuarios van en parejas, en asientos decorados que giran en torno a una gran araña de películas de serie B.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 usuarios"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Cría de elefante indio"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Cría de panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Raqueta de badminton"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Raqueta de badminton"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Linterna Bola"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Linterna Bola"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Puesto de globos",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Un puesto que vende globos llenos de helio"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Arbusto de bambú"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Peana de bambú"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Tejado de bambú"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Tejado de bambú"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Tejado de bambú"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Brote de bambú"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Pared de bambú"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Miembro de banda"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Miembro de banda"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Miembro de banda"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Miembro de banda"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Banco"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Montaña rusa Políticos",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Los usuarios se sientan suspendidos debajo de la estructura, pasando a toda velocidad por bucles gigantes, giros y grandes caídas en picado.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Tonel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Tonel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Tonel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Tonel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Bloque de base"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Bloque de base"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Bloque de base"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Bloque de base"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Montaña rusa Ariete",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Una montaña rusa compacta, de metal, con una subida en espiral y coches con asientos en línea.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por coche"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Puesto de tallarines",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Puesto que vende pasta rellena de ternera"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Bancos"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Montaña Rusa Tigre de Bengala",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Vagones capaces de dar giros a media altura",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicis Monorrail",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Bicicletas especiales que recorren sobre un monorraíl, impulsadas por pedaleo",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 ciclista por bicicleta"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "El Big Ben y las Casas Parlamentarias"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Geosfera grande"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motero"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Obispo negro"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Atracción de taxi londinense negro",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Vehículos eléctricos con la forma de taxis londinenses",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "El viaje de la peste negra",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Los usuarios recorren, en coches en forma de rata, una ruta guiada únicamente por la curvatura y el desnivel del recorrido semicircular.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Rey negro"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Caballero negro"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Peón negro"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Álamo negro"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Reina negra"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Torre negra"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Viaje del engendro del espacio exterior",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Cabina de observación rotatoria decorada",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 pasajeros"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Bloque"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Bloque"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Montaña Rusa Bobsleigh",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Los pasajeros viajan por unas vías retorcidas en vagones tipo bobsleigh guiados únicamente por la curvatura y los peraltes de la vía semicircular",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Olla hirviente"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Hueso"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Valla de huesos"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Huesos"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Montaña Bumerang",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Después de un emocionante lanzamiento propulsado por aire, el tren acelera por una vía vertical, pasa sobre la cima, y luego desciende verticalmente por el otro lado para volver a la estación",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Pared de ladrillo"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Pared de ladrillo"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Pared de ladrillo"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Cabina postal británica"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Cabina telefónica británica"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Estatua rota"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Rueda rota"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Sendero asfaltado marrón"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Pozo de brea burbujeante"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Cubo"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Edificio"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Edificio"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Montaña Bala",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Montaña rusa con vagones inspirados en el tren bala japonés",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Gladiolos"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Botes de choque",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Botes pequeños,inflables y redondos propulsados por un motor central controlado por los pasajeros",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasajeros por bote"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boya"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boya"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Hamburguesería",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Edificio con forma de hamburguesa que vende hamburguesas"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Matorral"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Mariposa"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Porche de cabaña"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Porche de cabaña"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pieza de tejado de cabaña"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pieza de tejado de cabaña"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pieza de tejado de cabaña"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cima de cabaña"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pieza de pared de cabaña"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Árbol repollo"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Olmo de Camperdown"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Palmera canaria"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Caramelo"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Caramelo"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Caramelo"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Caramelo de palo"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Árbol de caramelo"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Árbol de caramelo"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Árbol de caramelo"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Estilo caramelo"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Puesto de algodón de azúcar",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Un edificio con forma de algodón de azúcar que vende algodón de azúcar rosa"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cañón"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cañón"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Balas de cañón"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoas",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Largas canoas en las que los pasajeros palean",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 pasajeros por canoa"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Tejado de lona"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Carpa de Circo"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Atracción flotadores de carnaval; vagones mariposa",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Coches de montaña rusa con forma de flotadores mariposa de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Atracción flotadores de carnaval; vagones rana",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Vagones de montaña rusa con forma de flotadores rana de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Atracción flotadores de carnaval; vagones lagarto",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Vagones de montaña rusa con forma de flotadores lagarto de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Galería Vagoneta"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cajero Automático",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Un cajero automático para que los visitantes saquen si andan cortos de dinero"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castillo (marrón)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castillo (gris)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Esquina de castillo"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Esquina de castillo"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Entrada de castillo"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Esquina inversa de castillo"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Rastrillo de castillo"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Muralla de castillo"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Esquina de muralla de castillo"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Esquina de muralla de castillo"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Esquina de muralla de castillo"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Esquina inversa de muralla de castillo"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castillo"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Esquina de torre de castillo"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Esquina de torre de castillo"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Cruce de torre de castillo"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Sección recta de torre de castillo"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Sección en T de torre de castillo"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Sección en T de torre de castillo"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Muralla"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de castillo"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de castillo"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de castillo"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cráneo de ganado"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Abeto caucásico"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Caldero"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Entrada de cueva"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Coches cavernícolas",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Los usuarios compiten en los karts de la edad de piedra",
+    "reference-capacity": "Single-seater",
+    "capacity": "Monoplaza"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedro del Líbano"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Montaña rusa Cerbero",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Sentados en cómodos vagones con sujeciones simples, los viajeros disfrutan de grandes y suaves caídas así como de giros y gran cantidad de momentos de caída libre en los puntos superiores.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Coches de telesilla",
+    "reference-description": "Open cars for chairlift",
+    "description": "Vagones abiertos para el telesilla",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Tablero"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Gatos Cheshire",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Vehículos autopropulsados con forma de gato que siguen la ruta de las vías",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 pasajeros por gato"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Puesto de nuggets",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Puesto que vende trozos de pollo frito"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Cedro chino"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Dragón chino"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Montaña Rusa Cabeza de Dragón Chino",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Coches de choque eléctricos autopropulsados",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona por coche"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Columpio de junco chino",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "El barco está enganchado a un brazo con un contrapeso en el extremo opuesto, y hace un giro completo de 360 grados",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasajeros"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Puesto patatas fritas",
+    "reference-description": "A hut selling chips",
+    "description": "Un puesto que vende patatas fritas"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Puesto de patatas fritas",
+    "reference-description": "A stall selling chips",
+    "description": "Puesto que vende patatas fritas"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Barra de chocolate"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Sendero circuito"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circo",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Show de animales de circo bajo una gran carpa",
+    "reference-capacity": "30 guests",
+    "capacity": "30 visitantes"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circo"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Clásico / Romano"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Señal estilo clásico"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Temática clásica/romana"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Aguja de Cleopatra"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Enredaderas"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Reloj"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Árbol con forma de bastón"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Buques Costeros",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Vagones con forma de bote",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Atracción Tazas de Café",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Los pasajeros montan en parejas de dos asientos que giran alrededor de los extremos de tres largos brazos rotatorios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Una tienda de estilo art-deco que vende tazas de café"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Rueda dentada"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Rueda dentada"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Rueda dentada"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Rueda dentada"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Caramelo de cola"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Columnata"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Enebro común"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Roble común"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Tejo común"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Montaña Rusa Compacta",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Los pasajeros se sientan en parejas atravesando rizos e inversiones",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Atracción Condor",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Los pasajeros viajan boca abajo y acostados, suspendidos del arnés debajo de la pista en un vagón con forma de Cóndor que se balancea libremente de un lado a otro al pasar por las curvas.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Montaña Rusa Anguila Conger",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Una montaña rusa compacta de acero, donde un tren con forma de anguila circula por rizos y sacacorchos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Cerca de coníferas"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Cerca de coníferas"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Esquina de cinta transportadora"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Esquina de inversión de la cinta transportadora"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Final de cinta transportadora"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Subida de cinta transportadora"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Recta de cinta transportadora"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Puesto de galletas",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Puesto que vende galletas gigantes"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Colega simpático"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Montaña Rusa Sacacorchos",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Una montaña rusa compacta de acero donde los vagones circulan por rizos y  sacacorchos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pieza de tejado ondulado"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Base de acero arrugada"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Tejado de acero arrugado"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Pared de acero corrugado"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pieza de pared ondulada"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Pino de Córcega"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Vaquero 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Vaquero 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Sendero de empedrado loco"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Temática horripilante"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Atracción Cocodrilo",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Botes con forma de cocodrilo viajan por un canal de agua, salpicando por las empinadas cuestas de descenso para empapar a sus ocupantes",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Casa Inclinada",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Edificio con habitaciones combadas y pasillos angulosos para desorientar a la gente que entra",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitantes"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Fuentes de Cupido"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Tejado curvado"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Tejado curvado"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pieza de pared curvada de barro"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pieza de pared curvada de barro"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pieza de pared curvada de barro"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Tejado curvado"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Tejado curvado"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Pared curvada"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Pared curvada"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Música personalizada 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Música personalizada 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Viaje del cíclope",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Los usuarios viajan en el ojo de un cíclope gigante.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pasajero por coche"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Estatua de cíclope"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Lámpara margarita"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Torre de la presa"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Entrada a Edad Media"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Tema Edad Media"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Sección de esquina de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Sección de esquina de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Sección inversa de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Sección inversa de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Sección inferior de esquina de pueblo medieval"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Sección inferior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Sección de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Sección de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Sección de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Sección de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Tejado con chimenea de pueblo medieval"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Sección inferior de esquina de pueblo medieval"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Sección superior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Sección superior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Sección superior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Sección superior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Sección superior de muro de pueblo medieval"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Ventana de pueblo medieval"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Ventana de pueblo medieval"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Ventana de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Ventana de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Ventana de tejado de pueblo medieval"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Ventana de tejado de pueblo medieval"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Taberna de la Edad Media"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Tocón"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Tocón"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Tocón"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Atracción acuática Dhow",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Bote de pesca decorativo en el que los pasajeros pedalean",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasajeros por bote"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Vagoneta Diamante"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Atracción Diamante",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Los pasajeros montan en parejas de dos asientos que giran alrededor de los extremos de tres largos brazos rotatorios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Galería Diamante"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Árbol con forma de diamante"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridu"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Botes deslizantes",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Los pasajeros viajan en botes hinchables por tubos semicirculares o totalmente cerrados",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 pasajeros por bote"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurio"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurio"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurio"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurio"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurio"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Viaje en el huevo de dinosaurio",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Los usuarios montan en parejas, en asientos ambientados que giran alrededor de una madre dinosaurio animada.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Sendero sucio"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Coches de choque",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Coches de choque eléctricos autopropulsados",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona por vagón"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Estilo coches de choque"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Atracción Delfín",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Vehículos de uno solo asiento con forma de delfín que son conducidos por el propio pasajero",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 pasajero por vehículo"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Fuente delfín"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Estatua de delfín"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Tiovivo de dos niveles",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Tiovivo tradicional, cerrado, de dos niveles, con caballos tallados en madera.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasajeros"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Cabina de observación doble piso",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Cabinas de observación con doble piso que viajan verticalmente en una torre alta",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasajeros"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Tienda de Donuts",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Un puesto que vende donuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Base de torre grande apagada"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Base rota de torre grande apagada"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Sección intermedia de torre grande apagada"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Cima de torre grande apagada"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Pieza de minarete apagado 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Pieza de minarete apagado 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Pieza de minarete apagado 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Pieza de tejado apagado 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Pieza de tejado apagado 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Pieza de tejado apagado 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Pieza de tejado apagado 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Base de torre pequeña apagada"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Base de torre pequeña de minareteapagado"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Sección intermedia o cima de torre pequeña apagada"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Pieza de sección de escaleras apagadas 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Pieza de sección de escaleras apagadas 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Pieza de pared apagada 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Pieza de pared apagada10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Pieza de pared apagada 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Pieza de pared apagada 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Pieza de pared apagada 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Pieza de pared apagada 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Pieza de pared apagada 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Pieza de pared apagada 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Pieza de pared apagada 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Pieza de pared apagada 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Pieza de pared apagada 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Ataque de dragón"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Montaña del Dragón",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Montaña rusa con vagones inspirados en dragones",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Montaña rusa Libélula",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Los pasajeros viajan suspendidos en vagones especialmente diseñados unidos a una vía monorraíl, con libertad para balancearse en las curvas.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón."
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Puesto de bebidas",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Un puesto con forma de lata que vende bebidas refrescantes"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Estatua de la isla de Pascua 1"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Columna egipcia"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Estatua egipcia"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Señal estilo egipcio"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Temática egipcia"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Pared egipcia"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Estilo egipcio"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Torre Eiffel"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Valla electrificada"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Valla electrificada rota"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Esquina de valla electrificada"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Esquina inversa de valla electrificada"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Valla electrificada con luz"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Fuente elefante"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Vagoneta vacía"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rueda de la que cuelgan las vainas de los pasajeros, que comienza a girar y es entonces inclinada por un brazo soporte",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalipto"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Temática europea"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Larch europeo"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Entrada al parque europeo"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Samurai maligno"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Atracción Huevo Faberge",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Los pasajeros viajan en parejas de asientos que rotan alrededor de los extremos de tres largos brazos giratorios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Montaña Rusa Lanzadera",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "En esta montaña rusa, los pasajeros se sientan en parejas mirándose uno al otro o de espaldas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Estilo fantasía"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Herramientas de granja"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Buda obeso"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Mesa de banquetes"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Valla"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Valla"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Valla"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Vallas y paredes"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Rueda Gigante",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Gran rueda rotante con asientos al aire libre",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasajeros"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Faro de fuego"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Atracción Cometa Luchadora",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Los pasajeros se montan en parejas de asientos que rotan alrededor de los extremos de tres largos brazos giratorios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Coches de choque Caballeros en combate",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Los usuarios se suben en coches de choque decorados como caballos.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pasajero por coche"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Atracción Noria Fulgurante",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rueda de la que cuelgan las vainas de los pasajeros, que comienza a girar y luego se inclina mediante un brazo soporte",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Boca de incendios"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Sala Primeros Auxilios",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Donde los visitantes enfermos pueden ir para recuperarse"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Agujero de pesca"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Estatua arreglada"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Llamas"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamenco comiendo"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamenco mirando"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamenco acicalándose"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Montaña Rusa Sin Suelo",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Montaña rusa sin suelo, que da la sensación de estar al aire abierto",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flor"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Viaje de poder de las flores",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Pequeños botes decorados como flores controlados por un monitor central que controlan los pasajeros.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasajero por coche"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Camisetas de poder floral",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Puesto de venta de camisetas de motivos florales"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Viaje en el bote volante",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Los vagones en forma de bote volante corren por el recorrido de la montaña rusa, con curvas cerradas y caídas pronunciadas, pasando por zonas de agua.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasajeros por bote"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Montaña Rusa Volante",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Los pasajeros están sentados confortablemente bajo la vía sintiendo una experiencia de casi-vuelo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Platillos Volantes",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Vehículos aerodeslizadores autopropulsados",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona por vehículo"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Fútbol"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Atracción Fútbol",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Tren suspendido consistente en vagones con forma de balón de fútbol, los cuales se balancean libremente al tomar las curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Árbol del fruto prohibido"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Árboles del bosque"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fuente"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fuente"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Horquilla Invertida",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Vagones individuales corren bajo una vía zig-zageante",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Puesto de pollo frito",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Un puesto que vende pollo frito"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Puesto de arroz frito",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Puesto que vende dados de arroz frito"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Caída de la fruta"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Caída de la fruta"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Frutal"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Frutal"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Puesto de helados de frutas",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Un puesto que vende helados de frutas"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Casa de la risa",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "El edificio contiene muros y suelos móviles para desorientar a los que pasan por él.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 invitados"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Puesto de pasteles",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Puesto que vende pasteles"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Tema futurista"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Entrada a parque futurista"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Patíbulo"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Montaña rusa coche de gangster",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Los coches, ambientados como de gángsteres de los años veinte tienen que ser acelerados por motores de inducción lineal, para coger velocidad para los giros en inversión.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Jardines"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Gran almacén"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Estilo suave"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Fuente geométrica"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura geométrica"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura geométrica"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura geométrica"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura geométrica"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura geométrica"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Esquina de tejado plano georgiano"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Borde de tejado plano georgiano 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Borde de tejado plano georgiano 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Pieza de pared de suelo georgiano 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Pieza de pared de suelo georgiano 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Pieza de pared de suelo georgiano 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Pieza de pared de suelo georgiano 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Pieza de pared de suelo georgiano 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Pieza de pared de suelo georgiano 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Pieza de tejado georgiano 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Pieza final de tejado georgiano 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Pieza final de tejado georgiano 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Pieza de tejado georgiano 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Pieza de tejado georgiano 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Pieza de tejado georgiano 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Pieza de tejado georgiano 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Pieza de tejado georgiano 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Pieza de tejado georgiano 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Pieza de tejado georgiano 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Pieza de pared georgiana 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Pieza de pared georgiana 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Pieza de pared georgiana 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Pieza de pared georgiana 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Pieza de pared georgiana 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Géiseres"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Tren Fantasma",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Vagones con forma de monstruo en una vía múltiple pasando por un escenario tenebroso y lleno de efectos especiales",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Bajo gigante"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pedúnculo de judías"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pedúnculo de judías"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Temática caramelolandia"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Zanahoria gigante"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Huella gigante de dinosaurio"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Batería gigante"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Helecho gigante"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Temática jardín gigante"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Hierba gigante"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Guitarra gigante"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Árbol gigante de manglar"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Panda gigante"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Calabaza gigante"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Copo de nieve gigante"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Copo de nieve gigante"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Copo de nieve gigante"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Gigamontaña Rusa",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Una montaña rusa gigante capaz de caídas suaves y subidas de más de 300 pies",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Jirafa 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Jirafa 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Estatua jirafa"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Tejado de cristal"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Tejado de cristal"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Pared de cristal"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Pared de cristal"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Pared de cristal"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Pared de cristal"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Karts a gasolina autopropulsados",
+    "reference-capacity": "single-seater",
+    "capacity": "1 sólo pasajero"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Llama dorada"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Estatua de oro 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Estatua de oro 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Buda dorado"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Vellocino de oro"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Ciprés dorado Hinoki"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Samurai bueno"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Atracción Gorila",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Tren en suspensión consistentes en vagones con forma de gorila capaces de balancearse con libertad al tomar las esquinas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Gran piedra"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Gran piedra"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Gran piedra"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Gran piedra"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de cementerio"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de cementerio"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de cementerio"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Sec. frontal de la pared de la Gran Muralla China"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Sec. trasera de la pared de la Gran Muralla China"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Sec. de pared de las escaleras de la Gran Muralla"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Esquina de torre de la Gran Muralla China"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Recta de torre de la Gran Muralla China"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Atracción Gran Tiburón Blanco",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trenes espaciosos con simples barras de sujeción",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Sendero asfaltado verde"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Agua verde"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Buen bailarín"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Estatua de Hades"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Sala de los espejos",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "El edificio contiene espejos deformados que distorsionan el reflejo del observador.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 usuarios"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Embarcadero"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Muro del puerto"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Sección de esquina de muro del puerto"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Sección de esquina de muro del puerto"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Muro del puerto con embarcadero"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Muro del puerto con aparejos de pesca"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del puerto con noray"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del puerto con noray"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del puerto con noray"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del puerto con noray"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Montaña rusa de las arpías",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Los usuarios están sujetos con arneses especiales para quedar en una posición tumbada y viajar por un circuito lleno de giros e inversiones, bien sobre las espaldas o de cara al suelo.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Puesto de sombreros",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Un puesto de regalos que vende grandes sombreros de espuma"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Casa Encantada",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Gran edificio con pasillos tenebrosos y salas espectrales",
+    "reference-capacity": "15 guests",
+    "capacity": "15 visitantes"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Cárcel hechizada",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "El edificio contiene mazmorras y maniquíes de personas encarceladas, para atemorizar a los que pasen por allí.",
+    "reference-capacity": "16 guests",
+    "capacity": "16 usuarios"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Paseo por la Casa Encantada",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Vagones autopropulsados que corren sobre una vía multinivel",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Bala de heno"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Árbol con forma de corazón"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Suelo de termas de los dioses"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Piscina de termas de los dioses"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Esquina de piscina de termas de los dioses"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Borde de piscina de termas de los dioses"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Escalones de piscina de termas de los dioses"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Techo de termas de los dioses"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Techo de termas de los dioses"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Techo de termas de los dioses"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Techo de termas de los dioses"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Ventana de termas de los dioses"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de termas de los dioses"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de termas de los dioses"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de termas de los dioses"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitectura de termas de los dioses"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitectura de termas de los dioses"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitectura de termas de los dioses"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitectura de termas de los dioses"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fuente de termas de los dioses"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fuente de termas de los dioses"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escalera de termas de los dioses"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escalera de termas de los dioses"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Cerca"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Cerca"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipuerto"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hércules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hipopótamo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hipopótamo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Atracción Hipopótamo",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Los pasajeros montan en un submarino sumergido que viaja por una ruta submarina",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "pasajeros por vehículo"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Acacia de miel"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Estilo horror"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Caballo"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Estatua de caballo"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Estatua de jinete"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Carrera Ciega",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Los pasajeros se montan en unos vagones con forma de caballo que recorren sobre un monoraíl",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 jinetes por caballo"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Puesto de chocolate caliente",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Puesto que vende chocolate caliente"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Puesto de perritos",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Puesto que vende perritos calientes"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Bólido"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Bólido"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Montaña rusa bólido",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Después de un divertido lanzamiento por aire, el tren acelera por una vía vertical, hasta lo más alto, viajando verticalmente por el otro lado para llegar a la estación.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Viaje en moto jet",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Los viajeros se sientan en vehículos con forma de moto que viajan por un monorraíl.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasajeros por vehículo."
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Viaje en aerodeslizador",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "La tecnología de levitación magnética se ha implementado para crear la ilusión de aerodeslizadores futuristas.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto jet volando"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto jet volando"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto jet parada"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto jet parada"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Montaña rusa Tabla de suspensión",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Los usuarios montan en una tabla de suspensión, balanceándose libremente de lado a lado al realizar giros.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Aerodeslizador volando"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Aerodeslizador volando"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Aerodeslizador parado"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Aerodeslizador parado"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Vagón Huskie",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Vehículos eléctricos con forma de trineos de perros huskies, que siguen una ruta sobre raíles",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Trenes Hiper-Tornado",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Vagones muy espaciosos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Trenes Hiper-Tornado (anchos)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Vagones amplios con asientos elevados",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hipermontaña Rusa",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Una montaña rusa alta y que no se invierte con grandes caídas, alta velocidad y vagones confortables con sólo unas barras para sujetarse",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Puesto de helados",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Un puesto que vende conos de helados"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Cubo de hielo"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Formación de hielo"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Formación de hielo"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Palacio de hielo"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Entrada al parque de hielo"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Base de tubería de hielo"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Sección de tubería de hielo"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Salida de tubería de hielo"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Techo de hielo"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Pared de hielo"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Estilo hielo"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Barriles helados"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Barriles helados"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Barriles helados"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Puesto de té helado",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Puesto que vende té helado"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Iglú"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Tejado de iglú"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Pared de iglú"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Montaña Rusa Impulso Inverso",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Los vagones de la montaña rusa invertida aceleran saliendo del andén y toman un tramo de vía vertical, entonces vuelven marcha atrás pasando por el andén y subiendo por otro tramo de vía vertical",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Cedro de incienso"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandera de seda india"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandera de seda india"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandera de seda india"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandera de seda india"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandera de seda india"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Sección de esquina de tejado industrial"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Sección de esquina de tejado industrial"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Sección de muro industrial"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Sección de esquina de muro industrial"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Sección de esquina de muro industrial"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de muros industriales"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de muros industriales"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de muros industriales"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de muros industriales"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industrial con entrada"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industrial con ventana"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Quiosco de información",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Puesto en el que los visitantes obtienen mapas del parque y compran paraguas."
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Esquimal"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Esquimal"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Ciprés italiano"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Atracción Policía Italiana",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Los pasajeros viajan en parejas de asientos que rotan alrededor de los extremos de tres largos brazos giratorios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Atracción Jaguar",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Montaña rusa con vagones en forma de jaguares",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajero por vagón"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Cerezo en flor japonés"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Cerezo japonés"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Entrada japonesa al parque"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Pino japonés"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Tejado Shōji"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Tejado Shōji"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Tejado Shōji"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandera de seda japonesa"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Árbol de nieve japonés"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Miembro de banda de jazz"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Miembro de banda de jazz"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Miembro de banda de jazz"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Miembro de banda de jazz"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Bebé de gelatina"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Gominola"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Pared de gominolas"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avión a reacción"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avión a reacción"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avión a reacción"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Mochila de impulsión a chorro",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Los viajeros se montan en un vehículo que se lanza por un guía vertical.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasajeros por coche"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Montaña rusa avión a reacción",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Una montaña rusa compacta con vagones individuales y suaves caídas en espiral.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Jet Skis que un único pasajero puede conducir",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 pasajero por vehículo"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Caballero en la justa",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Los pasajeros se montan en la grupa de vehículos en forma de caballos que van por una vía monorraíl.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Fuentes Saltarinas"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Bolas de Nieve Saltarinas"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungla"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Cerca de jungla"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Señal estilo jungla"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Temática de jungla"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Árbol tropical 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Árbol tropical 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Árbol tropical con leopardos"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Árbol tropical con lianas"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Estilo tambores jungla"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Chatarra"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Señal estilo jurásico"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Temática jurásica"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Estilo jurásico"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Canguro"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Ballena asesina",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Los pasajeros montan en un submarino sumergido que viaja por una ruta submarina",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "pasajeros por vehículo"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Atracción Koala",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Gran vagón para la montaña rusa invertida de caída libre",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasajeros por vagón"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Base de torre grande del Kremlin"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Sección intermedia de torre grande de Kremlin"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Cima de torre grande de Kremlin"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Pieza de cúpula del Kremlin 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Pieza de cúpula del Kremlin 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Pieza de cúpula del Kremlin 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Pieza de tejado del Kremlin 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Pieza de tejado del Kremlin 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Base de torre pequeña del Kremlin"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Sección intermedia de torre pequeña del Kremlin"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Base de cúpula pequeña del Kremlin"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Pieza de pared de sección de escaleras del Kremlin 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Pieza de pared de sección de escaleras del Kremlin 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Pieza de pared del Kremlin 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Pieza de pared del Kremlin 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Pieza de pared del Kremlin 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Pieza de pared del Kremlin 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Pieza de pared del Kremlin 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Pieza de pared del Kremlin 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Pieza de pared del Kremlin 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Pieza de pared del Kremlin 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Montaña Rusa Impulso MLI",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Los vagones se aceleran por los motores lineales de inducción",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Tren Mariquita",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Montaña rusa con vagones de forma de mariquitas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lámpara"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lámpara"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lámpara"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lámpara"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lámpara"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Gran valla angulosa de mamut"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Gran valla angulosa de mamut"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Olmo grande"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Gran valla de mamut"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Gran valla de mamut"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Cráter gigante de meteorito"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Gran roble"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Árbol tropical 4"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Cráter grande de meteorito rojo"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Gran chimenea humeante"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Altavoz grande"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Gran poste tótem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Valla láser"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Esquina de valla láser"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Caída Libre Propulsada",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Un vagón es lanzado en un neumático a lo alto de una elevada torre de acero, cayendo libremente",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Ciprés de Lawson"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Mini Montaña Rusa Suspendida",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Los pasajeros se colocan boca abajo en unos vagones especiales en ésta montaña rusa",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasajero por vehículo"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Montaña Rusa Fija",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Los pasajeros están sujetos por unos arneses cara abajo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Puesto de limonada",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Un puesto de época en el que se vende limonada al viejo estilo, fresca."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Puesto de limonadas",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Puesto que vende refrescantes limonadas"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Ascensor",
+    "reference-description": "Steel lift cabin",
+    "description": "Los pasajeros suben o bajan en un ascensor para acceder a distintos niveles de una torre vertical",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Azucena"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Montaña Rusa de Limusina",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Montaña rusa con vagones inspirados en las limusinas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "León"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Atracción León",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Montaña rusa con vagones en forma de leónes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Papelera"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Papelera"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Papelera"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Papelera"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Cabaña de madera"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Troncos de madera"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pieza de tejado de cabaña de troncos"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pieza de tejado de cabaña de troncos"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pieza de tejado de cabaña de troncos"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Chimenea lateral de la cabaña de troncos"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pieza de pared de cabaña de troncos"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Trenes Tronco",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Montaña rusa con vagones en forma de tronco",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Troncos"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Leños de agua",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Barcos con forma de tronco que viajan por un canal de agua, salpicando hasta empapar a los pasajeros",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Chupachús"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Álamo de Lombardía"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Trenes de Montaña Rusa",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Montaña rusa con barras de regazo capaz de rizos verticales",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pieza de columna de ciudad perdida"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pieza de columna de ciudad perdida"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pieza de pared plana de ciudad perdida"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pieza de pared plana de ciudad perdida"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pieza de pared plana de ciudad perdida"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pieza de escalinata de ciudad perdida"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pieza de escalinata de ciudad perdida"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pieza de escalinata de ciudad perdida"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pieza de escalinata de ciudad perdida"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pieza de escalinata de ciudad perdida"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pieza de pared de ciudad perdida"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Arbusto bajo"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Proa de crucero de lujo"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Sección media de crucero de lujo"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Popa de crucero de lujo"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Viaje de la maza",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Los usuarios se sientan en un asiento ambientado en la época que está unido a un brazo giratorio.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 usuario por asiento"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Alfombras Mágicas",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Un vagón decorado con la temática de alfombra volante se mueve arriba y abajo cíclicamente",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasajeros"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Armadura mágica"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Yelmo mágico"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Escudo mágico"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Espada mágica"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolio"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Arco 1 del palacio del Maharajá"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Arco 2 del palacio del Maharajá"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Bóveda del palacio del Maharajá"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pieza del palacio del Maharajá"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pieza del palacio del Maharajá"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pieza del palacio del Maharajá"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Base de torre del palacio del Maharajá"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Columna de torre del palacio del Maharajá"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Cima de torre del palacio del Maharajá"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Tren de vapor",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Trenes de vapor en miniatura consistentes en una réplica de locomotora que tira de unos vagones de madera con capota",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Atracción acuática Pato Mandarín",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Bote con forma de cisne, impulsado por el pedaleo de los pasajeros del asiento delantero",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasajeros por bote"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Árbol tropical 3"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Atracción Manta Raya",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Botes de gran capacidad que viajan por un amplio canal de agua y son empujados hacia arriba por una cinta transportadora, para luego precipitarse cuesta abajo empapando a los viajeros con una salpicadura gigante",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasajeros por bote"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Techo de mármol"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Techo de mármol"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Techo de mármol"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Techo de mármol"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Bailarín de Mardi Gras"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Bailarín de Mardi Gras"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Carpa"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Bombón"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Malvavisco"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Edificio marciano"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Objeto marciano"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Objeto marciano"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Objeto marciano"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Objeto marciano"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Objeto marciano"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Temática marciana"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Pared marciana"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Estilo marciano"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Laberinto",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Laberinto de paredes de 6 pies de alto de cercas o paredes, en el que vagan los visitantes hasta que encuentran la salida"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Puesto de sopa albóndigas",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Puesto que vende sopa de albóndigas estilo china"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Temática mecánica"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Estilo mecánico"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Temática medieval"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Estilo medieval"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hombres convertidos en piedra"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hombres convertidos en piedra"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hombres convertidos en piedra"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hombres convertidos en piedra"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Tiovivo",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Carrusel tradicional con caballitos de madera tallada",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Cerca de malla"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Cerca de malla"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Esquina de cráter de meteorito"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Esquina de cráter de meteorito"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Esquina inversa de cráter de meteorito"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Pared de cráter de meteorito"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Pared de cráter de meteorito con cristales"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Pared de cráter de meteorito con cristales"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Enebro azul de Meyer"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Viaje en microbús",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Los viajeros ven una película en el interior de un sistema de simulación mientras son movidos y girados por un brazo hidráulico.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbús"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mina Loca de Madera",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Mini camiones que corren sobre una pista de madera",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por camión"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Coches de Mina",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Vehículos individuales con forma de vagonetas de madera",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Atracción Vagonetas",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Trenes de madera con asientos acolchados y barras de sujeción",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Cabaña minera"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Cabaña minera"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Elevador de la mina",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Los pasajeros montan en un elevador que sube o baja por una torre vertical para ir de un nivel a otro",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Pozo minero"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Temática minera"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Montaña Rusa Minitrén",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "El tren de la mina corre por una vía de acero que recuerda las viejas vías del tren",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ó 4 pasajeros por vagón"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Un sencillo juego de mini golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicópteros",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Vagones con forma de helicópteros corren por una vía de acero controlados por los pedales de los pasajeros",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Estatua de minotauro"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Menta"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Estilo moderno"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Pino Chileno"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Camiones gigantes autopropulsados 4x4 que pueden subir cuestas impresionantes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 pasajeros por camión"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Ciprés de Monterrey"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Pino de Montezuma"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pieza de tejado monumental 3"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Pieza de tejado monumental 1"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pieza de tejado monumental 4"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pieza de tejado monumental 4"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pieza de tejado monumental 4"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pieza de tejado monumental 4"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pieza de tejado monumental 2"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Zumo de luna",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Un puesto en el que se vende lo último en bebidas suaves"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Sendero con mosaico"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Simulador de Movimiento",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Los pasajeros ven una película dentro del simulador mientras se mueve por un brazo hidráulico",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Carrera de Motos",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Los pasajeros se montan en unos vagones con forma de moto que recorren sobre un monoraíl",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 pasajeros por moto"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicleta"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicleta"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Coches Ratón",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Coches individuales con forma de ratón",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Ratón Loco de Madera",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Coches con forma de ratones que corren sobre una pista de madera",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Pieza de tejado de barro"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pieza de pared de barro"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Montaña Rusa Multi-Dimensión",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Vagones con asientos capaces de poner a los pasajeros cabeza abajo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Entrada mitológica"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Tema mitológico"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Nativo americano"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Agua natural"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Baranda de esquina de tejado náutico"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pieza de tejado náutico"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pieza de tejado náutico"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pieza de tejado náutico"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pieza de tejado náutico"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pieza de tejado náutico"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Baranda de tejado náutico"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pieza de pared náutica"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Anuncio de neón de restaurante"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Anuncio de neón de restaurante"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Anuncio de neón de restaurante"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Anuncio de neón de restaurante"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Viaje de Neptuno",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Los usuarios se montan por parejas, en asientos perfectamente ambientados que giran alrededor de una estatua de Neptuno.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Puesto de comida marina de Neptuno",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Un puesto en el que se venden las saladas delicias de Neptuno"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Relleno de esquina de Nueva York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Entrada de Nueva York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Sección de esquina invertida de Nueva York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Sección de esquina invertida de Nueva York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Sección de esquina invertida de Nueva York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Sección de esquina invertida de Nueva York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Sección de tejado inversa de Nueva York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Sección de tejado de Nueva York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Sección de tejado de Nueva York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Sección de tejado de Nueva York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Sección de tejado de Nueva York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Sección de tejado de Nueva York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Sección de muro de Nueva York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muro con línea de Nueva York"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muro con línea de Nueva York"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Tendedero de Nueva York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Tendedero de Nueva York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Entrada invisible"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Entrada invisible, sin plataforma"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Entrada al parque Norteamérica"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Temática norteamericana"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Abeto de Noruega"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Viaje en el barril de roble",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Los barriles de roble van a la deriva por un ancho canal de agua, cayendo por cataratas y pasando por estremecedores rápidos.",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 pasajeros por coche"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Sección de puerta de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Sección de tejado de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Esquina de pendiente suave de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Esquina de pendiente suave de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Muro de pendiente suave de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Esquina de pendiente pronunciada de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Sección de puerta de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Sección de puerta de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Sección de puerta de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Muro de rascacielos de obsidiana"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Muro con ventana de rascacielos de obsidiana"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Bloque de oficinas"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Barril de petróleo"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Bomba de petróleo"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Árbol antiguo gigante"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Agua naranja"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Estilo órgano"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Estilo oriental"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estructura ornamental"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estructura ornamental"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estructura ornamental"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árbol ornamental"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árbol ornamental"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árbol ornamental"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árbol ornamental"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árbol ornamental"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Pared de mármol ornada"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Atracción Avestruz",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Una montaña rusa con rizos en la que los pasajeros viajan de pie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Atracción de Canoa",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Canoas largas en las que los pasajeros pedalean",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 pasajeros por canoa"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Señal estilo pagoda"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Temática de pagoda"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Torre pagoda"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palmera"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmera"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmera"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palmera"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palmera"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Papelera panda"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Temática Panda"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Trenes Panda",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Montaña rusa con vagones de forma de mimosos osos panda",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasajero por vagón"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Entrada al parque"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Puertas de entrada al parque"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Choza de campesino"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Viaje de pegaso",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Poderosos vehículos en forma de pegaso tiran de un carro, siguiendo una ruta prefijada.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Bobsleigh Pingüino",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Los pasajeros viajan por unas vías retorcidas en vagones con forma de pingüino guiados únicamente por la curvatura y los peraltes de la vía semicircular",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Punto de coches"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Punto de coches"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Punto de comida"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Bandera final"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Punto de regata"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Punto de farolas"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Punto de camiones"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Punto de camiones"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Gasolinera"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickups",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Vehículos autopropulsados con forma de furgonetas pickup",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 pasajero por vehículo"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Tubería"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Sección de tubería"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Sección de tubería"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Sección de tubería"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Bandera pirata"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Barco Pirata",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Gran barco pirata que se balancea",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Barco pirata"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Temática pirata"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Estilo pirata"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Puesto de pizza",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Un puesto que vende porciones de pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Típica"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Pared de mármol simple"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Pared de cartas"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Pared de cartas"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinto"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Arado"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Montaña Rusa Oso Polar",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Los pasajeros se sientan en parejas mirando atrás o adelante y atraviesan ceñidas inversiones que giran y se retuercen",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Polo"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Polo"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Asta"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Montaña rusa Persecución policial",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Una montaña rusa llena de bucles en la que los viajeros van sentados",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Montaña rusa Coche de policía",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Coches decorados como de la policía en los años sesenta que circulan por guías de madera, girando completamente en secciones de inversión especiales.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por coche"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Puesto de palomitas",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Un puesto que vende gigantes cubos de palomitas"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Puerta rastrillo"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Puerta rastrillo"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Poste"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Trenes Mineros",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Trenes mineros autopropulsados corren a lo largo de una vía enredada",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ó 4 pasajeros por vagón"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Entrada prehistórica"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Tema prehistórico"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Puesto de pretzel",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Puesto que vende galletas pretzel"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa primordial"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Puerta de prisión"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Valla de prisión"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Sección inversa de prisión"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Esquina de muro de prisión"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Esquina de muro de prisión"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Sección de muro de prisión"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Tejado de muro de prisión"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Torre de vigilancia de prisión"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escaleras de torre de vigilancia de prisión"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escaleras de torre de vigilancia de prisión"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Depósito de agua de prisión"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Montaña rusa Pterodáctilo",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Los pasajeros se acomodan en asientos debajo de la vía, viajando por un retorcido circuito que les proporciona la experiencia definitiva de vuelo prehistórico.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Calabaza"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Casa de calabaza"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pirámide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "TV zona de espera"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Coches de Carreras",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Vehículos autopropulsados con forma de coches de carreras",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasajero por vehículo"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Montaña rusa Raptor",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Los usuarios se sientan en vehículos con forma de velocirraptor, en un circuito monorraíl.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasajeros por vehículo"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Altavoz de carrera"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Antena de radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Balsas de Río",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Botes con forma de balsa",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 pasajeros por balsa"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Estilo ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Enrejado"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Sendero arcoiris"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Pieza de la esquina de tejado de ladrillo rojo"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Esquina de tejado plano de ladrillo rojo"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Pieza de borde de tejado plano de ladrillo rojo"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Pieza invertida de tejado de ladrillo rojo"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Pieza de tejado de ladrillo rojo 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Pieza de tejado de ladrillo rojo 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Pieza de tejado de ladrillo rojo 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Pieza de pared de ladrillo rojo 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Pieza de pared de ladrillo rojo 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Pieza de pared de ladrillo rojo 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Pieza de pared de ladrillo rojo 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Pieza de pared de ladrillo rojo 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Pieza de pared de ladrillo rojo 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Pieza de pared de ladrillo rojo 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Pieza de pared de ladrillo rojo 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Pieza de pared de ladrillo rojo 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abeto rojo"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abeto rojo"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Esquina de cráter de meteorito rojo"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Esquina de cráter de meteorito rojo"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Esquina invertida de cráter de meteorito rojo"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Muro de cráter de meteorito rojo"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Secuoya"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Trenes Monorrail Estilo Retro",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monoraíl con cabina abierta",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Coche Caída Libre Inversa",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Montaña Rusa Invertida",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Montaña Rusa Inversora",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Vagones que corren por una vía de madera girando en secciones especiales de inversión",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rinoceronte"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Atracción Rinoceronte",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Una montaña rusa compacta de acero con una colina de subida en espiral y vagones con asientos en línea",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Cordaje"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Rápidos",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Botes circulares que corren por canales de agua salpicando",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 pasajeros por bote"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Río Styx",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Botes con forma de balsa que serpentean tranquilamente por un circuito de río.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Carretera"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Entrada a parque de los locos años veinte"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Tema locos años veinte"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Conjunto de muros de locos años veinte"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Puesto de salchichas asadas",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Puesto que vende salchichas asadas"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Campamento de Robin Hood"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Choza de Robin Hood"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Choza de Robin Hood"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Entrada al parque del Rock & Roll"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Tema rock & roll"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Autobús de gira de grupo de rock"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Pared de roca"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Estilo rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Estilo rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Estilo rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Coches Cohete",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Montaña rusa con vagones en forma de cohetes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Sendero rocoso"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Estatua de condecoración de montaña rusa"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Camarera con patines"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Coliseo romano"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Columna romana"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Columna romana"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Sección de esquina de palacio romano"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Sección de esquina de palacio romano"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Sección de esquina de palacio romano"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Sección de esquina de palacio romano"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sección de cruce de palacio romano"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sección de cruce de palacio romano"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sección de cruce de palacio romano"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sección de cruce de palacio romano"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Sección final de palacio romano"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Sección final de palacio romano"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Sección recta de palacio romano"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Sección recta de palacio romano"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Sección recta de palacio romano"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Sección recta de palacio romano"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Estatua romana"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Estatua romana"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Templo romano"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Pared romana"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Pared romana"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Estilo fanfarria romana"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Tejado"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Caída Giratoria",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Un anillo de asientos arrastrados a lo alto de una torre mientras gira, y después cae libremente, parando suavemente en el fondo usando unos frenos magnéticos",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Signo de ruta 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Tranvía de autobús londinense",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Réplica de tranvías",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasajeros por vagón"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Bote a Remos",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Botes de remos en los que los pasajeros reman",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasajeros por bote"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Estatua rota"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Sección de esquina de autopista"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Sección de borde de autopista"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Sección de esquina inversa de autopista"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Sección de autopista"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Sección de autopista"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Sección de autopista"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Salón"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Tranvía de San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Réplica de tranvías",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasajeros por vagón"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Esquina inferior de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Esquina inferior de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Forma redondeada inferior de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Esquina inferior inversa de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Base inferior inclinada de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Esquina superior de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Parte superior inclinada de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Parte superior inclinada de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Zona de atraque de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Puerta de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Relleno de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Relleno de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Parte superior de esquina invertida de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Esquina media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Esquina media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pendiente inclinada media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pendiente inclinada media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Esquina inclinada media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sección de pared media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sección de pared media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sección de pared media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sección de pared media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sección de pared media de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Tejado de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Torre de tejado de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Torre de tejado de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Pasadizo de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Pasadizo de rascacielos de arenisca"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Esquina de pasaje de arenisca"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sección de cruce de pasaje de arenisca"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sección final de pasaje de arenisca"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Cruce en T de pasaje de arenisca"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satélite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Antena parabólica"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Autocar escolar"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Viaje del autocar escolar",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Réplica del clásico autocar amarillo",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasajeros por coche"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Pino escocés"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Señal desplazante"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Señal"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Escultura"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Escultura"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Puesto de mariscos",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Un puesto que vende calamares fritos"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Aeronave"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Montaña Rusa Focas",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Una montaña rusa compacta de acero donde los vagones circulan por rizos y sacacorchos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Pozos de hidroaviones"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Pozos de hidroaviones"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Foco de vigilancia"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Asientos"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Arbustos y ornamentos"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Volante"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Pelota de bádminton"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Pared Shōji"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sendero acera"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Señal"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Señales y artículos para caminos"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Abedul plateado"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Cantante con copete"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Torre de Observación",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Cabina de observación que viaja hasta una torre alta",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 pasajeros"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Temática six flags"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Montaña Rusa Caída Vertical",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Vagones superanchos descienden completamente verticales para una experiencia definitiva",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Esqueleto"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Sillas de telesilla",
+    "reference-description": "Open cars for chairlift",
+    "description": "Vagones abiertos para el telesilla",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Coches de choque esquimales",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Coches de choque eléctricos de conducción propia",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona por coche"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Calavera"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Calavera"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pieza de pared de rascacielos"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pieza de pared de rascacielos"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pieza de pared de rascacielos"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sendero paseo espacial"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Pieza cóncava de rascacielos"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Tejado cóncavo de rascacielos"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Pieza convexa de rascacielos"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Tejado convexo del rascacielos"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pieza de ascensor de rascacielos"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pieza de ascensor de rascacielos"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pieza de la sección del ascensor del rascacielos"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pieza de la sección del ascensor del rascacielos"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pieza de la sección del ascensor del rascacielos"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Pieza cóncava del set de metal 1 del rascacielos"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Pieza convexa del set de metal 1 del rascacielos"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Pieza de pared del set de metal 1 del rascacielos"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pieza cóncava del set de metal 2 del rascacielos"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pieza cóncava del set de metal 2 del rascacielos"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Pieza convexa del set de metal 2 del rascacielos"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pieza de pared del set de metal 2 del rascacielos"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pieza de pared del set de metal 2 del rascacielos"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Pieza de tejado de rascacielos"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Punta de rascacielos"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Atracción Perezoso",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Tren suspendido consistente en vagones con forma de perezoso que se balancean libremente al tomar las curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Pequeña valla angulosa de mamut"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Pequeña valla angulosa de mamut"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Pequeña rueda dentada"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Pequeña rueda dentada"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Pequeña rueda dentada"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Pequeña rueda dentada"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Geosfera pequeña"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Cráter pequeño de meteorito"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Coche Pequeño Monorrail",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Pequeños vagones de monoraíl",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Árbol tropical 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Árbol tropical 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Cráter pequeño de meteorito rojo"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Altavoz pequeño"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Chimeneas base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Chimeneas medias"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Caracol"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Nieve / Hielo"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Señal cubierta de nieve"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Tazas de Nieve",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Los pasajeros van en pareja rotando alrededor de un muñeco de nieve central",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Temática de nieve y hielo"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Estilo nieve"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Abeto caucásico nevado"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Abeto de Noruega nevado"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abeto rojo nevado"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abeto rojo nevado"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Muñeco de nieve"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Muñeco de nieve"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Carreras de Jaboneras",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Los pasajeros usan vagones con forma de jaboneras",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Puesto de peluches",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Un puesto de venta de preciosos peluches de dinosaurio"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Temática sudamericana"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Entrada al parque de Sudamérica"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Puesto de souvenirs",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Puesto que vende juguetitos y paraguas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Puesto leche de soja",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Puesto que vende leche de soja"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Espacial"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Cápsula espacial"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Cápsula espacial"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Orbes espaciales"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Anillos Espaciales",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Anillos concéntricos que pivotan permitiendo a los pasajeros rotar libremente en cualquier dirección",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 por visitante"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Cohete espacial"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Sección de carga de nave espacial"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Sección de comunicaciones de nave espacial"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Sección de control de nave espacial"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Sección de cruce de nave espacial"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Sección de amarre de nave espacial"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Sección de motores de nave espacial"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Sección de combustible de nave espacial"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Sección de gravedad de nave espacial"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Sección habitable de nave espacial"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Sección científica de nave espacial"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Paneles solares de nave espacial"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Sección solar de nave espacial"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Sendero estilo espacial"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Señal estilo espacial"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Temática espacial"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Estilo espacio"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Árbol con forma de pala"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Esfinge"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Araña"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Valla de espino"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Ratón Loco Giratorio",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Vagones con forma de ratón efectúan curvas bruscas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Montaña Rusa Espiral",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Una montaña rusa pequeña de acero con una subida en espiral y vagones con asientos en línea",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Tobogán Espiral",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Edificio de madera con una escalera interna y un tobogán externo que se usa con alfombrillas"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Botes Locos",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Botes de gran capacidad que viajan por un amplio canal impulsados por una cinta transportadora que producen grandes salpicaduras",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 pasajeros por bote"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Temática fantasmal"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Deportivos",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Vehículos autopropulsados de forma de carreras",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por coche"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Temática deportiva"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Atracción Voladora del Sputnik Suspendido",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Los pasajeros viajan boca abajo en posición tumbada, suspendidos del monorraíl en un vagón de diseño especial que se balancea libremente de un lado a otro al tomar las curvas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Árbol con forma de ardilla"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Montaña Rusa de Carroza",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Trenes de madera con asientos acolchados y barras de sujeción",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Montaña rusa Estampida",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Una montaña rusa llena de bucles, con vehículos en forma de rebaños de dinosaurios en estampida.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Montaña Rusa En Pie",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Una montaña rusa en el que los pasajeros permanecen de pie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Montaña Rusa En Pie Tornado",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Los pasajeros permanecen de pie en unos vagones con sujeciones especiales atravesando caídas y múltiples inversiones",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Puesto de bebidas de frutas",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Puesto que vende bebidas de frutas"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Estatua"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Estatua"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Estatua"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Estatua de la Libertad"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Tren de Vapor",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Trenes vapor en miniatura que son réplicas de las auténticas, tirando de vagones de madera",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Tren de Vapor Cubierto",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trenes miniatura de vapor con locomotoras réplica y vagones de madera y techos de lona",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasajero por vagón"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Alcantarillas"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Bloque de acero"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Bloque de acero"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Valla de acero"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Celosía de acero"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Pared de acero"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Templo de la edad de piedra"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Banco de piedra"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Bloque de piedra"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Base de la escalinata del rascacielos de piedra"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pieza de pared de rascacielos de piedra"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pieza de pared de rascacielos de piedra"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pieza de pared de rascacielos de piedra"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pieza de pared de rascacielos de piedra"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pieza de pared de rascacielos de piedra"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Pared de piedra"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Pared de piedra"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Pared de piedra"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Pared de piedra"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Taburete"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Taburetes"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Tren Monorrail Aerodinámico",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Trenes monoraíl de gran capacidad con coches delateros y traseros aerodinámicos",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 ó 10 pasajeros por vagón"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Puesto de mini-sandwiches",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Puesto que vende mini-sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Paseo en Submarino",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Los pasajeros van en un submarino sumergido bajo una vía acuática",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 pasajeros por submarino"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Puesto de sujeonggwa",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Puesto que vende bebidas estilo koreano sujeonggwa"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Estilo verano"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Puesto de gafas de sol",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Puesto que vende toda clase de gafas de sol"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Barco hundido"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Gran CPU de superordenador"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor de superordenador"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Pequeña CPU de superordenador"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Estructura de soporte"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Estructura de soporte"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Estructura de soporte"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Montaña Surfing",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Los pasajeros viajan de pie en amplios trenes con sujeciones especialmente diseñadas, y recorren suaves caídas con múltiples inversiones",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Trenes Monorrail Suspendidos",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Vagones de monoraíl de gran capacidad",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasajeros por vagón"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Viaje del hidroavión",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Tren de montaña rusa suspendido consistente en vagones capaces de girar con libertad cuando el tren coge curvas.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por coche"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Aviones Suspendidos Balancín",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Montaña rusa que consiste en vagones con forma de avión que giran libremente en las curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Coches Suspendidos",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Vagones suspendidos que se balancean libremente al tomar las curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Pieza de la base del puente suspendido"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Pieza espaciadora de la base del puente suspendido"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Sección de cable del puente suspendido"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Pieza de la sección intermedia del puente suspendido"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Lado 1 del inicio del puente suspendido"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Lado 2 del inicio del puente suspendido"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Lado 1 de la torre del puente suspendido"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Lado 2 de la torre del puente suspendido"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Helecho de pantano"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Ciénaga"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de pantano"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de pantano"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de pantano"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Cisnes",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Bote con forma de cisne impulsado mediante pedaleo por los pasajeros",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Coches Balancín",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Pequeños vagones que cuelgan del raíl superior",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Coches Balancín Sin Suelo",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Vagones suspendidos como en los telesilla que pueden balancearse libremente en las curvas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Barco Balancín Invertido",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Barco acoplado a un brazo con contrapeso que le permite hacer giros de 360 grados",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasajeros"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Espada en la piedra"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Puesto de camisetas",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Un puesto que vende camisetas"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "Tren TVG",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Los trenes de la montaña rusa salen de la estación acelerados por unos motores de inducción para pasar a toda velocidad por unas retorcidas inversiones",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Barriles de TNT"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Cajas de TNT"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Detonador de TNT"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Pila de TNT"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Linterna alta"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Linterna alta"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Valla alta de madera"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Objetivo"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Sendero asfaltado"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Taberna"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Estilo tecno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tipi"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teletransportador",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Los invitados son transportados arriba y abajo, de un nivel a otro.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasajeros"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Pieza de pared rota de templo con cabeza"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pieza de tejado de templo"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pieza de pared de templo"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Pieza de pared de templo con cabeza"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Habitación"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Pelota de tenis"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Pared de red de tenis"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Pared de red de tenis"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tienda"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tienda india"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Montículo de termitas"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Casa adosada"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Ejército de terracota"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Máquina del tiempo",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Los invitados se sientan en esferas diseñadas especialmente experimentando una simulación de viaje en el tiempo.",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 por invitado"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Seta"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Coches Tobogán",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Montaña rusa con forma de toboganes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Puesto de manzanas de caramelo",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Un puesto de comida que vende manzanas de caramelo."
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Puesto manzanas de caramelo",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Un puesto con forma de manzana que vende manzanas de caramelo"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Servicios",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Lavabos hechos de hormigón prefabricado"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Servicios",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Lavabos en una cabina de forma de tronco"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Servicios",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Lavabos hechos de hormigón prefabricado"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Viaje de la metralleta",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Los usuarios van en parejas, en vagones decorados que giran alrededor de una réplica de una metralleta.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Los pasajeros montan en góndolas suspendidas por largos brazos que rotan hacia delante y hacia atrás",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Columna tótem"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Ayuntamiento"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Estilo juguete"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Coches Trabant",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Vagones con forma de automóviles Trabant",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Railes en curva"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Railes rotos"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Final de railes"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "División de railes"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Recta de railes"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Entrada al parque tradicional"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Tranvías",
+    "reference-description": "Old-timer replica trams",
+    "description": "Tranvías de estilo antiguo",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasajeros por tranvía"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Furgoneta"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Cofre del tesoro"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Cofre del tesoro"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Cofres del tesoro"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "El viaje en el trabuco",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Los pasajeros viajan suspendidos en dos grandes brazos, basados en el arma de asedio medieval.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasajeros"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Árbol"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Árboles"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Coches de choque Triceratops",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Los usuarios se pegan cornadas en los coches de choque Triceratops.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 usuario por coche"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Botes trilobite",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Los vagones con forma de trilobite se desplazan por una montaña rusa de giros cerrados y pronunciadas caídas, pasando por zonas de agua de un río tranquilo.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasajeros por bote"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Pieza de pared de bahía de suelo Tudor"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pieza de pared de suelo Tudor 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pieza de pared de suelo Tudor 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pieza de pared de suelo Tudor 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pieza de pared de suelo Tudor 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pieza de pared de suelo Tudor 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pieza de pared de suelo Tudor 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pieza de pared de suelo Tudor 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pieza de pared de suelo Tudor 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pieza de pared de suelo Tudor 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pieza de pared de suelo Tudor 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Pieza de pared de suelo Tudor 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Pieza de pared de suelo Tudor 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Pieza de pared de suelo Tudor 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Pieza de tejado Tudor 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Pieza de tejado Tudor 1 pieza de extensión"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Pieza de tejado Tudor 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Pieza de tejado Tudor 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Pieza de tejado Tudor 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Pieza de pared Tudor 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Pieza de pared Tudor 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Pieza de pared Tudor 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Pieza de pared Tudor 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Atracción acuática Tortuga",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Botes pequeños inflables redondos propulsados por un motor central controlado por los pasajeros",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasajeros por bote"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Los pasajeros se sientan en parejas rotando alrededor de tres largos brazos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasajeros"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Coches Tornado",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Montaña rusa con vagones capaces de giros a media altura",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Coches Tornado (invertidos)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Montaña rusa con vagones capaces de giros a media altura",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Montaña Rusa Tornado",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Montaña rusa amplia sobre vías de acero que efectúa varias inversiones",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Lugar del accidente del OVNI"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Estatua de unicornio"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Temática urbana"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Estilo urbano"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkiria"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkiria"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Montaña rusa de las valkirias",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Coches especialmente anchos que descienden verticalmente en la experiencia de caída libre definitiva.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por coche"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Señal 3D vertical"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Lanzadera Vertical Inversa",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Los pasajeros están sentados suspendidos bajo la vía",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Árbol trepador"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Coches de Época",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Vehículos con forma de coches antiguos que recorren una vía",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vehículo"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Danza de Virginia",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Vagones circulares que rebotan mientras corren sobre la pista de madera en zigzag",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcán"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcán con árboles pequeños"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Labiérnago de Voss"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Furgón"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Furgón"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Rueda de carromato"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Pared"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Arco de pared"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Paredes y tejados"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Nogal"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Estatua de Washington"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Avispa"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Temática acuática"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Chorro de agua"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Surtidor de agua"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Triciclos de Agua",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Triciclos acuáticos a pedales con ruedas gigantes",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 pasajeros por triciclo"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Estilo acuático"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Cascada"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tejado de entramado pintado"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tejado de entramado pintado"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tejado de entramado pintado"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Pared de entramado pintado"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Grupo de armas"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Sauce llorón"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Ruedas"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Barril de whisky"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Barriles de whisky"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Obispo blanco"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Rey blanco"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Caballero blanco"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Peón blanco"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Álamo blanco"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Reina blanca"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Torre blanca"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Temática salvaje oeste"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Estilo salvaje oeste"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Esquina de tejado cóncavo esculpida por el viento"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Esquina de pared cóncava esculpida por el viento"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Esquina de pared cóncava esculpida por el viento"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Esquina de tejado convexo esculpida por el viento"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Esquina de pared convexa esculpida por el viento"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Esquina de pared convexa esculpida por el viento"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pieza de suelo esculpido por el viento"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pieza de suelo esculpido por el viento"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sección intermedia de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sección intermedia de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sección intermedia de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sección intermedia de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Cima de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Cima de formación de roca esculpida por el viento"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pieza de tejado plano esculpido por el viento"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pieza de tejado plano esculpido por el viento"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pieza de tejado plano esculpido por el viento"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de pared esculpida por el viento"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de pared esculpida por el viento"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pieza de pared esculpida por el viento"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pieza de pared esculpida por el viento"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pieza de pared esculpida por el viento"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pieza de pared esculpida por el viento"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Molino de viento"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Ventana"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Ventana"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Ventana"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Brujas preparando caldero",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Un puesto en el que se vende caldo tradicional"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Brujas alrededor del caldero"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Atracción Gusano Gorgojo",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Trenes formados por pequeños vagones con forma de gorgojo",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasajeros por vagón"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Temática fantástica"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Puesto de sopa wonton",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Un puesto que vende sopa wonton"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Valla de madera con enredaderas"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Valla de madera con enredaderas"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Valla de madera con enredaderas muertas"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Valla de madera con enredaderas muertas"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Valla de madera con enredaderas muertas"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Valla de madera con plantas carnívoras"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Madera"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Bloque de madera"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Carro de madera"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Valla de madera"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Valla de madera"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Sendero de madera"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Poste de madera"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Poste de madera"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Poste de madera"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Poste de madera"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Tren Montaña Rusa de Madera",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Vagones de madera",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Montaña Rusa Madera (6 asi.)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Montaña rusa de madera con asientos acolchados y barras de sujección",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Mt. Rusa Madera (6 as., inv.)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Trenes de madera de montaña rusa con asientos acolchados y barras de sujección, mirando los asientos hacia atrás",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasajeros por vagón"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Coches Madera Fricción Lat.",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Vagones básicos para la montaña rusa de fricción lateral",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Señal de madera"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Pared de madera"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Pared de madera"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Pared de madera"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Pared de madera"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Hidroavión naufragado"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "1 Montaña del Taxi",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Una montaña rusa gigante capaz de caídas suaves y subidas de más de 300 pies",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasajeros por vagón"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Tejo"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Cebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Estatua de Zeus"
+  }
+}

--- a/objects/fi-FI.json
+++ b/objects/fi-FI.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Karkkityyli"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 matkustajaa per auto"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptiläinen tyyli"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasiatyyli"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Hempeätyyli"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Kauhutyyli"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Jäätyyli"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Viidakkorummut-tyyli"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marssilainen tyyli"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mekaaninen tyyli"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Keskiaikainen tyyli"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modernityyli"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Ei sisäänkäyntiä"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Itämainen tyyli"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Merirosvotyyli"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Kivityyli"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Kivityyli 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Kivityyli 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Lumityyli"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Avaruustyyli"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Kesätyyli"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Teknotyyli"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Lelumaatyyli"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Kaupunkimainen tyyli"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Vesityyli"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Villilänsityyli"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/fr-FR.json
+++ b/objects/fr-FR.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "Panneau 'Goliath'"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Panneau 'Méduse'"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Panneau 'Nitro'"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Panneau 'Texas Giant'"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Voitures de course des années folles",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Les passagers font la course à bord de karts représentant des voitures des années folles",
+    "reference-capacity": "Single-seater",
+    "capacity": "Monoplace"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Voiture des années 50"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Voiture des années 50"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Fusée 1950"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Fusée 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Les trains de montagnes russes inversées sont propulsés hors de la station puis, après avoir atteint une pointe verticale, redescendent vers la station et entament une nouvelle montée verticale en sens inverse",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "Cinéma 3D",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinéma diffusant des films en 3D dans un bâtiment en forme de sphère géodésique",
+    "reference-capacity": "20 guests",
+    "capacity": "20 spectateurs"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "Panneau horizontal 3D"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "Panneau 3D"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Montagnes russes inversées",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Les passagers parcourent des boucles géantes, des virages et des grandes descentes en piqué, installés sur des sièges suspendus à la voie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Maxi-bobsleigh",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Les passagers descendent un parcours alambiqué à bord d'une grande voiture en forme de bobsleigh dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Oeuvre d'art aborigène"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Tuile aborigène unie"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Oeuvre serpent aborigène"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Oeuvre esprit aborigène"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstrait"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Thème abstrait"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Eau d'acide verdâtre"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Cheminée de volcan actif"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Eléphant d'Asie adulte"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Panda adulte"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Entrée du parc africain"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Thème Afrique"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Voiture propulsée dans les airs",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Trains monorail sur le thème de l'aviation",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Trains monorail thématiques composés de voitures aérodynamiques à l'avant et à l'arrière",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagers par voiture"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Pin d'Alep"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Vestiges extraterrestres"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Vestiges extraterrestres"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Plante extraterrestre"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Plante extraterrestre"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Grand voyant lumineux extraterrestre"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Petit voyant lumineux extraterrestre"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande structure extraterrestre"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande structure extraterrestre"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande structure extraterrestre"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Petite structure extraterrestre"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Petite structure extraterrestre"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Petite structure extraterrestre"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Bas de la tour extraterrestre"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Milieu de la tour extraterrestre"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Haut de la tour extraterrestre"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Arbre extraterrestre"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Arbre extraterrestre"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Arbre alligator"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Ballon de football américain"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Ballon de football américain"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Casque de foot US"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Trains vapeur",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trains miniatures comprenant une réplique de locomotive à vapeur et des petits wagons en bois avec des toits en tissu",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagers par wagon"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Train spacieux disposant d'une simple barre de protection au niveau des jambes",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cuit à la broche"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Ballons 1"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Feu de camp animé"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Automate : l'oeil qui voit tout"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Automate : Argonaute"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Automate : Argonaute"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Automate : Argonaute"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Automate : astronaute"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Automate : homme des cavernes allumant un feu"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Automate : vierge enchaînée"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Automate : membre de guilde"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Automate : le Chevalier noir"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Automate : le Chevalier noir"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Automate : libellules"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Automate : aigle en cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Automate : extraterrestre hostile"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Automate : extraterrestre hostile"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Automate : extraterrestre hostile"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Automate : pompier"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Automate : canon tirant des boulets"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Automate : gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Automate : extraterrestre sympa"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Automate : extraterrestre sympa"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Automate : extraterrestre sympa"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Automate : chevalier"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Automate : chevalier"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Automate : la Méduse"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Automate : officier de police"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Automate : Robin des Bois"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Automate : armée de squelettes"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Automate : armée de squelettes"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Automate : armée de squelettes"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Automate : shérif de l'espace"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Automate : stégosaure"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Automate : T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Automate : tricératops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Automate : roi saluant la foule"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Automate : attaque du scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Automate : attaque du scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Automate : ptérodactyle en vol"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Thème Antarctique"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antilope femelle"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antilope mâle"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Couple d'antilopes"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Tableau de bord anti-gravité"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Tableau de bord anti-gravité"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Cible de tir à l'arc"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Cyprès"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Section de virage art déco"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Virage art déco avec grille"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Virage art déco avec grille"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Virage art déco avec fenêtres"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Virage art déco avec fenêtres"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Virage art déco avec fenêtres"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Restaurant art déco",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Un restaurant proposant des pâtes et de la limonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Section de virage inversé art déco"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Section de virage inversé art déco"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Section de toit art déco"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Section de virage haut art déco"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Section de virage haut art déco"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Section de virage haut art déco"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Section haute art déco"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Section haute art déco"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Section de mur art déco"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Mur art déco avec porte"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur art déco avec grille"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur art déco avec grille"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur art déco avec grille"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur art déco avec grille"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Mur art déco avec fenêtres"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Mur art déco avec fenêtres"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Trains articulés",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Trains composés de voitures de petite taille disposées en une seule rangée et dévalant des montagnes russes",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Allée en bois"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Frêne avec des nymphes"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Thème Asie"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Peuplier"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Statue de Atlas"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Entrée du parc océanien"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Thème Australie"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Fontaine australienne 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Fontaine australienne 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Voitures de montagnes russes en forme d'automobile",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Pieuvre géante de film de série B"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Araignée géante de film de série B"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Araignée géante de film de série B",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une araignée géante de film de série B.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Eléphanteau d'Asie"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Bébé panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Raquette de badminton"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Raquette de badminton"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterne chinoise"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterne chinoise"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Stand de ballons",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Boutique de souvenirs vendant des ballons gonflés à l'hélium"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Haie de bambous"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Plinthe de bambou"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Toit de bambou"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Toit de bambou"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Toit de bambou"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Pousses de bambou"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Cloison de bambou"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Membre de groupe de rock"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Membre de groupe de rock"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Membre de groupe de rock"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Membre de groupe de rock"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Banque"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Attaque de l'entrepôt",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Les passagers parcourent des boucles géantes, des virages et des grandes descentes en piqué, installés sur des sièges suspendus à la voie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Tonneau"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Tonneau"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Tonneau"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Tonneau"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Bloc de base"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Bloc de base"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Bloc de base"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Bloc de base"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Le bélier",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Pâtes au boeuf",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Boutique vendant des pâtes au boeuf"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Banc"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Banc"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Banc"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Bancs"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Montagnes Tigre du Bengale",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Montagnes russes avec inversions à 360°",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Vélos",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Des vélos spéciaux parcourent une voie monorail métallique",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 personne par vélo"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben et le Parlement anglais"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Grande géosphère"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motard"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Fou noir"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Taxis londoniens",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Véhicules automobiles en forme de taxis londoniens",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "La peste noire",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Les passagers descendent un parcours alambiqué à bord d'une grande voiture en forme de rat dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Roi noir"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Cavalier noir"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Pion noir"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Peuplier noir"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Reine noire"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Tour noire"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob du fin fond de la galaxie",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Une cabine thématique rotative qui se hisse le long d'une immense tour",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Bloc"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Bloc"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Les passagers descendent un parcours plein de virages à bord d'une voiture en forme de bobsleigh dirigée uniquement par les courbes et l'inclinaison de la voie semi-circulaire",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Marmite"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Os"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Clôture d'ossements"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Os"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Montagnes boomerang",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brique"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Mur de brique"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Mur de brique"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Mur de brique"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Boîte à lettres anglaise"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Cabine téléphonique anglaise"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Statue cassée"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Roue cassée"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Allée en bitume marron"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Allée pavée marron"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Puits de pétrole bouillonnant"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Seau"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Bâtiment"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Bâtiment"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Montagnes Shinkansen",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Montagnes russes avec voitures en forme de TGV japonais",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Roseaux"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bateaux-tamponneurs",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Petits canots pneumatiques de forme circulaire alimentés par un moteur central que contrôlent les passagers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagers par bateau"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Bouée"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Bouée"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Bar burger",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Bâtiment en forme de hamburger vendant... des hamburgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Buisson"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Papillon"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Auvent de hutte"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Auvent de hutte"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pan de toit de hutte"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pan de toit de hutte"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pan de toit de hutte"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Toit de hutte"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pan de mur de hutte"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Palmiste"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Orme"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Palmier des Canaries"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Bonbon"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Bonbon"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Bonbon"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Sucre d'orge"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Arbrabonbon"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Arbrabonbon"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Arbrabonbon"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Bonbon-ville"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Barbe à papa",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Bâtiment en forme de barbe à papa vendant... des barbes à papa"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Canon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Canon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Boulets de canon"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoë",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Longs canoës que les passagers dirigent en pagayant",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagers par canoë"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Toit en tissu"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Toile"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnaval - Voitures papillons",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Voitures de montagnes russes en forme de chars papillons de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnaval - Voitures grenouilles",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Voitures de montagnes russes en forme de chars grenouilles de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnaval - Voitures lézards",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Voitures de montagnes russes en forme de chars lézards de carnaval",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Puits à chariot"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Distributeur",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Un D.A.B. (Distributeur automatique de billets) permet aux visiteurs de renflouer leur porte-monnaie"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Château (marron)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Château (gris)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Section de virage du château"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Section de virage du château"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Entrée du château"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Virage inversé du château"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Herse du château"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Remparts du château"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Virage des remparts du château"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Virage des remparts du château"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Virage des remparts du château"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Virage inversé des remparts du château"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Tour de château"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Section de virage du donjon"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Section de virage du donjon"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Section de croisement du donjon"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Section droite du donjon"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Section en T du donjon"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Section en T du donjon"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Mur de château"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Mur du château"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Mur du château"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Mur du château"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Crâne de vache"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Sapin du Caucase"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Chaudron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Entrée de la caverne"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Voitures des hommes des cavernes",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Les passagers font la course à bord de karts préhistoriques",
+    "reference-capacity": "Single-seater",
+    "capacity": "Monoplace"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cèdre du Liban"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Le cerbère",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Retenus uniquement par les jambes dans des voitures confortables, les visiteurs effectuent des descentes géantes le long d'un tracé sinueux et décollent de leur siège en haut des collines",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Voiture télésiège",
+    "reference-description": "Open cars for chairlift",
+    "description": "Voitures ouvertes pour télésiège",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Bloc en échiquier"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Échiquier"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Chat-chars",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Véhicule à propulsion en forme de chats se déplaçant sur une route plane",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passagers par chat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Nuggets",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Boutique vendant des nuggets au poulet"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Cèdre de Chine"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Dragon chinois"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "La tête du dragon",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Auto-tamponneuses électriques programmées",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Jonque chinoise",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Un bateau attaché à un bras avec contrepoids à l'autre côté effectue un tour complet à 360 degrés",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Friterie",
+    "reference-description": "A hut selling chips",
+    "description": "Cabane vendant des frites"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Stand de frites",
+    "reference-description": "A stall selling chips",
+    "description": "Boutique vendant des frites"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Barre au chocolat"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Allée circuit"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Cirque",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Grand chapiteau dans lequel se produit un spectacle d'animaux",
+    "reference-capacity": "30 guests",
+    "capacity": "30 spectateurs"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Cirque"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classique/Romain"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Panneau classique"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Thème classique/romain"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Obélisque de Cléopâtre"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Vigne grimpante"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Horloge"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Arbre en forme de trèfle"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Bateau-montagne",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Voitures de montagnes russes en forme de bateau",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagers par bateau"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Tasse de café",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Café",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Café de style art déco proposant des tasses de café"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Roue dentée"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Roue dentée"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Roue dentée"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Roue dentée"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Bonbon cola"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Genévrier"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Chêne"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "If"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Montagnes compactes inversées",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Les passagers sont assis par deux, suspendus à la voie tandis qu'ils zigzaguent et sont chahutés lors d'inversions serrées",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Le condor",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Les passagers sont couchés à plat ventre dans une voiture en forme de condor se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Montagnes du congre",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Montagnes russes compactes et métalliques sur lesquelles le train en forme d'anguille effectue tire-bouchons et boucles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Haie de conifères"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Haie de conifères"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Coin de tapis roulant"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Coin de tapis roulant en marche arrière"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Fin de tapis roulant"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Côte de tapis roulant"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Ligne droite de tapis roulant"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Stand à cookies",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Boutique vendant des cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Mec cool"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Montagnes russes tire-bouchon",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Montagnes russes compactes dont les voies en acier prennent la forme de tire-bouchons et de boucles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pan de toit ondulé"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Sol en tôle ondulée"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Toit en tôle ondulée"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Mur en tôle ondulée"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pan de mur ondulé"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Pin corse"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cow-boy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cow-boy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Allée pavée"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Thème Terreur"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Bateaux en forme de crocodiles parcourant un tube aquatique dont les pentes abruptes auront pour effet de tremper les passagers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Maison biscornue",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Bâtiment constitué de pièces déformantes et de couloirs tournants destinés à désorienter ceux qui s'y aventurent",
+    "reference-capacity": "5 guests",
+    "capacity": "5 personnes"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Fontaine de Cupidon"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Bloc courbe"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Bloc courbe"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pan de mur de terre arrondi"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pan de mur de terre arrondi"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pan de mur de terre arrondi"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Toit courbe"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Toit courbe"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Mur courbe"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Mur courbe"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Musique perso 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Musique perso 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Le cyclope",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Les passagers sont installés dans l'œil du cyclope",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Statue du cyclope"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Lampadaire marguerite"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Tour de barrage"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Entrée médiévale"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Thème du Moyen Age"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Section de toit du virage du village médiéval"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Section de toit du virage du village médiéval"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Section de toit inversé du village médiéval"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Section de toit inversé du village médiéval"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Section basse de virage du village médiéval"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Section basse de mur du village médiéval"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Section de toit du village médiéval"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Section de toit du village médiéval"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Section de toit du village médiéval"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Section de toit du village médiéval"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Toit avec cheminée du village médiéval"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Section haute de virage du village médiéval"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Section haute de mur du village médiéval"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Section haute de mur du village médiéval"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Section haute de mur du village médiéval"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Section haute de mur du village médiéval"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Section haute de mur du village médiéval"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Jardinière du village médiéval"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Jardinière du village médiéval"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Toit de jardinière du village médiéval"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Toit de jardinière du village médiéval"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Toit de jardinière du village médiéval"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Toit de jardinière du village médiéval"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Taverne médiévale"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Arbre mort"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Arbre mort"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Arbre mort"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Ballade en sampan",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Bateau de pêche décoratif, propulsé par les passagers à l'aide de pagaies",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagers par bateau"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Chariot à diamants"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamant",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Puits à diamants"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Arbre diamant"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Didgeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Canotube",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Les passagers descendent un tube semi-circulaire ou entièrement fermé à bord d'un canot pneumatique",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passagers par canot"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaure"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaure"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaure"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaure"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaure"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "OEuf de dinosaure",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Les passagers sont assis par deux dans des sièges thématiques et font le tour d'une maman dinosaure animée.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Boue"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Allée en terre"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Autos tamponneuses",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Autos tamponneuses électriques",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Auto-tamponneuse"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dauphin",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Véhicules individuels en forme de dauphins que les visiteurs peuvent conduire eux-mêmes",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passager par véhicule"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Fontaine dauphin"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Statue de dauphin"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Porte"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Porte"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Porte"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Manège à deux étages",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Manège traditionnel de chevaux de bois à deux étages",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Tour d'observation 2-ponts",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Cabine rotative d'observation à double pont qui se hisse au sommet d'une grande tour",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Beignetterie",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Boutique vendant des beignets en forme d'anneaux"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Base de grande tour terne"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Base cassée de grande tour terne"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Section moyenne de grande tour terne"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Sommet de grande tour terne"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Pièce de dôme terne 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Pièce de dôme terne 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Pièce de dôme terne 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Pan de toit terne 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Pan de toit terne 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Pan de toit terne 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Pan de toit terne 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Base de petite tour terne"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Base de petite tour de dôme terne"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Section moyenne ou sommet de petite tour terne"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Pièce de montée terne 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Pièce de montée terne 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Pan de mur terne 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Pan de mur terne 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Pan de mur terne 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Pan de mur terne 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Pan de mur terne 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Pan de mur terne 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Pan de mur terne 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Pan de mur terne 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Pan de mur terne 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Pan de mur terne 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Pan de mur terne 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon à l'attaque"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Montagnes du dragon",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Montagnes russes avec voitures en forme de dragon",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "La Libellule",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Les passagers voyagent dans une voiture spécialement conçue, suspendue à un rail, et qui se balance dans les virages",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Buvette",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Boutique en forme de canette vendant des boissons gazeuses"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Statue de l'île de Pâques 1"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Colonne égyptienne"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Statue égyptienne"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Panneau égyptien"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Thème égyptien"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Mur égyptien"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptien"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Tour Eiffel"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Clôture électrique"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Clôture électrique cassée"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Section de virage de clôture électrique"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Section de virage de clôture électrique inversé"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Clôture électrique illuminée"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Fontaine éléphant"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Chariot vide"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emeu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Grande roue rotative comprenant des nacelles qui tournent sur elles-mêmes avant d'être levées par un bras",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Thème Europe"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Mélèze"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Entrée du parc européen"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Samouraï du Mal"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Œufs de Fabergé",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Navette inversée",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Les passagers sont assis par deux, regardant tantôt devant, tantôt derrière, tandis qu'ils zigzaguent et sont chahutés lors d'inversions serrées",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Orgue champ de foire"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Imaginaire"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Outils de ferme"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Bouddha heureux"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Table forestière"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Clôture"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Clôture"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Clôture"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Clôtures et façades"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Grande roue",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Grande roue rotative constituée de sièges en plein air",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Signal lumineux"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Cerf-volant de combat",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Auto-tamponneuses des chevaliers",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Les passagers participent à un tournoi médiéval d'auto-tamponneuses",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Les feux de Bengale",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Grande roue rotative comprenant des nacelles qui tourne sur elle-même avant d'être levée par un bras",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Bouche d'incendie"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Infirmerie",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Endroit où l'on prodigue les premiers soins aux visiteurs malades"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Trou de pêche"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Statue réparée"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flammes"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamant rose mangeant"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamant rose observant"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamant rose se nettoyant"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Train sans fond",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Grand train de montagnes russes sans plancher donnant une sensation de plein-air aux passagers le long d'une voie alambiquée dotée de plusieurs inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Fleur"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Petits canots pneumatiques en forme de fleurs alimentés par un moteur central que contrôlent les passagers",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passager par voiture"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "T-shirts Flower Power",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Magasin proposant des T-shirts de hippies"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Bateau volant",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Des voitures en forme de bateau franchissent des virages serrés et des descentes abruptes, et plongent dans des zones aquatiques",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagers par bateau"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Montagnes russes volantes",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Installés dans des sièges confortables, les passagers sont suspendus à une voie alambiquée leur donnant le sentiment de voler",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Soucoupes volantes",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Aéroglisseurs auto-guidés",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Ballon de football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Coupe du monde",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Train de montagnes russes suspendu constitué de voitures en forme de ballon de football qui se balancent librement dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "L'arbre du fruit défendu"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Arbres forestiers"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontaine"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontaine"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Epingle à cheveux inversée",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Des voitures individuelles placées sous la voie zigzaguent à travers les virages en épingle à cheveux et les chutes abruptes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Poule aux oeufs d'or",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Boutique vendant des barquettes de poulet"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Traiteur chinois",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Boutique vendant des pâtes de riz"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Bonbon aux fruits"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Bonbon aux fruits"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Arbre fruitier"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Arbre fruitier"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Glacier",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Boutique thématique vendant des glaces fruitées"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Maison du rire",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Bâtiment contenant des murs et des sols mouvants visant à désorienter les visiteurs",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visiteurs"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Pâtisserie",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Boutique vendant des gâteaux"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Thème du futur"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Entrée du parc futuriste"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Potence"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Voiture de gangster",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Train sur le thème des gangsters des années folles propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversions renversantes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Boutique généraliste"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Tranquille"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Fontaine géométrique"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Sculpture géométrique"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Sculpture géométrique"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Sculpture géométrique"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Sculpture géométrique"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Sculpture géométrique"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Coin de toit plat géorgien"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Bord de toit plat géorgien 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Bord de toit plat géorgien 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Pan de mur de rez-de-chaussée géorgien 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Pan de mur de rez-de-chaussée géorgien 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Pan de mur de rez-de-chaussée géorgien 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Pan de mur de rez-de-chaussée géorgien 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Pan de mur de rez-de-chaussée géorgien 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Pan de mur de rez-de-chaussée géorgien 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Pan de toit géorgien 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Fin de toit géorgien 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Fin de toit géorgien 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Pan de toit géorgien 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Pan de toit géorgien 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Pan de toit géorgien 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Pan de toit géorgien 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Pan de toit géorgien 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Pan de toit géorgien 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Pan de mur géorgien 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Pan de mur géorgien 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Pan de mur géorgien 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Pan de mur géorgien 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Pan de mur géorgien 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Pan de mur géorgien 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geyser"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Train fantôme",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Des voitures en forme de monstres sont propulsées à travers plusieurs niveaux de décors et d'effets spéciaux effrayants",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Guitare basse géante"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Haricot géant"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Haricot géant"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Thème Bonbon"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Carotte géante"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Empreinte de pas géante de dinosaure"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Batterie géante"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Fougère géante"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Thème Jardin géant"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Pelouse géante"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Guitare géante"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Arbre géant de la mangrove"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Panda géant"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Citrouille géante"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Flocon de neige géant"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Flocon de neige géant"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Flocon de neige géant"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga montagnes russes",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Montagnes russes géantes proposant des chutes régulières depuis des collines dépassant les 100 mètres d'altitude",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Girafe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Girafe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Statue de girafe"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Toit en verre"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Toit en verre"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Façade vitrée"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Façade vitrée"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Façade vitrée"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Façade vitrée"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Karting",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Karts individuels constitués de moteurs à essence",
+    "reference-capacity": "single-seater",
+    "capacity": "1 passager par kart"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Lama d'or"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Statue d'or 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Statue d'or 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Bouddha d'or"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Toison d'or"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Cyprès doré d'Hinoki"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Samouraï du Bien"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorille",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Train de montagnes russes suspendu constitué de voitures en forme de gorille qui se balancent librement dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Herbe"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Touffes d'herbe"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Pierre tombale"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Pierre tombale"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Pierre tombale"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Pierre tombale"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monument aux morts"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monument aux morts"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monument aux morts"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Section du mur avant de la Grande Muraille de Chine"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Section de mur arrière de la Grande Muraille de Chine"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Section de mur avec montée de la Grande Muraille de Chine"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Tourelle en coin de la Grande Muraille de Chine"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Tourelle droite de la Grande Muraille de Chine"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Grand requin blanc",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Train spacieux disposant d'une simple barre de protection au niveau des jambes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Allée en bitume vert"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Eau verte"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Allée pavée verte et marron"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Allée pavée grise"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grille (vert)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grille (violet)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grille (rouge)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grille (jaune)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Danseur émérite"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "Navire HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Statue d'Hadès"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Palais des glaces",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Bâtiment contenant des miroirs déformant l'apparence des visiteurs",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visiteurs"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Quai du port"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Mur du port"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Section de virage du mur du port"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Section de virage du mur du port"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Mur du port avec quai"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Mur du port avec matériel de pêche"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur du port avec amarres"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur du port avec amarres"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur du port avec amarres"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur du port avec amarres"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Les harpies",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Les passagers franchissent une voie alambiquée pleine d'inversions, couchés à plat ventre ou sur le dos, et maintenus par des harnais spéciaux",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Chapelier",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Boutique de souvenirs vendant de grands chapeaux en mousse"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Maison hantée",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Grand bâtiment thématique rempli de couloirs effrayants et de salles terrifiantes",
+    "reference-capacity": "15 guests",
+    "capacity": "15 personnes"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Prison hantée",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Bâtiment contenant des cachots et des mannequins de prisonniers célèbres visant à effrayer les visiteurs",
+    "reference-capacity": "16 guests",
+    "capacity": "16 visiteurs"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Maison fantôme",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Des voitures à propulsion parcourent les étages d'un bâtiment bourré d'effets spéciaux et de décors",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Meule de foin"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Arbre en coeur"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Sol des thermes divins"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Bassin des thermes divins"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Virage du bassin des thermes divins"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Bord du bassin des thermes divins"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Marches du bassin des thermes divins"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Toit des thermes divins"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Toit des thermes divins"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Toit des thermes divins"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Toit des thermes divins"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Fenêtre des thermes divins"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arche des thermes divins"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arche des thermes divins"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arche des thermes divins"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architecture des thermes divins"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architecture des thermes divins"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architecture des thermes divins"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architecture des thermes divins"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontaine des thermes divins"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontaine des thermes divins"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escalier des thermes divins"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escalier des thermes divins"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Haie"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Haie"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Héliport"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercule"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Arbre d'Hiba"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippopotame 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippopotame 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippopotame",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Les passagers sont dans un sous-marin immergé suivant un itinéraire",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passagers par sous-marin"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Robinier"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horreur"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Cheval"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Statue de cheval"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Statue de cavalier"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Rodéo montagnes",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Véhicule en forme de cheval parcourant des montagnes russes sur une voie monorail",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 passagers par cheval"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Chocolat chaud",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Boutique vendant des chocolats chauds"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot dogs",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Boutique vendant des hot-dogs"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Bolide"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Bolide"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Bolide extrême",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Après avoir été propulsé dans les airs, le train accélère sur une voie verticale, passe le sommet, et retombe de l'autre côté en direction de la station",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Maison"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Moto sur coussin d'air",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Les passagers prennent place à bord de véhicules en forme de motos qui dévalent une voie monorail",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagers par véhicule"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Voiture sur coussin d'air",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "La technologie de lévitation magnétique a été intégrée pour donner l'illusion de voitures futuristes sur coussins d'air",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto sur coussin d'air en vol"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto sur coussin d'air en vol"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto sur coussin d'air à l'arrêt"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto sur coussin d'air à l'arrêt"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Aéroglisseur",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Les passagers sont installés dans un aéroglisseur futuriste se balançant d'un côté à l'autre dans les virages",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Voiture sur coussin d'air en vol"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Voiture sur coussin d'air en vol"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Voiture sur coussin d'air à l'arrêt"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Voiture sur coussin d'air à l'arrêt"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Traîneau husky",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Véhicules en forme de traîneaux suivant un itinéraire sur piste",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par traîneau"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Train super-tornado",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Train spacieux disposant d'une simple barre de protection au niveau des jambes",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Train sup.-torn. (grdes voit)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "4 voitures disposées de chaque côté avec des sièges relevés et des barres de protection simples",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Super-montagnes",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Montagnes russes non inversées, constituées de grandes boucles très rapides et que les passagers, uniquement retenus par des barres de protection placées au niveau des jambes, franchissent à bord de trains confortables",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Glace"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Glace"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Cône de glace",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Boutique vendant des cônes de glace"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Cube de glace"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Formation de glace"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Formation de glace"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Palais de glace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Entrée du parc de glace"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Base de tuyau de glace"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Section de tuyau de glace"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ventilation de tuyau de glace"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Toit de glace"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Mur de glace"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Glace"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Tonneaux glacés"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Tonneaux glacés"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Tonneaux glacés"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Salon de thé glacé",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Boutique vendant des thés glacés"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Toit d'igloo"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur d'igloo"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur d'igloo"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Mur igloo"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulsion inversée",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Les trains de montagnes russes à impulsion sont propulsés hors de la station puis, après avoir atteint une pointe verticale, redescendent vers la station et entament une nouvelle montée verticale en sens inverse",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Cèdre d'encens"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Drapeau de soie indienne"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Drapeau de soie indienne"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Drapeau de soie indienne"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Drapeau de soie indienne"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Drapeau de soie indienne"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Section de toit de virage industriel"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Section de toit de virage industriel"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Section de toit industriel"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Section de mur de virage industriel"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Section de mur de virage industriel"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Série de murs industriels"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Série de murs industriels"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Série de murs industriels"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Série de murs industriels"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur industriel avec porte"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur industriel avec fenêtre"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Point info",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Boutique proposant des cartes du parc et des parapluies"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Fer"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Cyprès d'Italie"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Police italienne",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Voitures de montagnes russes en forme de jaguar.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Cerisier du Japon en fleur"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Cerisier du Japon"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Clôture japonais"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Clôture japonais"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Clôture japonais"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Entrée du parc japonais"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Pin du Japon"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Toit japonais"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Toit japonais"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Toit japonais"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Drapeau de soie japonaise"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Boule-de-neige du Japon"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membre d'un orchestre de jazz"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membre d'un orchestre de jazz"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membre d'un orchestre de jazz"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membre d'un orchestre de jazz"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Bonbon"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Dragée"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Mur en dragées"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avion à réaction"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avion à réaction"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avion à réaction"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Sac à dos à propulsion",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Les passagers sont installés dans un véhicule propulsé sur une paroi verticale",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagers par voiture"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Avion à réaction",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Des voitures individuelles descendent des pentes régulières en virage",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Jet skis individuels que les visiteurs peuvent conduire eux-mêmes",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passager par véhicule"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Joute médiévale",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Les passagers voyagent à bord de véhicules en forme de chevaux le long d'une voie monorail",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagers par véhicule"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Fontaines à jets"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Boules de neiges sautantes"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Clôture de jungle"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Panneau jungle"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Thème Jungle"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Arbre jungle 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Arbre jungle 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Arbre jungle avec léopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Arbre jungle avec lianes"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Tambours de la jungle"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Jonque"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Panneau jurassique"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Thème Jurassique"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassique"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangourou"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Orque",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Les passagers sont dans un sous-marin immergé suivant un itinéraire",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passagers par sous-marin"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Voiture destinée à la Chute libre renversée",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagers par voiture"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Base de grande tour du Kremlin"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Section moyenne de grande tour du Kremlin"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Sommet de grande tour du Kremlin"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Pièce de dôme du Kremlin 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Pièce de dôme du Kremlin 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Pièce de dôme du Kremlin 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Pan de toit du Kremlin 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Pan de toit du Kremlin 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Base de petite tour du Kremlin"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Section moyenne de petite tour du Kremlin"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Base de petite tour de dôme du Kremlin"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Pan de mur de montée du Kremlin 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Pan de mur de montée du Kremlin 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Pan de mur du Kremlin 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Pan de mur du Kremlin 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Pan de mur du Kremlin 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Pan de mur du Kremlin 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Pan de mur du Kremlin 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Pan de mur du Kremlin 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Pan de mur du Kremlin 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Pan de mur du Kremlin 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Moteur à induction linéaire",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Train de montagnes russes propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversion renversantes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Train coccinelle",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Train de montagne russe avec des voitures en forme de coccinelle",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampadaire"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampadaire"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampadaire"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampadaire"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampadaire"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Clôture à mammouths très courbée"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Clôture à mammouths très courbée"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Grand orme"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Grande clôture à mammouths"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Grande clôture à mammouths"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Grand cratère météoritique"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Grand chêne"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Arbre forêt équatoriale 1 4"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Grand cratère météoritique rouge"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Grande cheminée fumante"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Grand haut-parleur"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Grand totem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Barrière de laser"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Virage de la barrière de laser"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Chute libre lancée",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Voiture lancée pneumatiquement au sommet d'une grande tour métallique puis lâchée en chute libre",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Cyprès de Lawson"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Mini montagnes suspendues",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Les passagers sont couchés à plat ventre dans une voiture spéciale se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passager par voiture"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Mont. russes - posit. couchée",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Les passagers franchissent une voie alambiquée pleine d'inversions, couchés à plat ventre ou sur le dos, et maintenus par des harnais spéciaux",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Stand de limonades",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Un stand thématique proposant de la limonade fraîche, à l'ancienne."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Limonadier",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Boutique vendant des limonades rafraîchissantes"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Ascenseur",
+    "reference-description": "Steel lift cabin",
+    "description": "Ascenseur montant ou descendant un à un les étages d'une tour verticale",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lys"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousines",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Montagnes russes avec voitures en forme de limousine",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Voitures de montagnes russes en forme de lion.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Poubelle"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Poubelle"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Poubelle"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Poubelle"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Cabane en rondins"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Rondins"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pan de toit de cabane en rondins"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pan de toit de cabane en rondins"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pan de toit de cabane en rondins"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Cheminée de cabane en rondins"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pan de mur de cabane en rondins"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Train-bûche",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Train de montagnes russes composé de petites voitures en forme de bûche",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Rondins"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Bûches",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Bateaux en forme de bûches géantes parcourant un tube aquatique dont les pentes abruptes auront pour effet de tremper les passagers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagers par bateau"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Sucette"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Peuplier de Lombardie"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Trains de montagnes russes",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Trains de montagnes russes avec des barres de protection au niveau des jambes et capables de passer dans des boucles verticales",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pièce de colonne de cité perdue"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pièce de colonne de cité perdue"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pan de toit plat de cité perdue"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pan de toit plat de cité perdue"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pan de toit plat de cité perdue"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pièce d'escalier de cité perdue"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pièce d'escalier de cité perdue"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pièce d'escalier de cité perdue"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pièce d'escalier de cité perdue"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pièce d'escalier de cité perdue"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Coin de mur de cité perdue"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Coin de mur de cité perdue"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Coin de mur de cité perdue"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Coin de mur de cité perdue"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pan de mur de cité perdue"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Petit buisson"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Proue de paquebot de luxe"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Section médiane de paquebot de luxe"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Poupe de paquebot de luxe"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Coup de massue",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Les passagers sont assis sur un siège thématique attaché à un bras articulé motorisé.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 visiteur par siège"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Tapis volant",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Grande voiture en forme de tapis volant qui monte et descend de manière cyclique, au bout de 4 bras",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Armure magique"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Casque magique"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Bouclier magique"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Epée magique"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Arc du palais du maharajah 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Arc du palais du maharajah 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Dôme du palais du maharajah"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pièce du palais du maharajah"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pièce du palais du maharajah"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pièce du palais du maharajah"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Pied de la tour du palais du maharajah"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Colonne de la tour du palais du maharajah"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Sommet de la tour du palais du maharajah"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Train à vapeur",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Train à vapeur miniature composé d'une réplique de locomotive à vapeur et d'un tender, tirant des voitures à toit de bois",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Le canard mandarin",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Bateau en forme de cygne, propulsé par les passagers avant à l'aide d'un pédalier",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagers par bateau"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Arbre forêt équatoriale 1 3"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Raie manta",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Grand bateau qui serpente le long d'une large voie navigable, monte sur des pentes grâce à un tapis roulant, et descend à toute vitesse de l'autre côté, éclaboussant allègrement les passagers",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagers par bateau"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Toit de marbre"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Toit de marbre"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Toit de marbre"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Toit de marbre"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Danseur Mardi Gras"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Danseur Mardi Gras"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquise"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Guimauve"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Guimauve"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martien"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Bâtiment alien"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Objet alien"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Objet alien"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Objet alien"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Objet alien"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Objet alien"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Thème Alien"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Mur alien"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Alien"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labyrinthe",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Haies ou murs hauts de 2 mètres parmi lesquels les marcheurs déambulent à la recherche de la sortie"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Soupière-boulettes",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Boutique vendant des soupes aux boulettes"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Thème Mécanique"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mécanique"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Thème Médiéval"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Médiéval"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hommes pétrifiés"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hommes pétrifiés"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hommes pétrifiés"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Hommes pétrifiés"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Manège",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Carrousel traditionnel composé de chevaux taillés dans le bois",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Grillage"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Grillage"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Virage de cratère météoritique"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Virage de cratère météoritique"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Virage de cratère météoritique inversé"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Mur de cratère météoritique"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Mur de cratère météoritique incrusté de cristaux"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Mur de cratère météoritique incrusté de cristaux"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Genévrier bleu de Meyer"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Minibus",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Les spectateurs visionnent un film dans une nacelle simulant les mouvements grâce à un bras hydraulique",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Minibus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine de bois",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "De tous petits wagons de mine dévalent une voie en zigzag composée de virages en épingle à cheveux et de chutes vicieuses",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Chariots",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Voitures individuelles en forme de chariot de mine en bois",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine en folie",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Train pour montagnes russes en bois avec des sièges rembourrés et des barres de protection au niveau des jambes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Cabane minière"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Cabane minière"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Ascenseur",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Les passagers passent aux différents niveaux d'une tour verticale à bord d'un ascenseur",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Puits minier"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Thème Minier"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Train de mine",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Trains emmenant les passagers sur des montagnes russes  dont les voies rappellent les vieilles voies ferrées",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ou 4 passagers par voiture"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Golf miniature",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini hélicoptère",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Installés dans des voitures en forme d'hélicoptère, les passagers parcourent une voie métallique en pédalant pour avancer",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Statue du Minotaure"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Menthe"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Moderne"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Araucaria"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Truck",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "4 x 4 énorme dont les roues colossales peuvent gravir des pentes abruptes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Cyprès de Monterrey"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Pin de Montezuma"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pan de toit de monument 3"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Pan de toit de monument 1"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pan de toit de monument 4"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pan de toit de monument 4"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pan de toit de monument 4"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pan de toit de monument 4"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Coin de mur de monument"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Coin de mur de monument"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Coin de mur de monument"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Coin de mur de monument"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pan de toit de monument 2"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Boissons lunaires",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Un bar proposant les boissons les plus branchées"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Allée en mosaïque"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Sim. de mvts",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Les spectateurs visionnent un film dans une nacelle simulant les mouvements grâce à un bras hydraulique",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Courses de moto",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Véhicule en forme de moto de course parcourant des montagnes russes sur une voie monorail",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 passagers par moto"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Moto"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Moto"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Souris",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Voitures individuelles en forme de souris",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Souris folle en bois",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "De petites voitures en forme de souris dévalent une voie en bois et sont chahutées dans des virages en épingle à cheveux et des descentes abruptes",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Pan de toit de terre"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pan de mur de terre"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Train multidimension",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Train dont les sièges sont conçus pour mettre les passagers la tête à l'envers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Entrée mythologique"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Thème de la mythologie"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indien d'Amérique"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Eau naturelle"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Barrière de toit en coin nautique"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pan de toit nautique"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pan de toit nautique"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pan de toit nautique"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pan de toit nautique"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pan de toit nautique"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Barrière de toit nautique"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pan de mur nautique"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Néon lumineux de restaurant"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Néon lumineux de restaurant"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Néon lumineux de restaurant"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Néon lumineux de restaurant"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une statue animée de Neptune.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Restaurant Le Neptune",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Restaurant proposant poissons et fruits de mer"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Remplissage de virage de New York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Entrée de New York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Section de virage inversé de New York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Section de virage inversé de New York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Section de virage inversé de New York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Section de virage inversé de New York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Toit de virage inversé de New York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Section de toit de New York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Section de toit de New York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Section de toit de New York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Section de toit de New York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Section de toit de New York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Section de mur de New York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Mur de New York avec corde à linge"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Mur de New York avec corde à linge"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Corde à linge de New York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Corde à linge de New York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Pas d'entrée"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Pas d'entrée, pas de quai"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Entrée du parc nord-américain"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Thème Amérique du Nord"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Epicéa de Norvège"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Le Tonneau",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Des tonneaux serpentent le long d'un large cours d'eau, puis dévalent des rapides et des chutes d'eau spectaculaires",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagers par bateau"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Section de porte du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Section de toit du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Virage en pente douce du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Virage en pente douce du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Mur en pente douce du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Virage en pente raide du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mur en pente raide du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mur en pente raide du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Mur en pente raide du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Mur du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Mur du gratte-ciel d'obsidienne avec fenêtre"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Bureaux"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Baril de pétrole"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Pompe à essence"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Vieil arbre imposant"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Eau orange"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgue"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Structure ornementale"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Structure ornementale"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Structure ornementale"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Arbre ornemental"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Arbre ornemental"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Arbre ornemental"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Arbre ornemental"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Arbre ornemental"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Mur de marbre ornementé"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Autruche",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Montagnes russes à loopings où les passagers sont debout",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Longs canoës que les passagers dirigent en pagayant",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagers par canoë"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Panneau pagode"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Thème Pagode"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Tour de pagode"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palmier"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmier"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmier"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palmier"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palmier"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Poubelle panda"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Thème Panda"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Train panda",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Train de montagnes russes dont les voitures ont la forme de gentils pandas",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passager par voiture"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Bâtiment d'entrée du parc"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Portes d'entrée du parc"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Cabane de paysan"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pégase",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Véhicule à propulsion en forme de Pégase tirant une charrette et parcourant une route plane",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Bobsleigh pingouin",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Les passagers suivent un tracé sinueux dans des voitures en forme de pingouin, dirigés uniquement par la courbure et l'inclinaison semi-circulaire de la piste",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Automobile d'époque"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Automobile d'époque"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Restaurants d'époque"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Drapeau moyenâgeux"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Bateau de plaisance d'époque"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Réverbères d'époque"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Camion d'époque"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Camion d'époque"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Station service"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickups",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Véhicules à propulsion en forme de camion",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passager par camion"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Eau rose"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Tuyau"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Section en forme de tube"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Section en forme de tube"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Section en forme de tube"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Drapeau pirate"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Bateau pirate",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Grand bateau pirate se balançant d'avant en arrière",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Bateau pirate"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Thème Pirates"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizzaïolo",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Boutique vendant des parts de pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Basique"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Mur de marbre simple"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plante"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plante"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Mur en cartes à jouer"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Mur en cartes à jouer"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Socle"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Charrue"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Montagnes de l'ours polaire",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Les passagers, alignés par deux, peuvent regarder en avant ou en arrière en effectuant boucles et inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Mât"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Mât"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Mâts"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Course poursuite policière",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Grand huit que les passagers parcourent assis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Voiture de police",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Voitures de police des années 60 dévalant une voie en bois, tournant à des sections inverseuses spéciales",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Boutique vendant de grands pots de popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Porte coulissante"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Porte coulissante"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Poteau"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Mineur",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Train de mine à propulsion franchissant une voie régulière et alambiquée",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ou 4 passagers par voiture"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Entrée préhistorique"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Thème de la préhistoire"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Bretzellier",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Boutique vendant des bretzels croustillants"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Soupe primitive"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Porte de prison"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Clôture de prison"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Section inversée de prison"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Virage de mur de prison"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Virage de mur de prison"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Section de mur de prison"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Toit de mur de prison"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Mirador de prison"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escalier de mirador de prison"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escalier de mirador de prison"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Château d'eau de prison"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Le ptérodactyle",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Les passagers sont confortablement assis et voyagent suspendus à une voie en zigzag offrant des sensations de vol préhistorique",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Citrouille"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Maison-citrouille"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Télé file d'attente"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Voitures de course",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Véhicules à propulsion en forme de voitures de course",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passager par voiture"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "La course du raptor",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Les passagers voyagent à l'arrière de véhicules en forme de raptor sur une voie monorail",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagers par véhicule"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Haut-parleurs de course"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Antenne radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Radeau médusé",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagers par radeau"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Grille"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Allée arc-en-ciel"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Pan de toit en coin de brique rouge"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Coin de toit plat de brique rouge"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Bord de toit plat de brique rouge"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Pan de toit inversé de brique rouge"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Pan de toit de brique rouge 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Pan de toit de brique rouge 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Pan de toit de brique rouge 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Pan de mur de brique rouge 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Pan de mur de brique rouge 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Pan de mur de brique rouge 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Pan de mur de brique rouge 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Pan de mur de brique rouge 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Pan de mur de brique rouge 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Pan de mur de brique rouge 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Pan de mur de brique rouge 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Pan de mur de brique rouge 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Sapin rouge"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Sapin rouge"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Virage de cratère météoritique rouge"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Virage de cratère météoritique rouge"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Virage inversé de cratère météoritique rouge"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Mur de cratère météoritique rouge"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Allée pavée rouge et marron"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Séquoia"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Trains monorail rétro",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Trains monorail avec cabines ouvertes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Voiture CLR",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Voiture destinée à la Chute libre renversée",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Inverseur",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Chariot dévalant une voie en bois, tournant à des sections inverseuses spéciales",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhinocéros"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhinocéros",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Gréement"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Rapides",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Des bateaux de forme circulaire serpentent le long d'un large cours d'eau, puis dévalent des rapides et des chutes d'eau spectaculaires",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagers par bateau"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Le Styx",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Des bateaux en forme de radeau descendent paisiblement une voie navigable",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagers par radeau"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Route"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Entrée du parc des années folles"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Thème des années folles"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Murs des années folles"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Saucisserie",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Boutique vendant des saucisses"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Camp de Robin des Bois"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Cabane de Robin des Bois"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Cabane de Robin des Bois"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Roche"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Pierre"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Entrée du parc Rock & Roll"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Thème du Rock & Roll"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Car de tournée de groupe de rock"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Mur de roche"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Fusées",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Voitures de montagnes russes en forme de fusées",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Allée rocailleuse"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Trophée des montagnes russes"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Déesse du patin à roulettes"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Colosse romain"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Colonne romaine"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Façade de colonnes romaines"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Section de virage de palais romain"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Section de virage de palais romain"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Section de virage de palais romain"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Section de virage de palais romain"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Croisement de palais romain"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Croisement de palais romain"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Croisement de palais romain"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Croisement de palais romain"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Section d'arrivée de palais romain"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Section d'arrivée de palais romain"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Section droite de palais romain"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Section droite de palais romain"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Section droite de palais romain"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Section droite de palais romain"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Statue romaine"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Statue romaine"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Temple romain"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Mur romain"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Mur romain"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Fanfare romaine"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Toit"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Toit (gris)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Toit (rouge)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-toboggan",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Un anneau de sièges est hissé au sommet d'une grande tour tout en tournant doucement sur lui-même. S'ensuit une chute libre, stoppée en bas par un système de freins magnétiques",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Panneau route 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Tram bus londonien",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Répliques de trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagers par voiture"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rameurs",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Bateaux que les passagers font avancer en ramant",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagers par bateau"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Statue en ruines"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Section de virage de piste d'atterrissage"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Section finale de piste d'atterrissage"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Section de virage inversé de piste d'atterrissage"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Section de piste d'atterrissage"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Section de piste d'atterrissage"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Section de piste d'atterrissage"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rouille"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Tram de San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Répliques de trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagers par voiture"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sable"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sable (marron)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sable (rouge)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Grès (marron)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Grès (gris)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Virage bas du gratte-ciel"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Virage bas du gratte-ciel"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Pente en courbe basse du gratte-ciel"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Virage inversé bas du gratte-ciel"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Base de pente basse du gratte-ciel"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Virage haut du gratte-ciel"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Haut de la pente en courbe du gratte-ciel"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Haut de la pente en courbe du gratte-ciel"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Voie d'amarrage du gratte-ciel"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Porte du gratte-ciel"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Remplissage du gratte-ciel"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Remplissage du gratte-ciel"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Haut du virage inversé du gratte-ciel"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Virage médian du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Virage médian du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pente courbe médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pente courbe médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Virage en pente médian du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Section de mur médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Section de mur médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Section de mur médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Section de mur médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Section de mur médiane du gratte-ciel d'obsidienne"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Toit du gratte-ciel"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sommet du toit du gratte-ciel"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sommet du toit du gratte-ciel"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Passerelle du gratte-ciel"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Passerelle du gratte-ciel"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Virage de la passerelle"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Croisement de la passerelle"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Section finale de la passerelle"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Jonction en T de la passerelle"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Antenne parabolique"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Bus scolaire"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Bus scolaire",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Tramways reprenant la thématique des bus scolaires jaunes américains",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagers par voiture"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Pin écossais"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Panneau de défilement"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Panneau à défilement"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Fruits de mer",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Boutique vendant du poulpe grillé"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Hydravion"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Montagnes des phoques",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Montagnes russes compactes et métalliques dont le train effectue tire-bouchons et boucles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hangars pour hydravions"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hangars pour hydravions"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Projecteur"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Sièges"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Arbuste"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Arbuste"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Arbustes et décorations"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Volant (de badminton)"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Volant (de badminton)"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Cloison shōji"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Allée trottoir"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Panneau"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Panneaux et éléments pour allées"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Bouleau argenté"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Chanteur à banane"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Tour d'observation",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Cabine rotative d'observation qui se hisse au sommet d'une grande tour",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Thème Six Flags"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Montagnes russes en chute vert.",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Des voitures très larges descendent des voies en pente verticale. Pour amateurs de chute libre",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Squelette"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Téléski",
+    "reference-description": "Open cars for chairlift",
+    "description": "Voitures ouvertes pour télésiège",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Motoneiges tamponneuses",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Auto-tamponneuses électriques programmées",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Crâne"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Crâne"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Allée aérienne"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Gratte-ciel (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Gratte-ciel (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Pièce concave de gratte-ciel"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Toit concave de gratte-ciel"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Pièce convexe de gratte-ciel"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Toit convexe de gratte-ciel"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pièce d'ascenseur de gratte-ciel"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pièce d'ascenseur de gratte-ciel"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pièce de section d'ascenseur de gratte-ciel"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pièce de section d'ascenseur de gratte-ciel"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pièce de section d'ascenseur de gratte-ciel"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Pièce concave d'élément pour gratte-ciel de métal 1"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Pièce convexe d'élément pour gratte-ciel de métal 1"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Pan de mur d'élément de gratte-ciel 1"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pièce concave d'élément pour gratte-ciel de métal 2"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pièce concave d'élément pour gratte-ciel de métal 2"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Pièce convexe d'élément pour gratte-ciel de métal 2"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pan de mur d'élément de gratte-ciel 2"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pan de mur d'élément de gratte-ciel 2"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Pan de toit de gratte-ciel"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Sommet de gratte-ciel"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Paresseux",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Train de montagnes russes suspendu constitué de voitures en forme de paresseux qui se balancent librement dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Clôture à mammouths peu courbée"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Clôture à mammouths peu courbée"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Petite roue dentée"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Petite roue dentée"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Petite roue dentée"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Petite roue dentée"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Petite géosphère"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Petit cratère météoritique"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Petites voitures monorail",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Petites voitures monorail ouvertes sur les côtés",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Arbre forêt équatoriale 1 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Arbre forêt équatoriale 1 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Petit cratère météoritique rouge"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Petit haut-parleur"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Base de cheminée"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Milieu de cheminée"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Escargot"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Neige/glace"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Panneau recouvert de neige"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Tasses de glace",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Les passagers sont assis par deux dans des tasses tournant autour d'un bonhomme de neige central",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Thème Neige et glace"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Neige"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Sapin blanc du Caucase"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Epicéa blanc de Norvège"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Sapin rouge couvert de neige"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Sapin rouge couvert de neige"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Boule de neige"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Bonhomme de neige"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Savonneuse",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Voiture en forme de boîte à savon se déplaçant sur des montagnes russes monorail",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Magasin de peluches",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Une boutique proposant des peluches de dinosaures"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Thème Amérique du Sud"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Entrée du parc sud-américain"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenirs",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Boutiques vendant des peluches et des parapluies"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Laiterie",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Boutique vendant du lait de soja"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Espace"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Navette spatiale"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Navette spatiale"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Orbe spatial"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Anneaux de l'espace",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Anneaux pivotant de manière concentrique permettant aux visiteurs de tourner librement dans toutes les directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 personne à la fois"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Fusée spatiale"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Section cargo du vaisseau spatial"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Section salle des communications du vaisseau spatial"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Section salle des commandes du vaisseau spatial"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Section de croisement du vaisseau spatial"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Section d'amarrage du vaisseau spatial"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Section de salle des moteurs du vaisseau spatial"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Section carburant du vaisseau spatial"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Section gravitationnelle du vaisseau spatial"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Section habitable du vaisseau spatial"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Section scientifique du vaisseau spatial"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Panneaux solaires du vaisseau spatial"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Section solaire du vaisseau spatial"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Allée spatiale"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Panneau spatial"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Thème Espace"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Espace"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Arbre en forme de pique"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Araignée"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Clôture à pointes"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Souris folle tournante",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Voiture en forme de souris fonçant dans des virages serrés et des petites chutes, tout en tournant sur elle-même afin de désorienter les passagers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Montagnes russes en spirale",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Montagnes russes compactes et métalliques avec une remontée en spirale et des voitures disposant de sièges en ligne",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Toboggan spirale",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Bâtiment en bois comprenant un escalier intérieur et un toboggan extérieur en spirale à descendre sur un tapis"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Eclabousseur",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Grand bateau qui serpente le long d'une large voie navigable, monte sur des pentes grâce à un tapis roulant, et descend à toute vitesse de l'autre côté, éclaboussant allègrement les passagers",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passagers par bateau"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Thème Terreur"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Voitures de sport",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Véhicules à propulsion en forme de voitures de sport",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Thème Sports"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Spoutnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Montagnes Spoutnik",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Les passagers sont couchés à plat ventre dans une voiture spéciale se déplaçant sur un monorail et se balançant d'un côté à l'autre dans les virages",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Arbre en forme d'écureuil"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Diligence",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Train pour montagnes russes en bois avec des sièges rembourrés et des barres de protection au niveau des jambes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "La course du troupeau",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Grand huit où les véhicules représentent un troupeau de dinosaures en fuite.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Montagnes russes debout",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Grand huit que les passagers parcourent debout",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Montagnes tornado debout",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Les passagers suivent un parcours jalonné de pentes régulières et de multiples inversions, debout dans de grands trains disposant de protections spéciales",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Fruitier",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Boutique vendant des jus de fruits"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue de la liberté"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Trains vapeur",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Trains miniatures comprenant une réplique de locomotive à vapeur et des petits wagons en bois et ouverts",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Trains vapeur couverts",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trains miniatures comprenant une réplique de locomotive à vapeur et des petits wagons en bois avec des toits en tissu",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Canalisations fumantes"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Bloc métallique"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Bloc métallique"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Clôture métallique"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Acier camouflage"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Mur métallique"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Mur métallique"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Mur en tôle"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Mur en tôle"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Mur en tôle"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Mur en tôle"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Temple de l'âge de pierre"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Banc en pierre"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Bloc de pierre"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Rez-de-chaussée de gratte-ciel de pierre"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel de pierre"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel de pierre"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel de pierre"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel de pierre"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pan de mur de gratte-ciel de pierre"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Mur de pierre"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Mur de pierre"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Mur en pierre"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Mur de pierre"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Tabouret"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Tabourets"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Trains monorail aérodynamiques",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Trains monorail composés de voitures aérodynamiques à l'avant et à l'arrière",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 ou 10 passagers par voiture"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stuc (vert)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stuc (gris)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stuc (violet)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stuc (rouge)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stuc (jaune)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sandwicherie",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Boutique vendant des sandwiches frais"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Sous-marin",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Sous-marin immergé qui transporte les passagers dans un parcours sub-aquatique",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passagers par sous-marin"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Rhumerie",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Boutique vendant du punch"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Estival"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Lunetier",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Boutique vendant toute sorte de lunettes de soleil"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Epave"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Grande unité centrale de super ordinateur"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Moniteur de super ordinateur"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Petite unité centrale de super ordinateur"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Structure de support"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Structure de support"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Structure de support"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Montagnes surf",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Les passagers suivent un parcours jalonné de pentes régulières et de multiples inversions, debouts dans de grands trains disposant de protections spéciales",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Train monorail suspendu",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Grande voiture de train monorail",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagers par voiture"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Le planeur",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Train suspendu à des montagnes russes et dont les voitures se balancent dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Voiture-avion suspendue",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Train suspendu à des montagnes russes et composé de voitures en forme d'avion qui se balancent librement dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Voitures à bascule suspendues",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Train suspendu à des montagnes russes et dont les voitures se balancent dans les virages",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Pièce de base de pont suspendu"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Pièce d'espacement de pont suspendu"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Section de câble de pont suspendu"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Pièce de section moyenne de pont suspendu"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Extrémité 1 de pont suspendu"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Extrémité 2 de pont suspendu"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Tour 1 de pont suspendu"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Tour 2 de pont suspendu"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Fougère marécageuse"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Marécages"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Plante marécageuse"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Plante marécageuse"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Plante marécageuse"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Cygnes",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Pédalos en forme de cygne",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagers par bateau"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Voitures balançoires",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Petites voitures se balançant sous un rail",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Balancelle sans fonds",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Train de montagnes russes suspendu et composé de télésièges qui se balancent librement dans les virages",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Vaisseau renverseur",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Vaisseau attaché à un bras au bout duquel est fixé un contre-poids et qui produit des cercles complets (360 degrés)",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Epée dans la pierre"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Boutiques vendant des T-Shirts souvenirs"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Train de montagnes russes propulsé hors de la station par des moteurs à induction linéaire et fonçant dans des inversions renversantes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Tonneaux de T.N.T."
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Caisses de T.N.T."
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Détonateur de T.N.T."
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Bâtons de T.N.T."
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterne haute"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterne haute"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Grande clôture en bois"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Cible"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Allée en bitume"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Taverne"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tipi"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Téléporteur",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Les visiteurs sont transportés vers le haut ou le bas d'un niveau à l'autre",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Pan de mur cassé de temple avec tête"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pan de toit de temple"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Pièce d'escalier de temple"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Pièce d'escalier de temple"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Coin de mur de temple"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Coin de mur de temple"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Coin de mur de temple"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Coin de mur de temple"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pan de mur de temple"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Pan de mur de temple avec tête"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Immeuble"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Balle de tennis"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Mur en filet de tennis"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Mur en filet de tennis"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tente"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tipi"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termitière"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Maison terrassée"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Armée de terre cuite"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Machine à voyager dans le temps",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Les visiteurs sont installés dans une sphère spécialement conçue pour donner l'illusion d'un voyage dans le temps",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 visiteur par siège"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Champignon vénéneux"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Voiture-toboggan",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Voiture de montagnes russes en forme de toboggan avec des sièges disposés en ligne",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Marchand de pommes d'amour",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Un stand thématique proposant des pommes d'amour."
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Pomme d'amour",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Boutique en forme de pomme vendant des pommes d'amour"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilettes",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Toilettes classiques placées dans un bâtiment préfabriqué en béton"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilettes",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilettes placées dans un bâtiment en rondins"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilettes",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Toilettes classiques placées dans un bâtiment préfabriqué en béton"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "La mitraillette",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Les passagers voyagent par deux à bord de sièges thématiques autour d'une mitraillette géante.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Méga Vrille",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Nacelle suspendue à de grands bras rotatifs tournant en avant et en arrière, et plaçant les passagers tête en bas",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Mât totémique"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Hôtel de ville"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Jouets par milliers"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Montagnes russes avec voitures en fome d'automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Voie en virage"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Voie cassée"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Fin de voie"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Bifurcation de voie"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Voie en ligne droite"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tracteur"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Entrée de parc traditionnelle"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Tramway",
+    "reference-description": "Old-timer replica trams",
+    "description": "Réplique des trams d'antan",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagers par voiture"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Camionnette"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Trésor"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Trésor"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Coffre à trésor"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "La catapulte",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Chariot suspendu à deux grands bras, inspiré d'une arme médiévale",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Arbre"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Arbres"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Auto-tamponneuses tricératops",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Les passagers se rentrent dedans à bord d'auto-tamponneuses en forme de tricératops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 personne par voiture"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Bateaux trilobites",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Les voitures en forme de trilobites dévalent une voie en zigzag qui descend à toute vitesse dans l'eau, éclaboussant allègrement les passagers avant de traverser des passages en eau calme",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagers par bateau"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Pan de baie de rez-de-chaussée Tudor"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pan de mur de rez-de-chaussée Tudor 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pan de mur de rez-de-chaussée Tudor 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pan de mur de rez-de-chaussée Tudor 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pan de mur de rez-de-chaussée Tudor 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pan de mur de rez-de-chaussée Tudor 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pan de mur de rez-de-chaussée Tudor 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pan de mur de rez-de-chaussée Tudor 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pan de mur de rez-de-chaussée Tudor 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pan de mur de rez-de-chaussée Tudor 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pan de mur de rez-de-chaussée Tudor 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Pan de mur de rez-de-chaussée Tudor 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Pan de mur de rez-de-chaussée Tudor 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Pan de mur de rez-de-chaussée Tudor 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Pan de toit Tudor 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Pan d'extension de toit Tudor 1"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Pan de toit Tudor 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Pan de toit Tudor 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Pan de toit Tudor 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Pan de mur Tudor 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Pan de mur Tudor 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Pan de mur Tudor 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Pan de mur Tudor 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Tortue aquatique",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Petits canots pneumatiques de forme circulaire alimentés par un moteur central que contrôlent les passagers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Vrille",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Les passagers sont assis par deux et tournent autour de l'extrémité de trois longs bras rotatifs",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Voiture tornado",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Voiture de montagnes russes capable de passer dans des inversions à 360°",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Voit. tornado (dép. inversé)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Voiture de montagnes russes capable de passer dans des inversions à 360°",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Montagnes tornado",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "De larges trains glissent le long de montagnes russes métalliques régulières proposant un grand éventail d'inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Site de crash d'Ovni"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Statue de licorne"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Thème Urbain"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urbain"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Walkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Walkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "La chevauchée des Walkyries",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Des voitures très larges descendent des voies en pente verticale. Pour amateurs de chute libre",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Panneau 3D vertical"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Navette verticale inversée",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Voitures suspendues à la voie, hissées en marche arrière au sommet d'une voie verticale, puis lâchées  dans un parcours fait de boucles et d'inversions serrées",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Arbre avec lianes"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Voiture vintage",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Véhicule à propulsion en forme de voiture ancienne et parcourant une route plane",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Voitures de forme circulaire tournant sur elles-même tout en parcourant une voie en bois faite de zigzags",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Vide"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcan"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcan avec de petits arbres"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Arbre de Voss Laburnam"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Chariot"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Chariot"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Roue de charrette"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Voûte"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Mur avec ouverture"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Façades et toits"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Noyer"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Statue de Washington"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Guêpe"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Thème Aquatique"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Jet d'eau"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Petit jet d'eau"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Tricycle aquatique",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pédalo avec trois grandes roues flottantes",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passagers par tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Aquatique"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Chute d'eau"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Toit en clayonnage"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Toit en clayonnage"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Toit en clayonnage"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Mur en clayonnage"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Arsenal"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Saule pleureur"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Roues"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Fût de whisky"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Fûts de Whisky"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Fou blanc"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Roi blanc"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Cavalier blanc"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Pion blanc"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Peuplier blanc"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Reine blanche"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Tour blanche"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Thème Western"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Western"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Coin de toit concave façonné par le vent"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Coin de mur concave façonné par le vent"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Coin de mur concave façonné par le vent"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Coin de toit convexe façonné par le vent"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Coin de mur convexe façonné par le vent"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Coin de mur convexe façonné par le vent"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pièce de sol façonné par le vent"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pièce de sol façonné par le vent"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de formation rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de formation rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Section rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Section rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Section rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Section rocheuse façonnée par le vent"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Sommet rocheux façonné par le vent"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Sommet rocheux façonné par le vent"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pièce de toit plat façonné par le vent"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pièce de toit plat façonné par le vent"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pièce de toit plat façonné par le vent"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de mur façonné par le vent"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de mur façonné par le vent"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pan de mur façonné par le vent"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pan de mur façonné par le vent"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pan de mur façonné par le vent"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pan de mur façonné par le vent"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Moulin à vent"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Fenêtre"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Fenêtre"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Fenêtre"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Soupe des sorcières",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Restaurant proposant un bouillon épais"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Sorcières autour d'un chaudron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Asticot",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Trains de montagnes russes avec voitures en forme d'asticots",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagers par voiture"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Thème Pays des merveilles"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Soupière",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Boutique vendant des bouillons"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Bois"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Bois (noir)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Bois (rouge)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Clôture de bois avec vigne grimpante"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Clôture de bois avec vigne grimpante"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Clôture de bois avec vigne morte"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Clôture de bois avec vigne morte"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Clôture de bois avec vigne morte"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Clôture de bois avec plante carnivore"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Bois"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Bloc en bois"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Chariot en bois"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Clôture en bois"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Mur en clôture de bois"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Allée forestière"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Clôture avec poteaux de bois"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Clôture avec poteaux de bois"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Clôture avec poteaux de bois"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Clôture avec poteaux de bois"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Trains montagnes en bois",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Trains pour montagnes russes en bois avec des sièges rembourrés et des barres de protection au niveau des jambes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Trains montagnes en bois (6 places)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Train pour montagnes russes en bois avec des sièges rembourrés et des barres de protection au niveau des jambes",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Trains montagnes en bois (6 places, retourné)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Train pour montagnes russes en bois avec des barres de protection au niveau des jambes et des sièges rembourrés placés dans le sens inverse de la marche",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagers par voiture"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Voitu. à frottemt. laté.",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Voitures destinées aux montagnes à frottement latéral",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Panneau en bois"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Mur en bois"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Mur en bois"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Mur en bois"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Mur en bois"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Hydravion accidenté"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Taxi 1",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Montagnes russes géantes proposant des chutes régulières depuis des collines dépassant les 100 mètres d'altitude",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagers par voiture"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "If"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zèbre"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Statue de Zeus"
+  }
+}

--- a/objects/hu-HU.json
+++ b/objects/hu-HU.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Absztrakt"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Alap blokk"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Alap blokk"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Alap blokk"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Alap blokk"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Cukorka stílus"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Vászonsátor"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Kastély (barna)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Kastély (szürke)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Klasszikus / római"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Egyedi stílus 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Egyedi stílus 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodzsem beat stílus"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyiptomi stílus"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Vásári orgona stílus"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantázia stílus"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Könnyed stílus"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Rémisztő stílus"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Jeges stílus"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Dzsungel"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Dzsungel dob stílus"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jura kori stílus"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Fakunyhó"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marsi stílus"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Gépi stílus"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Középkori stílus"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern stílus"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Nincs bejárat"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Nincs bejárat, nincs állomás"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgona stílus"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Keleti stílus"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Kalóz stílus"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Alap"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime stílus"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock stílus"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock stílus 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock stílus 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Római harsona stílus"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Tető"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Havas / jeges"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Havas stílus"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Űrbéli"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Űrbéli stílus"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Nyári stílus"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno stílus"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Játékország stílus"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Városi stílus"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Fal átjáróval"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Vizes stílus"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Vadnyugati stílus"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Fa"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/it-IT.json
+++ b/objects/it-IT.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "Insegna di 'Golia'"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Insegna della 'Medusa'"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Insegna della 'nitroglicerina'"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Insegna “Texas Giant”"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Auto da corsa degli anni '20",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "I passeggeri gareggiano in go-kart che richiamano le auto da corsa degli anni '20.",
+    "reference-capacity": "Single-seater",
+    "capacity": "Un solo passeggero"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Auto degli anni '50"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Auto degli anni '50"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Razzo anni '50"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Razzo del 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Le carrozze sono invertite ed escono dalla stazione per raggiungere un tratto verticale del percorso, salgono e invertono la direzione per tornare alla stazione scendendo lungo un altro tratto verticale",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "Cinema 3D",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema che proietta film in 3D all'interno di un edificio a forma di sfera geodetica",
+    "reference-capacity": "20 guests",
+    "capacity": "20 spettatori"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "Insegna 3D"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "Insegna 3D"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Ottovolante invertito",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "I passeggeri siedono su sedili sospesi sotto il tracciato e affrontano giri della morte giganti, curve e lunghe discese a strapiombo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Curve volanti",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "I passeggeri si fanno strada lungo un tracciato sinuoso in grandi carrozze a forma di bob guidati solo dalla curvatura e dall'inclinazione del tracciato semi-circolare",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Opera d'arte aborigena"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Piastrella semplice in stile aborigeno"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Opera d'arte aborigena a forma di serpente"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Opera d'arte aborigena a tema spirituale"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Astratto"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Tema astratto"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acqua verde acido"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Cratere di vulcano attivo"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Elefante indiano adulto"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Panda adulto"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Ingresso del parco africano"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Tema africano"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Corsa verticale ad aria",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Dopo un esilarante lancio effettuato sfruttando l'aria, il treno accelera lungo una salita verticale, supera la cima e scende per un pendio verticale per tornare infine alla stazione",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Treni monorotaia simili a dirigibili",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Treni monorotaia dalla grande capienza, con carrozze dalle estremità di forma aerodinamiche.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passeggeri per vettura"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Pino di Aleppo"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Strutture storiche degli alieni"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Strutture storiche degli alieni"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Pianta aliena"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Pianta aliena"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Grande lucernario alieno"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Piccolo lucernario alieno"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande struttura aliena"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande struttura aliena"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grande struttura aliena"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Piccola struttura aliena"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Piccola struttura aliena"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Piccola struttura aliena"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Parte inferiore della torre aliena"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Parte intermedia della torre aliena"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Parte superiore della torre aliena"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Albero alieno"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Albero alieno"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Albero a forma di alligatore"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Pallone da football americano"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Pallone da football americano"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Casco da football"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Treni a vapore americani",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Treni in miniatura che replicano le locomotive a vapore e i carri scorta. Trainano carrozze di legno con i tetti in tessuto",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "L'anaconda",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Usa ampie carrozze con semplici cinture di sicurezza",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri per carrozza"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animale cotto allo spiedo"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Palloni 1"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Fuoco da campo animato"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatrone occhio onniveggente"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrone argonauta"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrone argonauta"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatrone argonauta"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatrone astronauta"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatrone cavernicolo che accende un fuoco"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatrone fanciulla incatenata"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatrone membro di un clan"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatrone cavaliere nero"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatrone cavaliere nero"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatroni libellule"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatrone aquila in gabbia"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrone alieno nemico"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrone alieno nemico"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatrone alieno nemico"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatrone vigile del fuoco"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatrone cannone che spara"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatrone gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrone alieno amico"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrone alieno amico"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatrone alieno amico"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatrone cavaliere"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatrone cavaliere"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatrone Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatrone agente di polizia"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrone esercito di scheletri"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrone esercito di scheletri"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatrone esercito di scheletri"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatrone ranger spaziale"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatrone Stegosauro"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatrone T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatrone Triceratopo"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatrone re che saluta"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatrone scorpione che attacca"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatrone scorpione che attacca"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatrone Pterodattilo in volo"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Tema antartico"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antilope femmina"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antilope maschio"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Coppia di antilopi"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Tabellone a cristalli liquidi antigravità"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Tabellone a cristalli liquidi antigravità"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Bersaglio del tiro con l'arco"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Cipresso dell'Arizona"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Sezione di curva in art decò"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Curva in art decò con ringhiere"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Curva in art decò con ringhiere"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Curva in art decò con finestre"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Curva in art decò con finestre"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Curva in art decò con finestre"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Chiosco alimentare in art decò",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Un chiosco che vende tagliatelle e limonata fresca"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Sezione di curva invertita in art decò"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Sezione di curva invertita in art decò"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Sezione di tetto in art decò"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sezione di curva superiore in art decò"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sezione di curva superiore in art decò"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Sezione di curva superiore in art decò"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Sezione superiore in art decò"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Sezione superiore in art decò"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Sezione del muro in art decò"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Muro in art decò con porta"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro in art decò con ringhiere"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro in art decò con ringhiere"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro in art decò con ringhiere"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muro in art decò con ringhiere"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muro in art decò con finestre"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muro in art decò con finestre"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Treni da ottovolante articolati",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Treni da ottovolante con piccole carrozze a unica fila aperte sul davanti",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Sentiero di cenere"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Frassino con ninfa"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Tema asiatico"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gong asiatico"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Pioppo"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Statua di Atalante"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Ingresso del parco australiano"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Tema australiano"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Fontane australiane, gruppo 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Fontane australiane, gruppo 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobili",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Carrozze da ottovolante a forma di automobili",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Polipo gigante B-Movie"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Ragno gigante B-Movie"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Corsa del ragno gigante di film di 2a cat.",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "I passeggeri siedono su sedili che ruotano intorno a un grande ragno da B-Movie.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Cucciolo di elefante indiano"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Cucciolo di panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Racchetta da volano"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Racchetta da volano"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterna sferica"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterna sferica"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Chiosco dei palloncini",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Un chiosco di souvenir che vende palloncini riempiti di elio"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Canneto di bambù"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Plinto di bambù"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Tetto di bambù"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Tetto di bambù"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Tetto di bambù"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Germogli di bambù"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parete di bambù"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Membro del gruppo"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Membro del gruppo"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Membro del gruppo"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Membro del gruppo"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Banca"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Ottovolante acrobatico",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "I passeggeri siedono su sedili sospesi sotto il tracciato e affrontano giri della morte giganti, curve e lunghe discese a strapiombo.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barile"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barile"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barile"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barile"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Ottovolante Ariete",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Un ottovolante d'acciaio compatto, caratterizzato da una salita da traino a spirale e da carrozze con sedili in fila.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri per vettura"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Chiosco degli spaghetti al ragù",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Un chiosco che vende spaghetti al ragù alla cinese"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Panchina"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Panchina"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Panchina"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Panchine"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Ottovolante Tigre del Bengala",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Ottovolante con carrozze capaci di avvitamento",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Biciclette su monorotaia",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Speciali biciclette viaggiano lungo un tracciato monorotaia d'acciaio, spinti dalle pedalate dei passeggeri",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 passeggero a bicicletta"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben e Palazzo del Parlamento"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Grande geosfera"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motociclista"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Alfiere nero"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Corsa sui taxi neri di Londra",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Veicoli semoventi a forma di taxi londinesi",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Corsa della morte nera",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "I passeggeri si fanno strada lungo un tracciato sinuoso in carrozze a forma di topi, guidati solo dalla curvatura e dall'inclinazione del tracciato semi-circolare.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Re nero"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Cavallo nero"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Pedone nero"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Pioppo nero"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Regina nera"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Torre nera"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob dallo spazio esterno",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Speciale cabina d'osservazione che sale su un'alta torre",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passeggeri"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Blocco"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Blocco"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Ottovolante a slittino",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "I passeggeri si fanno strada lungo un tracciato con molte curve all'interno di carrozze a forma di slittino guidate solo dalla curvatura e dall'inclinazione del tracciato semi-circolare",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Pentola in ebollizione"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Osso"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Recinto d'ossa"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Ossa"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Ottovolante boomerang",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Dopo un esilarante lancio con aria compressa, il treno prende velocità lungo un tratto verticale, arriva in cima scende verticalmente dalla parte opposta per tornare alla stazione",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Muro di mattoni"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Muro di mattoni"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Muro di mattoni"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Casella postale inglese"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Cabina telefonica inglese"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Statua rotta"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Ruota rotta"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Sentiero di catrame marrone"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Fossa di pece bollente"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Secchio"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Edificio"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Edificio"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Ottovolante Tokaido",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Ottovolante con carrozza a forma di treno proiettile giapponese",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Giunchi"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Barche da scontro",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Piccoli canotti circolari, alimentati da un motore montato al centro e controllati dai passeggeri",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passeggeri per barca"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boa"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boa"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Panineria",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Un edificio a forma di panino che vende panini"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Cespuglio"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Farfalla"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda di capanna da spiaggia"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pezzo di tetto di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pezzo di tetto di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Pezzo di tetto di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Tetto di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Pezzo di parete di capanna da spiaggia"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Albero dei cavoli"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Olmo di Camperdown"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Palma delle Canarie"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Dolce"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Dolce"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Dolci"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Stecca di zucchero"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Albero dei dolci"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Albero dei dolci"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Albero dei dolci"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Stile dolciumi"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Chiosco dello zucchero filato",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Un edificio a forma di zucchero filato che vende dello zucchero filato rosa"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannone"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannone"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Palla di cannone"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoe",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lunghe canoe mosse dalle pagaiate dei visitatori stessi",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passeggeri a canoa"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Tetto di tela"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Tenda di tela"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnevale sull'acqua - Carrozze farfalla",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Carrozze galleggianti di ottovolante a forma di farfalla",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnevale sull'acqua - Carrozze rana",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Carrozze galleggianti di ottovolante a forma di rana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnevale sull'acqua - Carrozze lucertola",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Carrozze galleggianti di ottovolante a forma di lucertola",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Entrata galleria"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Bancomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Un bancomat (ATM) che i visitatori possono usare se sono a corto di denaro"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castello (marrone)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castello (grigio)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Tratto di curva del Castello"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Tratto di curva del Castello"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Entrata del Castello"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Curva invertita del Castello"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Saracinesca del Castello"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Bastioni del Castello"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Curva dei bastioni del Castello"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Curva dei bastioni del Castello"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Curva dei bastioni del Castello"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Curva invertita dei bastioni del Castello"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre del castello"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Tratto di curva della torre del Castello"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Tratto di curva della torre del Castello"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Tratto di intersezione della torre del Castello"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Tratto rettilineo della torre del Castello"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Tratto a T della torre del Castello"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Tratto a T della torre del Castello"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Mura del castello"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Muro del Castello"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Muro del Castello"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Muro del Castello"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Teschio di bue"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Abete caucasico"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Pentolone"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Entrata della caverna"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Carrozze dei cavernicoli",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "I passeggeri si sfidano su go-kart dell'Età della Pietra",
+    "reference-capacity": "Single-seater",
+    "capacity": "Un solo passeggero"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedro libanese"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Ottovolante Cerbero",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Seduti comodamente - il solo limite è che si può effettuare un solo giro alla volta - i passeggeri affrontano dolci discese e numerose curve, sperimentando una piacevole sensazione di assenza di gravità.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Carrozze",
+    "reference-description": "Open cars for chairlift",
+    "description": "Carrozze aperte che vengono trainate",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Blocco da scacchiera"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Gatti del cheshire",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Veicoli a motore a forma di gatto che seguono un percorso stabilito",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passeggeri a gatto"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chiosco crocchette di pollo",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Un chiosco che vende crocchette di pollo"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Cedro cinese"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Drago cinese"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Testa del drago cinese",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Vetture elettriche tipo autoscontro",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per vettura"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "La giunca cinese",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "La nave è montata su un lungo braccio con un contrappeso dalla parte opposta e ruota di 360 gradi completi",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passeggeri"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chiosco a patatina",
+    "reference-description": "A hut selling chips",
+    "description": "Una capanna che vende patatine"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chiosco dei fritti",
+    "reference-description": "A stall selling chips",
+    "description": "Un chiosco che vende cibi fritti"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Barretta di cioccolato"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Sentiero circuito"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circo",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Spettacolo circense con animali tenuto all'interno di una tenda molto alta",
+    "reference-capacity": "30 guests",
+    "capacity": "30 spettatori"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circo"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classico / Romano"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Insegna stile classico"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Tema romano/classico"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Ago di Cleopatra"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Albero di vite rampicante"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Orologio"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Albero a forma di fiori"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Barche",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Carrozze da ottovolante a forma di barche",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passeggeri a barca"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Tazze di caffè",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "I passeggeri trovano posto, a coppie, su seggiolini che ruotano all'estremità di tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Negozio del caffè",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Un negozio in stile art-deco che vende tazzine di tè"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Ruota dentata"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Ruota dentata"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Ruota dentata"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Ruota dentata"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Dolce alla cola"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnato"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Ginepro comune"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Quercia comune"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Tasso comune"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Ottovolante invertito compatto",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "I passeggeri siedono in coppia sospesi al tracciato e affrontano giri della morte, curve e improvvise inversioni",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Guidando in speciali carrelli sotto la pista, i piloti sperimentano la sensazione di volo mentre prendono aria nei treni Condor",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "L'anguilla",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Un compatto ottovolante d'acciaio con carrozze a forma di anguilla che percorrono avvitamenti e giri della morte",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Siepe di conifere"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Siepe di conifere"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Curva di nastro trasportatore"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Inversione di nastro trasportatore"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Termine di nastro trasportatore"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Salita di nastro trasportatore"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Sezione diritta di nastro trasportatore"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Negozio dei biscotti",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Un chiosco che vende biscotti giganti"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Persona in gamba"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Ottovolante ad avvitamento",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Un ottovolante compatto d'acciaio in cui il treno compie giri della morte e avvitamenti vari",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Pezzo di tetto ondulato"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Base d'acciaio ondulata"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Tetto d'acciaio ondulato"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Muro d'acciaio ondulato"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Pezzo di parete ondulata"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Pino corso"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Sentiero strampalato"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Tema spaventoso"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Il coccodrillo",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Le carrozze hanno la forma di coccodrillo e si muovono lungo un canale, piombando in acqua dopo le discese ripide e facendo infradiciare i passeggeri",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passeggeri per imbarcazione"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Casa distorta",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Un edificio con stanze distorte e dagli angoli assurdi che disorienta chi vi entra dentro",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitatori"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Fontana di Cupido"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Tetto curvo"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Blocco curvo"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pezzo di parete di fango ricurva"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pezzo di parete di fango ricurva"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Pezzo di parete di fango ricurva"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Tetto curvo"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Tetto curvo"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Muro curvo"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Muro curvo"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Musica personalizzata 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Musica personalizzata 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Corsa del Ciclope",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "I passeggeri viaggiano nell'occhio di un ciclope gigante.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per carrozza"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Statua dei Ciclopi"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Lampione a margherita"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Torre della diga"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Entrata dell'Età Oscura"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Tema Età Oscura"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Tratto di tetto in curva del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Tratto di tetto in curva del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Tratto di tetto invertito del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Tratto di tetto invertito del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Tratto di curva inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Tratto di muro inferiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Tratto di tetto del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Tratto di tetto del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Tratto di tetto del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Tratto di tetto del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Tetto con camino del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Tratto di curva superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Tratto di muro superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Tratto di muro superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Tratto di muro superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Tratto di muro superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Tratto di muro superiore del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Copertura dei vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Copertura dei vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Copertura dei vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Copertura dei vasi di fiori del villaggio dell'Età Oscura"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Taverna dell'Età Oscura"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Albero morto"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Albero morto"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Albero morto"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Il sambuco",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Una nave da pesca ornamentale, che deve essere mossa dai passeggeri con i remi",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passeggeri per imbarcazione"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Carrozza per diamanti"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "I diamanti",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "I passeggeri trovano posto, a coppie, su seggiolini che ruotano all'estremità di tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Pozzo diamantifero"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Albero a forma di quadri"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Scivolo con canotto",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "I passeggeri viaggiano su canotti gonfiabili lungo un percorso semi-circolare pieno di curve o lungo un percorso a tubo completamente chiuso",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passeggeri per canotto"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosauro"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosauro"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosauro"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosauro"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosauro"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Corsa Uova di dinosauro",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "I passeggeri siedono in coppia su sedili che ruotano intorno a un pupazzo animato raffigurante una mamma dinosauro.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Sentiero di terra"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Auto-scontro",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Auto da scontro elettriche guidate dal visitatore",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per auto"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Stile auto da scontro"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Il delfino",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Usa veicoli monoposto a forma di delfino che sono controllati dai passeggeri",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passeggero per veicolo"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Fontana del delfino"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Statua di delfini"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Portale"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Portale"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Portale"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Giostra a due piani",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "La tradizionale giostra a due piani con i cavalli scolpiti in legno.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passeggeri"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Torre d'osservazione a due piani",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Cabina d'osservazione rotante a due piani che sale su un'alta torre",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passeggeri"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Negozio di ciambelle",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Un chiosco che vende ciambelle"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Base di torre grande smorta"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Base rotta di torre grande smorta"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Sezione centrale di torre grande smorta"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Sommità di torre grande smorta"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Pezzo di minareto smorto 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Pezzo di minareto smorto 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Pezzo di minareto smorto 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Pezzo di tetto smorto 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Pezzo di tetto smorto 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Pezzo di tetto smorto 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Pezzo di tetto smorto 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Base di torre piccola smorta"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Base di torre piccola smorta a minareto"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Base o sezione centrale di torre piccola smorta"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Pezzo di rialzo smorto 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Pezzo di rialzo smorto 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Pezzo di muro smorto 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Pezzo di muro smorto 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Pezzo di muro smorto 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Pezzo di muro smorto 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Pezzo di muro smorto 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Pezzo di muro smorto 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Pezzo di muro smorto 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Pezzo di muro smorto 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Pezzo di muro smorto 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Pezzo di muro smorto 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Pezzo di muro smorto 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Drago che attacca"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Ottovolante drago",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Ottovolante con carrozze a forma di drago",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Ottovolante Libellula",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "I passeggeri, in una carrozza speciale, sono sospesi al tracciato monorotaia, oscillando liberamente da lato a lato a ogni curva.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Chiosco delle bibite",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Un chiosco a forma di lattina che vende bevande effervescenti"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Statua dell'isola di Pasqua 1"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Colonna egiziana"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Statua egiziana"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Insegna stile egiziano"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Tema egiziano"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Muro egiziano"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Stile egiziano"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Torre Eiffel"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Recinzione elettrica"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Recinzione elettrica rotta"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Recinzione elettrica con tratto di curva"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Tratto di curva invertita di recinzione elettrica"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Recinzione elettrica con illuminazione"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Fontana con elefanti"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Carrozza vuota"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emù"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Impresa",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Una ruota rotante cui sono attaccate le cabine dei passeggeri (sospese), che prima cominciano a ruotare su loro stesse e poi vengono inclinate verso l'alto da un braccio di sostegno",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalipto"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Tema europeo"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Larice europeo"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Ingresso del parco europeo"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Samurai cattivo"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Le uova Fabergé",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "I passeggeri trovano posto, a coppie, su seggiolini che ruotano all'estremità di tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Ottovolante a navetta invertita",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "I passeggeri siedono in coppia guardando avanti o indietro mentre affrontano giri della morte, curve e improvvise inversioni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Stile organo da fiera"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Stile fantastico"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Attrezzi agricoli"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Budda grasso"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Tavolata del banchetto"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Recinto"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Recinto"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Recinto"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Recinti e muri"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ruota panoramica",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Grande ruota rotante con sedili aperti",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passeggeri"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Falò ardente"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Gli aquiloni",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "I passeggeri trovano posto, a coppie, su seggiolini che ruotano all'estremità di tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Autoscontro dei Cavalieri Duellanti",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "I passeggeri viaggiano in auto simili a cavalli.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per carrozza"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "I petardi",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Una ruota che regge delle capsule passeggeri sospese e inizia a ruotare per poi venire inclinata verso l'alto da un braccio portante",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Pompa antincendio"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Sala del pronto soccorso",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Un luogo dove i visitatori che si sentono poco bene possono trovare un veloce ricovero"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Foro per pescare"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Statua riparata"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Fiamme"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Fenicottero che mangia"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Fenicottero che guarda"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Fenicottero che si pulisce"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Ottovolante senza pavimento",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Grandi treni da ottovolante senza pavimento danno ai passeggeri la sensazione di volare senza sostegno mentre attraversano un tracciato contorto dalle inversioni multiple",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Fiore"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Corsa floreale",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Piccoli fiori a forma di canotti circolari, alimentati da un motore montato al centro e controllati dai passeggeri.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passeggero per carrozza"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "T-shirt floreali",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Chiosco che vende T-shirt con motivi floreali."
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Corsa delle navi volanti",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Carrozze volanti a forma di barca viaggiano lungo l'ottovolante, caratterizzato da ripide discese, curve avvitate e tuffi in sezioni acquatiche più tranquille.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passeggeri per nave"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Ottovolante volante",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "I passeggeri siedono in comodi sedili posti sotto il tracciato e corrono lungo una pista piena di curve che garantisce loro un'estrema esperienza di volo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Dischi volanti",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Veicoli hovercraft guidati dai visitatori",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona a disco volante"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Pallone"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Calcio",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Ottovolante sospeso con carrozze a forma di pallone da calcio che possono oscillare liberamente quando percorrono le curve",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Albero del frutto proibito"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Foreste"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontana"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontana"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Corsa a U invertita",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Carrozze individuali corrono sotto un tracciato a zig-zag con curve a U e ripide discese",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Chiosco del pollo fritto",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Un chiosco che vende porzioni di pollo fritto"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Chiosco del riso fritto",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Un chiosco che vende spaghetti di riso fritto alla cinese"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Goccia di frutta"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Goccia di frutta"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Albero da frutta"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Albero da frutta"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Chiosco di gelati alla frutta",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Un chiosco a tema che vende gelati alla frutta"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Casa del divertimento",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "L'edificio è composto da muri e pavimenti che si muovono, per disorientare le persone che si trovano all'interno.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitatori"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Negozio delle torte",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Un chiosco che vende torte a ciambella"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Tema futuristico"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Entrata del Parco futuristico"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Forche"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Ottovolante dei gangster",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Le tipiche auto dei gangster degli anni '20 vengono fatte accelerare dalla stazione con motori a induzione lineare (MIL), per poter affrontare vari capovolgimenti e serpentine.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Giardini"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Magazzini generali"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Stile tranquillo"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Fontana geometrica"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Scultura geometrica"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Scultura geometrica"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Scultura geometrica"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Scultura geometrica"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Scultura geometrica"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Angolo di tetto piatto georgiano"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Orlo di tetto piatto georgiano 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Orlo di tetto piatto georgiano 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Pezzo di muro georgiano del piano terra 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Pezzo di muro georgiano del piano terra 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Pezzo di muro georgiano del piano terra 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Pezzo di muro georgiano del piano terra 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Pezzo di muro georgiano del piano terra 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Pezzo di muro georgiano del piano terra 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Pezzo di tetto georgiano 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Pezzo di orlo di tetto georgiano 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Pezzo di orlo di tetto georgiano 1"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Pezzo di tetto georgiano 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Pezzo di tetto georgiano 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Pezzo di tetto georgiano 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Pezzo di tetto georgiano 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Pezzo di tetto georgiano 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Pezzo di tetto georgiano 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Pezzo di muro georgiano 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Pezzo di muro georgiano 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Pezzo di muro georgiano 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Pezzo di muro georgiano 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Pezzo di muro georgiano 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Pezzo di muro georgiano 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geyser"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Treno fantasma",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Carrozze a motore dalle forme mostruose corrono lungo un tracciato multi-livello attraverso uno scenario spaventoso ricco di effetti speciali",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Chitarra basso gigante"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pianta di fagiolo gigante"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pianta di fagiolo gigante"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Tema paese dei dolci"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Carota gigante"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Enorme impronta di dinosauro"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Batteria gigante"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Felce gigante"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Tema giardino gigante"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Erba gigante"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Chitarra gigante"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Albero di mangrovia secolare"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Panda gigante"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Zucca gigante"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Fiocco di neve gigante"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Fiocco di neve gigante"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Fiocco di neve gigante"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga-coaster",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Un ottovolante gigante d'acciaio con lunghe cadute e colline di più di 100 metri d'altezza",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffa 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffa 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Statua della giraffa"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Tetto di vetro"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Tetto di vetro"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Muro di vetro"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Muro di vetro"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Muro di vetro"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Muro di vetro"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-kart",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Go-kart a benzina guidati dal passeggero",
+    "reference-capacity": "single-seater",
+    "capacity": "sedile singolo"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Lama dorato"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Statua d'oro 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Statua d'oro 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Budda dorato"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Vello d'oro"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Cipresso d'oro di Hinoki"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Samurai buono"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "I gorilla",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Ottovolante sospeso con carrozze a forma di gorilla che possono oscillare liberamente quando percorrono le curve",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Pietra tombale"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Pietra tombale"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Pietra tombale"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Pietra tombale"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento tombale"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento tombale"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento tombale"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Sezione frontale di parete della Grande Muraglia Cinese"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Sezione posteriore di parete della Grande Muraglia Cinese"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Sezione di parete rialzata della Grande Muraglia Cinese"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Sezione diritta della Grande Muraglia Cinese con torre"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Angolo della Grande Muraglia Cinese con torre"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Il grande squalo bianco",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Usa ampie carrozze con semplici cinture di sicurezza",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Sentiero di catrame verde"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Acqua verde"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Ballerino affascinante"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Statua di Ade"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Casa degli specchi",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Un edificio composto da specchi curvi che deformano la figura riflessa dei visitatori.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitatori"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Banchina del porto"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Muro del porto"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Tratto di curva del muro del porto"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Tratto di curva del muro del porto"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Muro del porto con banchina"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Muro del porto con attrezzatura da pesca"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del porto con ormeggio"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del porto con ormeggio"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del porto con ormeggio"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Muro del porto con ormeggio"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Ottovolante delle Arpie",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "I passeggeri sono tenuti distesi da speciali bardature e viaggiano lungo un tracciato contorto caratterizzato da inversioni, guardando ora verso la terra e ora verso il cielo.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Chiosco dei cappelli",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Un chiosco di souvenir che vende grandi cappelli di gomma"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Casa infestata",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Un grande edificio a tema pieno di corridoi e stanze terrorizzanti",
+    "reference-capacity": "15 guests",
+    "capacity": "15 visitatori"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Carcere dei ricercati",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Edificio composto da prigioni e manichini raffiguranti individui carcerati, ricostruito al fine di impaurire i visitatori che l'attraversano.",
+    "reference-capacity": "16 guests",
+    "capacity": "16 visitatori"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Corsa del palazzo infestato",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Carrozze a motore si muovono lungo un tracciato multi-livello attraverso uno scenario con effetti speciali",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Balla di fieno"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Albero a forma di cuore"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Pavimento delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Piscina delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Curva della piscina delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Bordo della piscina delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Gradini della piscina delle Terme Celestiali"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tetto delle Terme Celestiali"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tetto delle Terme Celestiali"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tetto delle Terme Celestiali"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tetto delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Finestra delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architettura delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architettura delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architettura delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architettura delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontana delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontana delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Scale delle Terme Celestiali"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Scale delle Terme Celestiali"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Siepe"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Siepe"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Piazzola per elicotteri"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Ercole"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Ippopotamo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Ippopotamo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "L'ippopotamo",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "I passeggeri entrano in un sottomarino che si muove lungo un percorso subacqueo",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "passeggeri per carrozza"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Carrubo"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Stile horror"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Cavallo"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Statua di cavallo"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Statua di un cavaliere"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Corsa a ostacoli",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "I passeggeri attraversano un tracciato monorotaia su veicoli a forma di cavallo",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 passeggeri per cavallo"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Chiosco della cioccolata calda",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Un chiosco che vende cioccolate calde"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Chiosco degli hot dog",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Un chiosco che vende hot dog"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Carrozza del brivido"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Carrozza del brivido"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Ottovolante del brivido",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Dopo un esilarante lancio effettuato sfruttando l'aria compressa, il treno accelera lungo una salita verticale, supera la cima e scende lungo un pendio verticale per tornare infine alla stazione.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Giro sulla bicicletta volante",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "I passeggeri attraversano un tracciato monorotaia su veicoli a forma di biciclette volanti.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passeggeri per veicolo"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Auto volante",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "La tecnologia a levitazione magnetica è stata implementata per creare l'illusione di futuristiche auto che viaggiano sospese in aria.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Bicicletta volante in volo"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Bicicletta volante in volo"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Bicicletta volante ferma"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Bicicletta volante ferma"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Ottovolante sulla tavola volante",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "I passeggeri viaggiano su una futuristica tavola volante, oscillando liberamente da lato a lato a ogni curva.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Auto volante in volo"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Auto volante in volo"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Auto volante ferma"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Auto volante ferma"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "La slitta coi cani",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Attrazione composta da veicoli a propulsione autonoma a forma di slitta coi cani, che procedono lungo un percorso",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Treni della super-serpentina",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Treni spaziosi con semplici protezioni al petto",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Super-serpentina (treni grandi)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Grandi carrozze da quattro posti a fila con sedili rialzati e semplici protezioni al petto",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Super-ottovolante",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Un ottovolante alto, senza inversioni ma con lunghe discese, elevate velocità e carrozze confortevoli, dove l'unica misura di protezione è la barra al petto",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Chiosco di coni gelato",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Un chiosco che vende coni gelato"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Cubetto di ghiaccio"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Formazione di ghiaccio"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Formazione di ghiaccio"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Palazzo di ghiaccio"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ingresso del parco di ghiaccio"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Base per tubo di ghiaccio"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Sezione di tubo di ghiaccio"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Apertura per tubo di ghiaccio"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Tetto di ghiaccio"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Parete di ghiaccio"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Stile ghiacciato"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Fusti congelati"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Fusti congelati"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Fusti congelati"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Chiosco del tè freddo",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Un chiosco che vende tè freddo"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Tetto dell'igloo"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete dell'igloo"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete dell'igloo"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Parete di igloo"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Corsa invertita a impulsi",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Treni da ottovolante invertiti accelerano partendo dalla stazione lungo un braccio verticale del tracciato, quindi tornano in retromarcia alla stazione per salire su un altro braccio verticale",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Cedro da incenso"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandiera indiana di seta"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandiera indiana di seta"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandiera indiana di seta"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandiera indiana di seta"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandiera indiana di seta"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Tratto di curva dei tetti di New York"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Tratto di curva dei tetti di New York"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Tratto di tetto industriale"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Tratto di curva del muro industriale"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Tratto di curva del muro industriale"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Serie di muri di New York"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Serie di muri di New York"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Serie di muri di New York"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Serie di muri di New York"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muro industriale con entrata"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muro industriale con finestra"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Ufficio informazioni",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Un chiosco in cui i visitatori possono avere delle mappe del parco e comprare degli ombrelli"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Cipresso italiano"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "La polizia italiana",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "I passeggeri trovano posto, a coppie, su seggiolini che ruotano all'estremità di tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Il giaguaro",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Carrozze di ottovolante a forma di giaguari",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggero per carrozza"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Ciliegio giapponese in boccio"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Ciliegio giapponese"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Ingresso del parco giapponese"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Pino giapponese"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Tetto di Shōji"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Tetto di Shōji"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Tetto di Shōji"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandiera giapponese di seta"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Albero palla di neve giapponese"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membro di un gruppo jazz"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membro di un gruppo jazz"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membro di un gruppo jazz"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Membro di un gruppo jazz"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Bambino di gelatina"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Confetti ripieni"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Muro di confetti ripieni"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Aviogetto"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Aviogetto"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Aviogetto"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Razzi propulsori",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "I passeggeri siedono su un veicolo lanciato lungo una sezione verticale del tracciato.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passeggeri per carrozza"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Ottovolante aviogetto",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Un ottovolante compatto con carrozze individuali e rapide curve in discesa.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Moto d'acqua",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Moto d'acqua che il passeggero può guidare da solo",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passeggero a veicolo"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Torneo dei Cavalieri",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "I passeggeri attraversano un tracciato monorotaia, su veicoli a forma di cavallo.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passeggeri per veicolo"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Fontane zampillanti"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Palle di neve saltellanti"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Giungla"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Recinto tropicale"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Insegna stile tropicale"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Tema tropicale"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Albero della giungla 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Albero della giungla 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Albero della giungla con leopardi"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Albero della giungla con liane"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Stile tamburi nella giungla"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Giunca"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Insegna stile giurassico"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Tema giurassico"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Stile giurassico"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Canguro"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "L'orca",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "I passeggeri entrano in un piccolo sottomarino che procede lungo un percorso subacqueo",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "passeggeri per carrozza"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Il koala",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Usa le grandi carrozze dell'ottovolante invertito a caduta libera",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passeggeri per carrozza"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Base di torre grande del Cremlino"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Sezione centrale di torre grande del Cremlino"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Sommità di torre grande del Cremlino"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Pezzo di cupola del Cremlino 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Pezzo di cupola del Cremlino 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Pezzo di cupola del Cremlino 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Pezzo di tetto del Cremlino 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Pezzo di tetto del Cremlino 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Base di torre piccola del Cremlino"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Sezione centrale di torre piccola del Cremlino"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Base di torre piccola a cupola del Cremlino"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Pezzo di muro di rialzo del Cremlino 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Pezzo di muro di rialzo del Cremlino 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Pezzo di muro del Cremlino 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Pezzo di muro del Cremlino 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Pezzo di muro del Cremlino 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Pezzo di muro del Cremlino 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Pezzo di muro del Cremlino 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Pezzo di muro del Cremlino 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Pezzo di muro del Cremlino 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Pezzo di muro del Cremlino 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Ottovolante lanciato con MIL",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "I treni da ottovolante vengono fatti accelerare dalla stazione con motori a induzione lineare (MIL) per poter affrontare vari capovolgimenti e serpentine",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Treni coccinella",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Treni da ottovolante a forma di piccole coccinelle",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampione"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampione"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampione"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampione"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampione"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Grande recinzione di mammut ad angolo"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Grande recinzione di mammut ad angolo"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Grande olmo"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Grande recinzione di mammut"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Grande recinzione di mammut"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Grande cratere meteoritico"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Grande quercia"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Albero di foresta pluviale 4"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Grande cratere meteoritico rosso"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Grande ciminiera fumante"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Grande altoparlante"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Grande totem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Recinzione laser"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Curva della recinzione laser"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Lancio in caduta libera",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "La carrozza per la caduta libera viene issata pneumaticamente su un'alta torre e poi lanciata in caduta libera",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Cipresso di Lawson"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Mini-ottovolante sospeso",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "I passeggeri, distesi a pancia in giù in una carrozza speciale, sono sospesi al tracciato monorotaia e oscillano da una parte all'altra a ogni curva",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passeggero a carrozza"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Ottovolante in pos. distesa",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "I passeggeri sono tenuti distesi da speciali bardature e viaggiano lungo un tracciato contorto caratterizzato da inversioni, guardando ora per terra ora verso il cielo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Chiosco di limonata",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Un chiosco che vende tradizionali e rinfrescanti limonate."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Chiosco delle limonate",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Un chiosco che vende rinfrescanti limonate"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Ascensore",
+    "reference-description": "Steel lift cabin",
+    "description": "I visitatori corrono dentro un ascensore su e giù per una torre per passare da un livello all'altro",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Giglio"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Ottovolante limousine",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Ottovolante con carrozze simili a limousine",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Leone"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Il leone",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Carrozze di ottovolante a forma di leoni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Cestino dei rifiuti"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Cestino dei rifiuti"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Cestino dei rifiuti"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Cestino dei rifiuti"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Capanna di legno"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Capanna di legno"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pezzo di tetto di capanna di tronchi"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pezzo di tetto di capanna di tronchi"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Pezzo di tetto di capanna di tronchi"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Comignolo laterale di capanna di tronchi"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Pezzo di parete di capanna di tronchi"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Tronchi",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Treni da ottovolante con carrozze a forma di tronchi",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Tronchi"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Canale con i tronchi",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Barche a forma di tronco viaggiano lungo un canale d'acqua, generando al termine delle discese enormi spruzzi che inzuppano i passeggeri",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passeggeri per barca"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lecca-lecca"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Pioppo lombardo"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Treni da ottovolante",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Treni da ottovolante con barre al petto capaci di correre lungo giri della morte in verticale",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pezzo di colonna di città perduta"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Pezzo di colonna di città perduta"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pezzo di tetto piatto di città perduta"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pezzo di tetto piatto di città perduta"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Pezzo di tetto piatto di città perduta"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pezzo di scala di città perduta"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pezzo di scala di città perduta"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pezzo di scala di città perduta"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pezzo di scala di città perduta"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Pezzo di scala di città perduta"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Pezzo di muro di città perduta"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Cespuglio basso"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Prua della nave di linea di lusso"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Sezione media della nave di linea di lusso"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Poppa della nave di linea di lusso"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Corsa del martello",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "I passeggeri siedono su un sedile speciale, collegato a un braccio rotante controllato da un motore.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 occupante per sedile"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Tappeto magico",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Una vasta carrozza che ricorda un tappeto magico, che si muove su e giù ciclicamente sulle estremità di quattro bracci",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passeggeri"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Armatura magica"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Elmo magico"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Scudo magico"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Spada magica"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Arco 1 del palazzo del Maragià"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Arco 2 del palazzo del Maragià"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Cupola del palazzo del Maragià"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pezzo di palazzo del Maragià"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pezzo di palazzo del Maragià"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Pezzo di palazzo del Maragià"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Base di torre del palazzo del Maragià"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Colonna di torre del palazzo del Maragià"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Cima della torre del palazzo del Maragià"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Treno a vapore",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Un treno a vapore in miniatura, composto da una replica di locomotiva con tender che traina carrozze di legno coperte",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passeggeri per carrozza"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "L'anatra mandarina",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Un'imbarcazione a forma di cigno che utilizza da pedali azionati dai passeggeri seduti davanti",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passeggeri per imbarcazione"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Albero di foresta pluviale 3"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "La manta",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Delle capienti imbarcazioni si muovono lungo un ampio canale, risalendo grazie a un nastro trasportatore e lanciandosi dalle discese per piombare in acqua e infradiciare i passeggeri",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passeggeri per imbarcazione"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Tetto di marmo"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Tetto di marmo"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Tetto di marmo"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Tetto di marmo"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Danzatore del Mardi Gras"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Danzatore del Mardi Gras"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Padiglione"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Costruzione marziana"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Oggetto marziano"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Oggetto marziano"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Oggetto marziano"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Oggetto marziano"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Oggetto marziano"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Tema marziano"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Muro marziano"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Stile marziano"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labirinto",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Il labirinto è costituito da siepi o muri alti 2 metri tra i quali i visitatori sono costretti a vagare finché non trovano l'uscita"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Chiosco di polpette in salsa",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Un chiosco che vende polpette in salsa alla cinese"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Tema meccanico"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Stile meccanico"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Tema medievale"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Stile medievale"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Uomini tramutati in pietra"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Uomini tramutati in pietra"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Uomini tramutati in pietra"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Uomini tramutati in pietra"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Girotondo",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Il tradizionale carosello rotante con i cavalli di legno intagliato",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Recinto a rete"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Recinto a rete"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Curva del cratere meteoritico"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Curva del cratere meteoritico"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Curva invertita del cratere meteoritico"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Parete del cratere meteoritico"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Parete del cratere meteoritico con cristalli"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Parete del cratere meteoritico con cristalli"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Ginepro blu di Meyer"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Corsa Minibus",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "I visitatori, all'interno di una capsula fatta ondeggiare attraverso un braccio idraulico, vedono un film vivendone i movimenti.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Minibus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Corsa folle in miniera",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Carrelli da miniera sfrecciano lungo un percorso di legno a zig-zag, inclinandosi precariamente nelle curve a U e nelle spericolate discese",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Carri da miniera",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Carrozze individuali a forma di carri da miniera di legno",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "La miniera",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Ottovolante percorso da carrozze di legno con sedili imbottiti e barre di sicurezza che bloccano le gambe",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Capanna del minatore"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Capanna del minatore"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Il montacarichi da miniera",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "I passeggeri entrano in un montacarichi che si muove verticalmente in una torre per passare da un livello all'altro",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Pozzo della miniera"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Tema miniera"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Treno delle miniere",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "I treni degli ottovolanti con il tema della miniera si fanno strada lungo un tracciato d'acciaio costruito a somiglianza delle vecchie strade ferrate",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 o 4 passeggeri a carrozza"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Un tranquillo campo per il golf in miniatura",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini-elicotteri",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Carrozze a motore a forma di elicotteri corrono lungo un tracciato d'acciaio spinte dalle pedalate dei passeggeri",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Statua del Minotauro"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Menta"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Stile moderno"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Araucaria"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Truck",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Camion giganti 4 x 4 capaci di arrampicarsi per pendii scoscesi",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passeggeri per camion"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Cipresso di Monterey"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Pino di Montezuma"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Pezzo di tetto monumentale 3"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Pezzo di tetto monumentale 1"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pezzo di tetto monumentale 4"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pezzo di tetto monumentale 4"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pezzo di tetto monumentale 4"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Pezzo di tetto monumentale 4"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Pezzo di tetto monumentale 2"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Spremuta lunare",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Chiosco con le bevande analcoliche più nuove."
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Sentiero a mosaico"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Simulatore di movimenti",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "I visitatori, all'interno di una capsula fatta ondeggiare attraverso un braccio idraulico, vedono un film dai movimenti corrispondenti",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Corsa in motocicletta",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "I passeggeri attraversano un tracciato monorotaia su veicoli a forma di motocicletta",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 passeggeri per motocicletta"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicletta"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicletta"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Topolini",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Carrozze individuali a forma di topolini",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Topo tutto matto di legno",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Piccole carrozze a forma di topo sfrecciano lungo un tracciato di legno, inclinandosi pericolosamente nelle curve a U e nelle discese ripide",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Pezzo di tetto di fango"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Pezzo di parete di fango"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Treno corsa multi-dimensionale",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Carrozze con sedili capaci di capovolgere i visitatori",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Entrata mitologica"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Tema mitologico"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indiano"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Acqua naturale"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Angolo di ringhiera di tetto in stile nautico"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pezzo di tetto in stile nautico"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pezzo di tetto in stile nautico"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pezzo di tetto in stile nautico"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pezzo di tetto in stile nautico"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Pezzo di tetto in stile nautico"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Ringhiera di tetto in stile nautico"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Pezzo di muro in stile nautico"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Insegna al neon del ristorante"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Insegna al neon del ristorante"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Insegna al neon del ristorante"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Insegna al neon del ristorante"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Corsa di Nettuno",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "I passeggeri siedono in coppia su sedili a tema che ruotano intorno alla statua animata di Nettuno.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Chiosco di frutti di mare di Nettuno",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Un chiosco che vende le specialità salmastre di Nettuno"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Riporto in curva invertita di New York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Entrata di New York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Tratto di curva invertita di New York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Tratto di curva invertita di New York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Tratto di curva invertita di New York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Tratto di curva invertita di New York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Tetto in curva invertita di New York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Tratto dei tetti di New York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Tratto dei tetti di New York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Tratto dei tetti di New York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Tratto dei tetti di New York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Tratto dei tetti di New York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Tratto di muro di New York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muro di New York con linea"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muro di New York con linea"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Panni stesi di New York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Panni stesi di New York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Senza entrata"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Senza entrata, senza piattaforma"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Ingresso del parco nordamericano"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Tema nordamericano"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Abete norvegese"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Corsa dei tronchi",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Tronchi di quercia si fanno strada lungo un largo canale d'acqua, per poi tuffarsi dalle cascate e seguire un eccitante percorso fra le rapide.",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passeggeri per nave"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Tratto di porta del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Tratto di tetto del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Curva del pendio poco profondo del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Curva del pendio poco profondo del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Parete in pendenza poco profonda del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Curva del pendio ripido del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parete in pendenza ripida del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parete in pendenza ripida del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parete in pendenza ripida del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Muro del grattacielo in ossidiana"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Muro del grattacielo in ossidiana con finestra"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Uffici"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Barile d'olio"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Pompa di petrolio"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Vecchio albero incolto"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Acqua arancione"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Stile organo"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Stile orientale"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Struttura ornamentale"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Struttura ornamentale"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Struttura ornamentale"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Albero ornamentale"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Albero ornamentale"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Albero ornamentale"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Albero ornamentale"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Albero ornamentale"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Muro di marmo ornato"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "L'ostrica",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Un tortuoso ottovolante in cui i passeggeri stanno in piedi",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Fuoriscalmo",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lunghe canoe sospinte a remi dai passeggeri",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passeggeri per canoa"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Insegna stile pagoda"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Tema pagoda"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Torre pagoda"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Cestino dei rifiuti a panda"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Tema panda"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Treni panda",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Treni da ottovolante con carrozze a forma di teneri panda",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passeggero a carrozza"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Edificio d'entrata del parco"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Cancelli d'entrata del parco"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Capanna del contadino"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Corsa di Pegaso",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "I veicoli elettrici, a forma di Pegaso che traina un carrello, seguono un circuito prestabilito.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Bob dei pinguini",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "I passeggeri procedono lungo un tortuoso tracciato su carrozze a forma di pinguino, guidate solo dalla curvatura e dall'inclinazione del tracciato a sezione semicircolare",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Automobile d'epoca"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Automobile d'epoca"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Ristorante ricorrente"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Bandiera ricorrente"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Yacht in navigazione ricorrente"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Lampioni ricorrenti"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Camion ricorrente"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Camion ricorrente"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Stazione di rifornimento"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Camion con rimorchio",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Veicoli a motore a forma di camion con rimorchio",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passeggero a camion"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Acqua rosa"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Sezione di tubo"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Sezione di tubo"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Sezione di tubo"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Bandiera dei pirati"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Nave dei pirati",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Enorme nave dei pirati oscillante",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Nave dei pirati"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Tema piratesco"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Stile piratesco"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Chiosco delle pizze",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Un chiosco che vende tranci di pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Standard"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Muro di marmo semplice"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Pianta"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Pianta"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Muro a carta da gioco"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Muro a carta da gioco"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Basamento"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Aratro"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Ottovolante dell'orso polare",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "I passeggeri siedono a coppie, rivolti in avanti o indietro, e ruotano in diversi modi superando strette inversioni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Palo"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Palo"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Pali"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Ottovolante inseguimento della polizia",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Un ottovolante con giro della morte in cui i passeggeri stanno in posizione seduta.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Ottovolante auto della polizia",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Auto della polizia in perfetto stile anni '60 corrono su un tracciato di legno, ruotando di 180° in speciali sezioni.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri per vettura"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Chiosco dei pop-corn",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Un chiosco che vende cesti giganti di pop-corn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Saracinesca"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Saracinesca"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Sostegno"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Corsa in miniera",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Treni a motore da miniera si fanno strada lungo un tracciato pianeggiante ma pieno di curve",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 o 4 passeggeri a carrozza"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Entrata preistorica"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Tema preistorico"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Chiosco dei biscottini",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Un chiosco che vende biscottini croccanti"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Brodo primordiale"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Porta della prigione"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Recinto della prigione"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Tratto invertito della prigione"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Curva del muro della prigione"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Curva del muro della prigione"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Tratto di muro della prigione"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Tetto del muro della prigione"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Torretta di guardia della prigione"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Scale della torretta di guardia della prigione"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Scale della torretta di guardia della prigione"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Torretta di guardia della prigione"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Ottovolante Pterodattilo",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "I passeggeri siedono su comodi sedili posti sotto il tracciato e corrono lungo una pista piena di curve che garantisce loro un'esperienza di volo preistorico.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Zucca"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Casa a zucca"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Piramide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "TV fila d'attesa"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Auto da corsa",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Veicoli a motore che ricordano le auto da corsa",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passeggero a carrozza"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Ottovolante dei rapaci",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "I passeggeri attraversano un tracciato monorotaia su veicoli a forma di rapaci.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passeggeri per veicolo"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Altoparlante per corse"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Antenna radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Zattere lungo il fiume",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Barche a forma di zattera si muovono dolcemente lungo una pista d'acqua",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passeggeri a zattera"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Stile ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Ringhiera"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Sentiero arcobaleno"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Pezzo d'angolo di tetto di mattoni rossi"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Angolo di tetto piatto di mattoni rossi"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Pezzo d'orlo di tetto piatto di mattoni rossi"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Pezzo di tetto invertito di mattoni rossi"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Pezzo di tetto di mattoni rossi 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Pezzo di tetto di mattoni rossi 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Pezzo di tetto di mattoni rossi 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Pezzo di muro di mattoni rossi 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Pezzo di muro di mattoni rossi 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Pezzo di muro di mattoni rossi 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Pezzo di muro di mattoni rossi 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Pezzo di muro di mattoni rossi 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Pezzo di muro di mattoni rossi 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Pezzo di muro di mattoni rossi 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Pezzo di muro di mattoni rossi 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Pezzo di muro di mattoni rossi 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abete rosso"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abete rosso"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Curva del cratere meteoritico rosso"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Curva del cratere meteoritico rosso"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Curva invertita del cratere meteoritico rosso"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Parete del cratere meteoritico rosso"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Sequoia"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Treni monorotaia retrò",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Treni monorotaia dalle cabine aperte",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Carr. a caduta libera rovesciata",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Grande carrozza usata nell'ottovolante a caduta libera rovesciata",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Ottovolante alla rovescia",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Dei carrelli corrono su un tracciato di legno, ruotando di 180° in speciali sezioni",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rinoceronte"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Il rinoceronte",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Un compatto ottovolante d'acciaio con una collina che si risale a spirale e carrozze con sedili in fila",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri per carrozza"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Attrezzatura"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Rapide",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Barche circolari si fanno strada lungo un largo canale d'acqua per poi tuffarsi dalle cascate e seguire un eccitante percorso fra le rapide",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passeggeri per barca"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Lo Stige",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Barche a forma di zattere si muovono dolcemente lungo una pista d'acqua.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passeggeri per zattera"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Strada"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Entrata del Parco dei Ruggenti Anni Venti"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Tema Ruggenti Anni Venti"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Set di muri dei Ruggenti Anni Venti"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Chiosco delle salsicce",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Un chiosco che vende salsicce arrosto alla cinese"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Accampamento di Robin Hood"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Capanna di Robin Hood"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Capanna di Robin Hood"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Entrata del Parco Rock & Roll"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Tema Rock & Roll"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Autobus per i tour del complesso rock"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Muro di roccia"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Stile rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Stile rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Stile rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Razzi",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Carrozze di ottovolante a forma di razzi",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Sentiero roccioso"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Statuetta del premio Ottovolante"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Cameriera sui pattini a rotelle"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Colosseo romano"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Colonna romana"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Muro a colonne romane"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Tratto di curva del Palazzo Romano"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Tratto di curva del Palazzo Romano"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Tratto di curva del Palazzo Romano"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Tratto di curva del Palazzo Romano"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sezione di intersezione del Palazzo Romano"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sezione di intersezione del Palazzo Romano"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sezione di intersezione del Palazzo Romano"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Sezione di intersezione del Palazzo Romano"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Tratto finale del Palazzo Romano"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Tratto finale del Palazzo Romano"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Tratto rettilineo del Palazzo Romano"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Tratto rettilineo del Palazzo Romano"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Tratto rettilineo del Palazzo Romano"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Tratto rettilineo del Palazzo Romano"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Statua romana"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Statua romana"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Tempio romano"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Mura romane"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Mura romane"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Stile fanfara romana"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Tetto"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-discesa",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Un anello di sedili viene innalzato su un'alta torre mentre ruota lentamente su se stesso; viene poi fatto precipitare in caduta libera e quindi fermato poco prima di arrivare al suolo da freni magnetici",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Cartello Route 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Autobus di Londra",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replica del famoso autobus Routemaster di Londra",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passeggeri per carrozza"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Barche a remi",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Barche in cui sono i passeggeri a remare",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passeggeri a barca"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Statua rovinata"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Tratto di curva in salita"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Tratto del bordo in salita"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Tratto di curva invertita in salita"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Tratto in salita"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Tratto in salita"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Tratto in salita"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Tram di San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replica dei tram di San Francisco",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passeggeri per carrozza"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Curva inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Curva inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Pendio in curva inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Curva invertita inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Base del pendio inferiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Curva superiore del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Cima del pendio in curva del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Cima del pendio in curva del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Baia di attracco del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Entrata del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Riporto del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Riporto del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Cima della curva invertita del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Curva di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Curva di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pendio in curva di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Pendio in curva di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Curva del pendio di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sezione del muro di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sezione del muro di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sezione del muro di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sezione del muro di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sezione del muro di mezzo del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Tetto del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Apice del tetto del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Apice del tetto del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Viale del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Viale del grattacielo in arenaria"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Curva del viale in arenaria"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sezione trasversale del viale in arenaria"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sezione finale del viale in arenaria"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Giunzione a T del viale in arenaria"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Parabola per satellite"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Scuolabus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Tram a forma di scuolabus",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Tram in miniatura a forma di scuolabus nordamericani",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passeggeri per carrozza"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Pino scozzese"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Insegna a scorrimento"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Insegna scorrevole"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Scultura"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Scultura"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Chiosco dei frutti di mare",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Un chiosco che vende tentacoli fritti"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Idrovolante"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Ottovolante delle foche",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Un ottovolante compatto, di acciaio, in cui le carrozze percorrono avvitamenti e giri della morte",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Fosse degli idrovolanti"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Fosse degli idrovolanti"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Fotoelettrica"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Sedili"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Arbusti e ornamenti"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttle"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttle"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Muro di Shōji"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sentiero marciapiede"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Insegna"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Insegne e oggetti per i sentieri"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Betulla argentata"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Cantante con cappello"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Torre d'osservazione",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Cabina di osservazione rotante che sale su un'alta torre",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passeggeri"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Tema Six Flags"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Ottovolante a caduta verticale",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Carrozze larghissime scendono giù per un tracciato completamente in verticale per offrire l'esperienza di caduta libera definitiva per quel che riguarda un ottovolante",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Scheletro"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Sedili di ski-lift",
+    "reference-description": "Open cars for chairlift",
+    "description": "Carrozze aperte che vengono trainate",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Le motoslitte",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Usa veicoli elettrici tipo autoscontro",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per veicolo"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Teschio"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Teschio"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sentiero aereo"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Pezzo concavo di grattacielo"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Tetto concavo di grattacielo"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Pezzo convesso di grattacielo"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Tetto convesso di grattacielo"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pezzo di ascensore di grattacielo"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Pezzo di ascensore di grattacielo"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pezzo di sezione di ascensore del grattacielo"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pezzo di sezione di ascensore del grattacielo"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Pezzo di sezione di ascensore del grattacielo"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Pezzo concavo di grattacielo metallico, gruppo 1"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Pezzo convesso di grattacielo metallico, gruppo 1"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Pezzo di parete di grattacielo metallico, gruppo 1"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pezzo concavo di grattacielo metallico, gruppo 2"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Pezzo concavo di grattacielo metallico, gruppo 2"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Pezzo convesso di grattacielo metallico, gruppo 2"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pezzo di parete di grattacielo metallico, gruppo 2"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Pezzo di parete di grattacielo metallico, gruppo 2"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Pezzo di tetto di grattacielo"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Cima del grattacielo"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Il bradipo",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Ottovolante sospeso con carrozze a forma di bradipo che possono oscillare liberamente quando percorrono le curve",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Piccola recinzione di mammut ad angolo"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Piccola recinzione di mammut ad angolo"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Piccola ruota dentata"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Piccola ruota dentata"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Piccola ruota dentata"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Piccola ruota dentata"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Piccola geosfera"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Piccolo cratere meteoritico"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Piccole carrozze monorotaie",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Piccole carrozze monorotaie aperte ai lati",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Albero di foresta pluviale 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Albero di foresta pluviale 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Piccolo cratere meteoritico rosso"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Piccolo altoparlante"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Base del fumaiolo"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Parte centrale del fumaiolo"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Lumaca"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Neve / Ghiaccio"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Insegna innevata"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Tazze di neve",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "I passeggeri siedono in coppia su sedili che ruotano intorno a un pupazzo di neve posto al centro",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Tema nevoso/ghiacciato"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Stile nevoso"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Abete caucasico innevato"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Abete norvegese innevato"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abete rosso innevato"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abete rosso innevato"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Palla di neve"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Pupazzo di neve"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Derby delle scatole di sapone",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "I visitatori salgono su carrozze a forma di scatole di sapone che corrono lungo un tracciato monorotaia da ottovolante",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Chiosco di pupazzi di peluche",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Un chiosco che vende un simpatico dinosauro di peluche."
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Tema sudamericano"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Ingresso del parco sudamericano"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Chiosco di souvenir",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Un chiosco che vende peluche e ombrelli"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Chiosco del latte di soia",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Un chiosco che vende cartoni di latte di soia"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Spazio"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Capsula spaziale"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Capsula spaziale"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Sfere spaziali"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Anelli spaziali",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Anelli concentrici e che ruotano su un asse, permettendo ai visitatori di ruotare liberamente in tutte le direzioni",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 visitatore ciascuno"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Razzo spaziale"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Sezione del carico della navicella spaziale"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Sezione delle comunicazioni della navicella spaziale"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Ponte di comando della navicella spaziale"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Sezione trasversale della navicella spaziale"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Sezione di attracco della navicella spaziale"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Sezione dei motori della navicella spaziale"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Sezione di rifornimento della navicella spaziale"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Sezione di gravità della navicella spaziale"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Sezione dell'abitacolo della navicella spaziale"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Sezione scientifica della navicella spaziale"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Pannelli solari della navicella spaziale"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Sezione solare della navicella spaziale"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Sentiero spaziale"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Insegna stile spaziale"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Tema spaziale"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Stile spaziale"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Albero a forma di picche"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sfinge"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Ragno"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Recinto chiodato"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Topo rotante tutto matto",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Le carrozze a forma di topo sfrecciano lungo curve molto strette e ripide discese, ruotando lentamente su se stesse per disorientare i passeggeri",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Ottovolante a spirale",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Un ottovolante d'acciaio compatto caratterizzato da una salita da traino a spirale e da carrozze con sedili in fila",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Scivolo a spirale",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Edificio di legno con una scala interna e uno scivolo a spirale esterno da utilizzare con tappetini per scivolare"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Barche con lo schizzo",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Barche molto capienti viaggiano per un largo canale d'acqua, trainate da nastri trasportatori, per poi prendere velocità lungo ripidi pendii bagnando i passeggeri con schizzi d'acqua giganti",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passeggeri a barca"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Tema spettrale"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Auto sportive",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Veicoli a motore che ricordano le auto sportive",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Tema sportivo"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Ottovolante sospeso Sputnik",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "I passeggeri si trovano in posizione prona, sospesi in speciali carrozze monorotaia che oscillano liberamente nelle curve",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Albero a forma di scoiattolo"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Ottovolante diligenza",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Ottovolante percorso da carrozze di legno con sedili imbottiti e barre di sicurezza che bloccano le gambe",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Ottovolante del branco in fuga",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Un ottovolante con giro della morte a forma di branco di dinosauri in preda al panico.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Corsa in posiz. eretta",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Un ottovolante con giro della morte in cui i passeggeri stanno in posizione eretta",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Serpentone in pos..eretta",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "I passeggeri si muovono stando in posizione eretta sopra grandi treni da ottovolante forniti di speciali misure di sicurezza, percorrendo lunghe discese e subendo numerose inversioni consecutive",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Chiosco dei succhi di frutta",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Un chiosco che vende succhi di frutta"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statua"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statua"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statua"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statua della Libertà"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Treni a vapore",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Treni a vapore in miniatura che replicano le locomotive a vapore e i carri scorta. Trainano carrozze di legno aperte",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Treni a vapore con carrozze coperte",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Treni in miniatura che replicano le locomotive a vapore e i carri scorta. Trainano carrozze di legno con i tetti in tessuto",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Tombini fumanti"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Blocco d'acciaio"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Blocco d'acciaio"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Recinto d'acciaio"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Traliccio d'acciaio"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Muro d'acciaio"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Tempio dell'Età della Pietra"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Panchina di pietra"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Blocco di pietra"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Base delle scale di grattacielo di pietra"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo in pietra"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo in pietra"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo in pietra"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo in pietra"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Pezzo di parete di grattacielo in pietra"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Muro di pietra"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Muro di pietra"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Muro di pietra"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Muro di pietra"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Sgabello"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Sgabello"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Treni monorotaia aerodinamici",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Treni monorotaia dalla grande capienza, con carrozze alle estremità dalle forme aerodinamiche",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 o 10 passeggeri a carrozza"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Chiosco dei sandwich",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Un chiosco che vende sandwich freschi"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Corsa sottomarina",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "I passeggeri si trovano in sottomarini che viaggiano immersi lungo un percorso acquatico",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passeggeri a sottomarino"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Chiosco di sujeonggwa",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Un chiosco che vende bevande di sujeonggwa alla coreana"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Stile estivo"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Chiosco degli occhiali da sole",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Un chiosco che vende tutti i tipi di occhiali da sole"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Nave affondata"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Grande CPU del super computer"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor del super computer"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Piccola CPU del super computer"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Struttura di supporto"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Struttura di supporto"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Struttura di supporto"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Ottovolante surf",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "I passeggeri trovano posto in piedi su carrozze larghe e sono trattenuti da appositi elementi di sicurezza mentre affrontano discese dolci e numerose inversioni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Treni monorotaia sospesi",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Grandi carrozze di treni monorotaia",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passeggeri a carrozza"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Corsa sull'idrovolante",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "I treni sospesi trainano carrozze capaci di oscillare liberamente quando il treno affronta una curva.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Aeroplani in oscillazione",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Treni da ottovolante trainano carrozze a forma d'aeroplano sospese e capaci di oscillare liberamente durante le curve",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Carrozze oscillanti sospese",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "I treni da ottovolante sospesi trainano carrozze capaci di oscillare liberamente quando il treno gira in una curva",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Pezzo della base di ponte sospeso"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Pezzo di distanziatore della base di ponte sospeso"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Sezione di cavi di ponte sospeso"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Pezzo di sezione centrale di ponte sospeso"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Testa di ponte sospeso, lato 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Testa di ponte sospeso, lato 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Torre di ponte sospeso, lato 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Torre di ponte sospeso, lato 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Felce palustre"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Fanghiglia della palude"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Pianta palustre"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Pianta palustre"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Pianta palustre"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Cigni",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Barche a forma di cigno, spinte dalle pedalate dei passeggeri in prima fila",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passeggeri a barca"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Carrozze oscillanti",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Piccole carrozze che oscillano da sotto la rotaia",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Carr. oscillanti senza pavimento",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Treno da ottovolante sospeso che traina sedili da seggiovia capaci di oscillare liberamente nelle curve",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Nave oscillante invertita",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "La nave è attaccata a un braccio che ha un contrappeso all'altra estremità e che oscilla compiendo giri di 360 gradi",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passeggeri"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Spada nella roccia"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Chiosco delle magliette",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Un chiosco che vende magliette come souvenir"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Le carrozze dell'ottovolante sono spinte da motori lineari a induzione, che le lanciano lungo una serie di tortuose inversioni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Fusti di TNT"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Casse di TNT"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Detonatore per TNT"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Candelotti di TNT"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterna alta"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterna alta"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Alto recinto di legno"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Obiettivo"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Sentiero di catrame"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Taverna"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Stile techno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Teepee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teletrasportatore",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "I visitatori vengono trasportati su e giù da un livello all'altro",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passeggeri"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Pezzo di muro rotto di tempio con testa"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Pezzo di tetto di tempio"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Pezzo di muro di tempio"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Pezzo di muro di tempio con testa"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Abitazione"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Palla da tennis"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Muro a rete da tennis"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Muro a rete da tennis"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tenda"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termitaio"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Case a schiera"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Esercito di terracotta"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Macchina del tempo",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "I visitatori siedono all'interno di una sfera appositamente creata per dare l'illusione del viaggio nel tempo.",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 per visitatore"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Fungo velenoso"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboghe",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Carrozze da ottovolante a forma di toboghe con i sedili l'uno dietro l'altro",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Chiosco di mele caramellate",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Un chiosco che vende appiccicose mele caramellate"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Chiosco di mele caramellate",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Un chiosco a forma di mela che vende mele caramellate infilzate su un bastoncino"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Servizi igienici",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Servizi igienici di base situati in costruzioni di cemento prefabbricate"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Servizi igienici",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Servizi igienici situati in una costruzione simile a una capanna di legno"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Servizi igienici",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Servizi igienici di base situati in costruzioni di cemento prefabbricate"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Corsa del mitragliatore",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "I passeggeri siedono in coppia su sedili che ruotano intorno a una grande riproduzione di un fucile mitragliatore.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Sottosopra",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "I passeggeri, seduti su una gondola sospesa tenuta da due grandi bracci rotanti, ruotano capovolti in avanti e all'indietro",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Municipio"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Stile giocattolo"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Auto Trabant",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Le carrozze dell'ottovolante hanno la forma di auto Trabant",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Curva dei binari"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Binari rotti"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Fine binari"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Diramazione dei binari"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Binari diritti"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Trattore"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Entrata del parco tradizionale"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Tram",
+    "reference-description": "Old-timer replica trams",
+    "description": "Repliche dei tram d'altri tempi",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passeggeri a carrozza"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Furgone del commesso viaggiatore"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Scrigno del tesoro"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Scrigno del tesoro"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Scrigno del tesoro"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Corsa del trabocco",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "I passeggeri viaggiano su una carrozza sospesa su due grandi bracci, che richiamano un'arma di assedio del periodo dell'Età Oscura.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passeggeri"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Albero"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Alberi"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Autoscontro Triceratopo",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "I passeggeri si lanciano uno contro l'altro in auto a forma di Triceratopo.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 persona per carrozza"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Navi trilobiti",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Carrozze a forma di trilobite viaggiano lungo l'ottovolante, caratterizzato da ripide discese, curve avvitate e tuffi in sezioni acquatiche più tranquille.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passeggeri per nave"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Pezzo di rientro a terra di muro Tudor"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pezzo di muro Tudor del piano terra 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Pezzo di muro Tudor del piano terra 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pezzo di muro Tudor del piano terra 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Pezzo di muro Tudor del piano terra 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pezzo di muro Tudor del piano terra 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Pezzo di muro Tudor del piano terra 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pezzo di muro Tudor del piano terra 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Pezzo di muro Tudor del piano terra 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pezzo di muro Tudor del piano terra 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Pezzo di muro Tudor del piano terra 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Pezzo di muro Tudor del piano terra 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Pezzo di muro Tudor del piano terra 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Pezzo di muro Tudor del piano terra 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Pezzo di tetto Tudor 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Pezzo di estensione di tetto Tudor"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Pezzo di tetto Tudor 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Pezzo di tetto Tudor 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Pezzo di tetto Tudor 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Pezzo di muro Tudor 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Pezzo di muro Tudor 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Pezzo di muro Tudor 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Pezzo di muro Tudor 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "La tartaruga marina",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Usa piccole imbarcazioni circolari spinte da un motore centrale controllato dai passeggeri",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passeggeri per imbarcazione"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Contorsione",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "I passeggeri si siedono in coppia su sedili che ruotano intorno a tre lunghi bracci rotanti",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passeggeri"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Carrozze per Serpentone",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Carrozze da ottovolante adatte alle curve ondulate",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Car. per Serpentone (retrom.)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Carrozze da ottovolante adatte alle curve ondulate",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Ottovolante contorsionista",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Dei grandi treni sfrecciano su un tracciato di acciaio passando per tutta una serie di inversioni",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Punto di caduta di un UFO"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Statua di unicorno"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Tema urbano"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Stile urbano"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valchiria"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valchiria"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Ottovolante Valchiria",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Carrozze larghissime scendono per un tracciato completamente in verticale per offrire l'esperienza di caduta libera suprema, per quel che riguarda un ottovolante.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri per vettura"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Insegna 3D verticale"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Navetta verticale invertita",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "I passeggeri siedono in carrozze sospese sotto il tracciato, trainate in retromarcia su per un tratto verticale e poi sganciate per effettuare giri della morte e curve molto strette",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vite"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Auto d'epoca",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Veicoli a motore che ricordano le auto d'epoca seguono un percorso fisso su un tracciato",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri a carrozza"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Bobine della Virginia",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Carrozze circolari ruotano per il tracciato di legno a zig-zag",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Vulcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Vulcano con piccoli alberi"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Laburno di Voss"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Vagone"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Vagone"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Ruota di carro"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Muro"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Muri e tetti"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Nocciolo"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Statua di Washington"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Vespa"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Tema acquatico"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Schizzo d'acqua"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Grondaia d'acqua"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Tricicli acquatici",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Tricicli a pedali con grandi ruote galleggianti",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passeggeri a triciclo"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Stile acquatico"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Cascata"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tetto di canne e fango"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tetto di canne e fango"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Tetto di canne e fango"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parete di canne e fango"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Collezione di armi"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Salice piangente"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Ruote"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Barile di whisky"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Barili di whisky"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Alfiere bianco"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Re bianco"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Cavallo bianco"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Pedone bianco"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Pioppo bianco"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Regina bianca"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Torre bianca"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Tema far west"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Stile far west"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Angolo di tetto concavo eroso dal vento"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Angolo di muro concavo eroso dal vento"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Angolo di muro concavo eroso dal vento"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Angolo di tetto convesso eroso dal vento"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Angolo di muro convesso eroso dal vento"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Angolo di muro convesso eroso dal vento"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pezzo di pavimento eroso dal vento"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Pezzo di pavimento eroso dal vento"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sezione centrale di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sezione centrale di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sezione centrale di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Sezione centrale di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Sommità di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Sommità di formazione rocciosa erosa dal vento"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pezzo di tetto piatto eroso dal vento"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pezzo di tetto piatto eroso dal vento"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Pezzo di tetto piatto eroso dal vento"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base di muro eroso dal vento"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base di muro eroso dal vento"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pezzo di parete erosa dal vento"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pezzo di parete erosa dal vento"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pezzo di parete erosa dal vento"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Pezzo di parete erosa dal vento"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Mulino a vento"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Finestra"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Finestra"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Finestra"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Brodaglia delle streghe",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Un chiosco che vende porzioni di brodo dalla consistenza di una zuppa."
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Streghe intorno al calderone"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Il bruco",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Ottovolante con piccole carrozze a forma di bruco",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passeggeri per carrozza"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Tema del paese delle meraviglie"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Chiosco della zuppa di wonton",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Un chiosco che vende zuppa di wonton"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Recinto di legno con viti rampicanti"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Recinto di legno con viti rampicanti"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Recinto di legno con viticci morti"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Recinto di legno con viticci morti"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Recinto di legno con viticci morti"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Recinto di legno con pianta carnivora"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Legno"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Blocco di legno"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Carrello di legno"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Recinto di legno"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Muro a recinto di legno"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Sentiero di legno"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Recinto di sostegno in legno"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Muro di sostegno in legno"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Muro di sostegno in legno"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Muro di sostegno in legno"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Treni da ottovolante di legno",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Treni da ottovolante di legno con sedili imbottiti e barra al petto per protezione",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Ottovolante di legno",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Treni di legno da ottovolante con sedili imbottiti e barre al petto per protezione",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Ottovolante di legno (in retrom.)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Treni di legno da ottovolante con sedili imbottiti e barre al petto per protezione, in cui i passeggeri sono orientati in senso contrario rispetto al senso di marcia",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passeggeri a carrozza"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Carrozze di legno a frizione lat.",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Carrozze di base per l'ottovolante a frizione laterale",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri a carrozza"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Insegna di legno"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Muro di legno"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Muro di legno"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Muro di legno"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Muro di legno"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Idrovolante naufragato"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Ottovolante taxi",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Un gigantesco ottovolante d'acciaio che alterna dolci discese a salite di oltre 100 metri",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passeggeri per carrozza"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Tasso"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Statua di Zeus"
+  }
+}

--- a/objects/ja-JP.json
+++ b/objects/ja-JP.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "「ゴリアテ」看板"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "「メドゥーサ」看板"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "「ニトロ」看板"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "「テキサスジャイアント」看板"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920年代のレースカー",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "自分で操縦する、1920年代のレースカーです",
+    "reference-capacity": "Single-seater",
+    "capacity": "各車両1名"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950年代の車"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950年代の車"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950年代のロケット"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950年代のロケット車両",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "コースにぶら下がった1950年代のロケット型の車両が、コーナーで大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D映画",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "3D映画を上映する、球形の映画館です",
+    "reference-capacity": "20 guests",
+    "capacity": "定員20名"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D看板"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D看板"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "インバーテッド・ジェットコースター",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "コースの下にぶら下がった座席があり、コースには巨大ループ、ひねり、急降下があります",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "フライング・ターン",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "ひねりのある半円形のコースを、カーブとバンクだけで支えられた大きなボブスレー形の車両が疾走するコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "アボリジニアート・セット"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "アボリジニ・タイル"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "アボリジニ・スネーク工芸"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "アボリジニ・スピリット工芸"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "抽象"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "抽象派風のテーマ"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "酸性の緑色の水"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "活火山の割れ目"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "大人のインドゾウ"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "大人のパンダ"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "アフリカの遊園地の入口"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "アフリカのテーマ"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "エアーパワード・バーティカル・コースター",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "空気圧で勢いよく発進した後、コースを垂直に駆け上り、また反対側を駆け下りて発着所に戻ってくるコースターです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "ツェッペリン車両",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "ツェッペリンの形をした大定員のモノレールです",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "各車両8名"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "アレッポ松"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "エイリアン歴史建造物"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "エイリアン歴史建造物"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "エイリアン惑星"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "エイリアン惑星"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "エイリアンの天窓（大）"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "エイリアンの天窓（小）"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "エイリアン建造物（大）"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "エイリアン建造物（大）"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "エイリアン建造物（大）"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "エイリアン建造物（小）"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "エイリアン建造物（小）"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "エイリアン建造物（小）"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "エイリアンタワー（下）"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "エイリアンタワー（中）"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "エイリアンタワー（上）"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "エイリアンの木"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "エイリアンの木"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "ワニの形の木"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "アメリカンフットボール"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "アメリカンフットボール"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "アメリカンフットボールヘルメット"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "アメリカンスタイルの蒸気機関車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "レプリカの蒸気機関車と炭水車、布製の屋根の木製客車からなるミニチュア列車です",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "各客車6名"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "アナコンダ・トレイン",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "シンプルな安全バーが付いた広々とした車両です",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "アニマル・ロースト"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "バルーン"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "キャンプファイヤー"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "アニマトロニックのプロビデンスの目"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "アニマトロニックのアルゴノート"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "アニマトロニックのアルゴノート"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "アニマトロニックのアルゴノート"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "アニマトロニックの宇宙飛行士"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "アニマトロニックの火を焚く穴居人"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "アニマトロニックの鎖に繋がれた少女"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "アニマトロニックの氏族の男"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "アニマトロニックの黒騎士"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "アニマトロニックの黒騎士"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "アニマトロニックのとんぼ"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "アニマトロニックのケージに乗った鷲"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "アニマトロニックの悪のエイリアン"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "アニマトロニックの悪のエイリアン"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "アニマトロニックの悪のエイリアン"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "アニマトロニックの消防士"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "アニマトロニックの点火された大砲"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "アニマトロニックの悪党"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "アニマトロニックの善良なエイリアン"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "アニマトロニックの善良なエイリアン"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "アニマトロニックの善良なエイリアン"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "アニマトロニックの騎士"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "アニマトロニックの騎士"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "アニマトロニックのメドゥーサ"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "アニマトロニックの警察官"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "アニマトロニックのロビンフッド"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "アニマトロニックのガイコツの戦士"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "アニマトロニックのガイコツの戦士"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "アニマトロニックのガイコツの戦士"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "アニマトロニックのスペース・レンジャー"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "アニマトロニックのステゴサウルス"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "アニマトロニックのティラノサウルス"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "アニマトロニックのトリケラトプス"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "アニマトロニックの手を振る王様"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "アニマトロニックの攻撃するサソリ"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "アニマトロニックの攻撃するサソリ"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "アニマトロニックの羽ばたくプテロダクティルス"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "南極のテーマ"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "レイヨウ（メス）"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "レイヨウ（オス）"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "レイヨウ（ペア）"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "空中LCDビルボード"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "空中LCDビルボード"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "アーチェリーの"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "アリゾナ糸杉"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "アールデコ・コーナー部分"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "アールデコ・コーナー　ガードレール付き"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "アールデコ・コーナー　ガードレール付き"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "アールデコ・コーナー　窓付き"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "アールデコ・コーナー　窓付き"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "アールデコ・コーナー　窓付き"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "アールデコ食料品店",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "牛肉麺と新鮮なレモネードを売る店です"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "アールデコ・コーナー部分（反転）"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "アールデコ・コーナー部分（反転）"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "アールデコ・天井部分"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "アールデコ・コーナー上部"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "アールデコ・コーナー上部"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "アールデコ・コーナー上部"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "アールデコ・壁上部"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "アールデコ・壁上部"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "アールデコ・壁部分"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "アールデコ・ドア付きの壁"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "アールデコ・ガードレール付きの壁"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "アールデコ・ガードレール付きの壁"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "アールデコ・ガードレール付きの壁"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "アールデコ・ガードレール付きの壁"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "アールデコ・窓付の壁"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "アールデコ・窓付の壁"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "接合式ローラーコースター列車",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "前の空いた短い車両のローラーコースターです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "灰色の歩道"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "乙女とトリネコの木"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "アジアのテーマ"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "アジアのゴング"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "ヤマナラシ"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "アトラスの像"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "アトミウム"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "オーストラリアの遊園地の入口"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "オーストラリアのテーマ"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "オーストラリアの噴水セット２"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "オーストラリアの噴水セット２"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "自動車",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "自動車の形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B級映画の巨大なタコ"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B級映画の巨大なクモ"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B級映画の巨大なクモライド",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "巨大なクモが中心にいて、その周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "インドゾウ（子供）"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "パンダ（子供）"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "バドミントンラケット"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "バドミントンラケット"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "提灯"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "提灯"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "風船ショップ",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "ヘリウムガスの入った風船を売る売店です"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "竹やぶ"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "竹の台座"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "竹の屋根"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "竹の屋根"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "竹の屋根"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "たけのこ"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹の壁"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "バンドのメンバー"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "バンドのメンバー"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "バンドのメンバー"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "バンドのメンバー"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "銀行"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "バーンストーミングトレイン",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "二階建て飛行機の型のローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "樽"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "樽"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "樽"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "樽"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "ベースブロック"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "ベースブロック"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "ベースブロック"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "ベースブロック"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "破城槌トレイン",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "暗黒時代の破城槌をモチーフにした、直列シートのローラーコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "牛肉ヌードルショップ",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "中華風牛肉ヌードルを売るお店です"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "ベンチ"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "ベンチ"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "ベンチ"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "ベンチ"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "ベンガルトラ車両",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "ハートライン・ツイストが可能な、ベンガルトラの形をしたローラーコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "モノレール自転車",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "乗客が特殊な自転車のペダルを漕ぎ、モノレールコースを走る乗物です",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "各車両1名"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "ビッグベンと国会議事堂"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "大きな地球圏"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "暴走族"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "ブラックビショップ"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "ロンドンタクシー",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "動力つきのロンドンタクシー型車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "黒死病ボブスレー",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "ネズミの型の二人乗り車両で、乗客は前後に座ります",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "黒キング"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "黒ナイト"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "黒ポーン"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "黒ポプラ"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "黒クイーン"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "黒ルーク"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "宇宙からの塊",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "回転しながら登る、B級SF映画に出てくる物体のような形をした展望キャビンです",
+    "reference-capacity": "20 passengers",
+    "capacity": "定員20名"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "ブロック"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "ブロック"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "ボブスレー・コースター",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "乗客2人が前後に座るボブスレーです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "煮鍋"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "骨"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "骨のフェンス"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "骨"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "ブーメラン"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "ブーメラン・トレイン",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "空気動力で打ち上げられた、ブーメラン形のジェットコースター車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "レンガ"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "レンガの壁"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "レンガの壁"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "レンガの壁"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "イギリス風郵便ポスト"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "イギリス風電話ボックス"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "壊れた像"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "壊れた車輪"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "茶色の舗装歩道"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "茶色のタイルの歩道"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "沸き立つタール坑"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "桶"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "建物"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "建物"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "新幹線",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "日本の新幹線をモチーフにしたローラーコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "ガマ"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "バンパー・ボート",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "丸い小型ボートで、乗客が操作する中央部のモーターで動きます",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "各ボート2名"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "ブイ"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "ブイ"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "バーガーショップ",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "ハンバーガー形をしたバーガーショップです"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "低木"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "ちょうちょう"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "小屋"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "小屋"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋の屋根"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋の屋根"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋の屋根"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "小屋の上部"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋の壁"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "食用ヤシ"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "サボテン"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "サボテン"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "サボテン"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "サボテン"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "サボテン"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "セイヨウハルニレの木"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "カナリアヤシの木"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "キャンディー"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "キャンディー"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "キャンディー"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "キャンディースティック"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "キャンディーツリー"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "キャンディーツリー"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "キャンディーツリー"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "キャンディ・スタイル"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "綿菓子ショップ",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "ピンク色の綿菓子を売る、綿菓子形の売店です"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "大砲"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "大砲"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "大砲の弾"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "カヌー",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "乗客自身が漕ぐロングカヌーです",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "各カヌー2名"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "キャンバス地の屋根"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "キャンバス"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "カーニバルフロート (蝶車両)",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "蝶の形をしたカーニバルフロート車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "カーニバルフロート (カエル車両)",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "カエルの形をしたカーニバルフロート車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "カーニバルフロート (トカゲ車両)",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "トカゲの形をしたカーニバルフロート車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "カートシャフト"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "ATM",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "所持金の減った来園客が利用する、ATM(キャッシュディスペンサー)です"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "城 (茶色)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "城 (灰色)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "城のコーナー部分"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "城のコーナー部分"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "城の入り口"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "城のコーナー部分（反転）"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "城の落とし格子"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "城壁"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城壁のコーナー"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城壁のコーナー"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城壁のコーナー"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "城壁のコーナー（反転）"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "城の塔"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "城の塔のコーナー部分"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "城の塔のコーナー部分"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "城の塔のクロス部分"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "城の塔のストレート部分"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "城の塔のT型部分"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "城の塔のT型部分"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "城の壁"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "牛の頭蓋骨"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "カフカスモミの木"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "大釜"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "洞窟の入り口"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "穴居人のレースカー",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "石器時代をモチーフにしたゴーカート",
+    "reference-capacity": "Single-seater",
+    "capacity": "各車両1名"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "レバノン杉"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "ケルベロストレイン",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "乗客は、簡単な膝の安全バーを備えた快適な車両に座り、急降下やツイストを楽しめます",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "チェアリフト車両",
+    "reference-description": "Open cars for chairlift",
+    "description": "屋根のないリフトカーです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "市松模様ブロック"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "チェスボード"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "チェシャ猫",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "動力つきの猫型の車両です",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "各車両2名"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "チキンナゲット・ショップ",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "チキンナゲットを売る売店です"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "中国杉"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "中国の竜"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "竜の頭車両",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "乗客同士が闘う、龍の頭のような形をしたバンパーカー",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "中国のジャンク船",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "アームの片側に中国のジャンク船型が、もう片側に重りが付いており、360度回転する乗物です",
+    "reference-capacity": "12 passengers",
+    "capacity": "定員12名"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "フライドポテト・ショップ",
+    "reference-description": "A hut selling chips",
+    "description": "フライドポテトを売る売店です"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "フライドポテト・ショップ",
+    "reference-description": "A stall selling chips",
+    "description": "フライドポテトを売る売店です"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "板チョコ"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "迂回路の歩道"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "サーカス",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "動物のサーカスショーをやっている大テントです",
+    "reference-capacity": "30 guests",
+    "capacity": "定員30名"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "サーカス"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "クラシック/ローマ風"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "クラシックなバナー"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "クラシック/ローマ風のテーマ"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "クレオパトラの針"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "ぶどうの木のつる"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "時計"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "クラブ形の木"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "コースター・ボート",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "ボート型の車両を持つローラーコースターです",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "コーヒーカップツイスター",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "大きなコーヒーミルの周りをペアシート車両が回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "コーヒーショップ",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "コーヒーを売るアールデコ風の売店です"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "はめ歯歯車"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "はめ歯歯車"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "はめ歯歯車"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "はめ歯歯車"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "コーラキャンディー"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "並木"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "普通のネズの木"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "普通のカシの木"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "普通のイチイの木"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "コンパクト・インバーテッド・コースター",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "レールにぶら下がった二人乗り車両のコースターです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "コンドルトレイン",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "乗客はレールの下のコンドルの形をした車両の特殊なハーネスに乗り、飛んでいるような感覚を体験できます",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "あなごトレイン",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "シートベルトの付いた、あなごの形のローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "針葉樹の生垣"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "針葉樹の生垣"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "ベルトコンベアーのコーナー部分"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "ベルトコンベアーのコーナー部分（逆回り）"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "ベルトコンベアーの終点"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "ベルトコンベアー上昇"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "ベルトコンベアー直進"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "クッキーショップ",
+    "reference-description": "A stall selling giant cookies",
+    "description": "巨大なクッキーを売る売店です"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "ダンディな男"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "コークスクリュー・ジェットコースター",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "シートベルトのあるローラーコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "波形の屋根"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "スチール製の波形ベース"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "スチール製の波形屋根"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "スチール製の波形の壁"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "波形の壁"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "コルシカ松"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "カウボーイ１"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "カウボーイ２"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "クレイジー敷石歩道"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "不気味なテーマ"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "ワニ型ボート",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "水路を走るワニの形をしたボートです",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "各ボート4名"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "ねじれた家",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "中に入った人の方向感覚を狂わせる、ゆがんだ部屋と曲がった廊下がある建物です",
+    "reference-capacity": "5 guests",
+    "capacity": "定員5名"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "キューピッドの噴水"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "カーブしたブロック"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "カーブしたブロック"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "カーブした泥の壁"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "カーブした泥の壁"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "カーブした泥の壁"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "カーブした屋根"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "カーブした屋根"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "カーブした壁"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "カーブした壁"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "カスタム・スタイル １番"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "カスタム・スタイル １番"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "サイクロプスの目",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "自分で運転するサイクロプスの目の形をしたホバークラフト車両です",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "サイクロプスの像"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "デイジーランプ"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "ダムタワー"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "暗黒時代の遊園地の入口"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "暗黒時代のテーマ"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "暗黒時代の村のコーナーの屋根部分"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "暗黒時代の村のコーナーの屋根部分"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "暗黒時代の村の屋根部分（反転）"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "暗黒時代の村の屋根部分（反転）"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "暗黒時代の村のコーナー部分（下部）"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "暗黒時代の村の壁部分（下部）"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "暗黒時代の村の屋根部分"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "暗黒時代の村の屋根部分"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "暗黒時代の村の屋根部分"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "暗黒時代の村の屋根部分"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "暗黒時代の村の屋根（煙突付き）"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "暗黒時代の村のコーナー部分（上部）"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "暗黒時代の村の壁部分（上部）"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "暗黒時代の村の壁部分（上部）"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "暗黒時代の村の壁部分（上部）"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "暗黒時代の村の壁部分（上部）"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "暗黒時代の村の壁部分（上部）"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "暗黒時代の村の窓ボックス"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "暗黒時代の村の窓ボックス"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "暗黒時代の村の窓ボックスの屋根"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "暗黒時代の村の窓ボックスの屋根"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "暗黒時代の村の窓ボックスの屋根"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "暗黒時代の村の窓ボックスの屋根"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "暗黒時代のバー"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "枯れ木"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "枯れ木"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "枯れ木"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "ダウ船",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "乗客が自分で漕ぐ装飾的な漁船",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "各ボート2名"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "ダイヤモンド・カート"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "スクランブルダイヤモンド",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "大きなダイヤモンドの周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "ダイヤモンド・シャフト"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "ダイヤモンド型の木"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "先住民族の楽器"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "ディンジー・スライド",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "ねじれた半円形のコース、またはパイプの中を通るゴムボートです",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "各ボート2名"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "恐竜"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "恐竜"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "恐竜"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "恐竜"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "恐竜"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "恐竜の卵ツイスター",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "ママ恐竜が中心にいて、その周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "泥"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "土の歩道"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "ダージャムズ",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "乗客が運転する、電動のバンパーカーです",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "ダージャムズ・ビート・スタイル"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "イルカ・ジェットスキー",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "乗客が自分で操縦できる、イルカの形をした一人乗りジェットスキーです",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "各1名"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "イルカの噴水"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "イルカの像"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "戸口"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "戸口"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "戸口"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "ダブルデッキ回転木馬",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "昔ながらの木彫りのダブルデッキ回転木馬です",
+    "reference-capacity": "32 passengers",
+    "capacity": "定員32名"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "二階建て展望台",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "2階建ての展望キャビンが回転しながら高い塔を登ります",
+    "reference-capacity": "32 passengers",
+    "capacity": "定員32名"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "ドーナツショップ",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "リングドーナツを売る売店です"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "壊れた巨大タワーの土台"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "壊れた巨大タワーの壊れた土台"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "壊れた巨大タワーの中間部分"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "壊れた巨大タワーの頂上"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "壊れたミナレットのピース 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "壊れたミナレットのピース 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "壊れたミナレットのピース 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "壊れた壁のピース 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "壊れた壁のピース 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "壊れた壁のピース 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "壊れた壁のピース 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "壊れた小さな塔の土台"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "壊れた小さな塔のミナレットの土台"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "壊れた小さな塔の頂上もしくは中間部分"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "壊れたステップアップの部分1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "壊れたステップアップの部分2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "壊れた壁1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "壊れた壁10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "壊れた壁11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "壊れた壁2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "壊れた壁3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "壊れた壁4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "壊れた壁5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "壊れた壁6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "壊れた壁7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "壊れた壁8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "壊れた壁9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "ドラゴン・アタック"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "竜車両",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "竜の形をしたジェットコースター車両",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "とんぼ車両",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "上部のレールからスイングする、とんぼ形の車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "飲み物ショップ",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "炭酸飲料を売る、缶の形の売店です"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "イースター島の像"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "エジプト風の柱"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "エジプト風の像"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "エジプト風のバナー"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "エジプト風のテーマ"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "エジプト風の壁"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "エジプト・スタイル"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "エッフェル塔"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "電気フェンス"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "壊れた電気フェンス"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "電気フェンス コーナー部分"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "電気フェンス コーナー部分（反転）"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "電気フェンス（ライト付き）"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "ゾウの噴水"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "空のカート"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "エミュー"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "エンタープライズ",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "乗客の乗ったポッドがぶら下がった大きな輪が、回転しながら傾斜する乗物です",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "ユーカリの木"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "ヨーロッパのテーマ"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "ヨーロッパカラマツ"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "ヨーロッパの遊園地の入口"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "邪悪な侍"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "ファベルジェの卵",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "大きなファベルジェの卵のレプリカの周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "対戦カー",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "乗客は2人ずつ前後に向かって座り、反転したりひねったりしながら走行するコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "フェアグラウンドオルガン・スタイル"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "ファンタジー・スタイル"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "農業の道具"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "仏"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "宴会テーブル"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "フェンス"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "フェンス"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "フェンス"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "フェンスと壁"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "観覧車",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "屋根のないイス付きの、大きな観覧車です",
+    "reference-capacity": "32 passengers",
+    "capacity": "定員32名"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "のろし"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "戦闘凧ツイスター",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "戦闘凧をテーマにした３本の回転する長いアームの先に、それぞれペアシートが付いた乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "戦う騎士バンパーカー",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "乗客が運転する、馬上槍試合の騎士形の電動のバンパーカーです",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "爆竹ライド",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "乗客の乗ったポッドがぶら下がった大きな爆竹の形をした輪が、回転しながら傾斜する乗物です",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "消火栓"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "救護所",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "気分の悪くなった来園客がここに来ると早く回復します"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "釣り堀"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "銅像"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "炎"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "餌を食べるフラミンゴ"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "周りを見るフラミンゴ"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "羽づくろいするフラミンゴ"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "フロアレス・ジェットコースター",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "肩ベルト付きの、底のない幅広のコースターで、空を飛んでいるような気分になるライドです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "花"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "フラワーパワーバンパーカー",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "自分で運転する花の形のホバークラフト車両です",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "フラワーパワーTシャツショップ",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "花をモチーフにしたTシャツを販売するショップです"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "飛行艇",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "飛行艇型の車両を持つローラーコースターで、カーブや急降下、川にスプラッシュします",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "各車両6名"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "フライング・ローラーコースター",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "コースの下にある快適な座席に座り、ひねったコースによって究極の飛行体験が楽しめるコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "フライングソーサー",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "自分で運転するホバークラフト車両です",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "フットボール"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "サッカーボール車両",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "ぶら下がったサッカーボール型の車両が、コーナーで大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "禁断の果実の木"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "森の木"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "噴水"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "噴水"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "ヘアピン・コースター",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "個別の車両がヘアピン回転や急降下するコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "フライドチキン・ショップ",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "フライドチキンを売る売店です"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "焼きビーフン・ショップ",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "中華風の焼きビーフンを売る売店です"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "フルーツドロップ"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "フルーツドロップ"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "果物の木"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "果物の木"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "フルーツアイスクリーム・ショップ",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "フルーツアイスクリームを売る売店です"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "ファンハウス",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "歩く人の方向感覚を狂わせる、動く壁と床のある建物です",
+    "reference-capacity": "5 guests",
+    "capacity": "定員5名"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "ファネルケーキ・ショップ",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "ファネルケーキを売る売店です"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "未来のテーマ"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "未来的な遊園地の入口"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "絞首台"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "ギャングスターカー",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920年代のギャング車のような、リニアモーターで動く車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "花壇"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "芸者"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "雑貨店"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "ジェントル・スタイル"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "幾何学的噴水"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何学的彫刻"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何学的彫刻"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何学的彫刻"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何学的彫刻"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何学的彫刻"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "ジョージア風の平屋根 コーナー"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "ジョージア風の平屋根 角 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "ジョージア風の平屋根 角 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "ジョージア風の 一階 壁部分 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "ジョージア風の 一階 壁部分 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "ジョージア風の 一階 壁部分 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "ジョージア風の 一階 壁部分 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "ジョージア風の 一階 壁部分 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "ジョージア風の 一階 壁部分 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "ジョージア風の 一階 壁部分 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "ジョージア風の 軒部分 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "ジョージア風の 軒部分 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "ジョージア風の 屋根部分 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "ジョージア風の 屋根部分 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "ジョージア風の 屋根部分 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "ジョージア風の 屋根部分 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "ジョージア風の 屋根部分 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "ジョージア風の 屋根部分 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "ジョージア風の 壁部分 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "ジョージア風の 壁部分 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "ジョージア風の 壁部分 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "ジョージア風の 壁部分 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "ジョージア風の 壁部分 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "ジョージア風の 壁部分 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "間欠泉"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "ゴースト・トレイン",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "さまざまな特殊効果と薄気味悪い仕掛けを施した立体的コースを通る、モンスターの形をした動力付きの乗物です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "巨大なベースギター"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大豆"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大豆"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "巨大キャンディーのテーマ"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "巨大ニンジン"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "巨大な恐竜の足跡"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "巨大なドラムセット"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "巨大シダ"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "巨大花壇風のテーマ"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "巨大な草"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "巨大なギター"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "巨大なマングローブの木"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "ジャイアントパンダ"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "巨大カボチャ"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大な雪片"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大な雪片"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大な雪片"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "ギガコースター",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "300フィート(約91m)もの高さの丘と、スムーズな降下がある巨大なスチール製のコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "キリン１"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "キリン２"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "キリンの像"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "ガラスの屋根"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "ガラスの屋根"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "ガラスの壁"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "ガラスの壁"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "ガラスの壁"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "ガラスの壁"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "ゴーカート",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "自分で操縦する、ガソリンエンジンのゴーカートです",
+    "reference-capacity": "single-seater",
+    "capacity": "各車両1名"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "黄金のリャマ"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "黄金の像 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "黄金の像 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "黄金の仏"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "金の羊毛"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "ゴールデンヒノキ"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "ゴング"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "善良な侍"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "ゴリラ車両",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "ぶら下がったゴリラ型の車両が、コーナーで大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "草"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "草の塊"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "墓石"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "墓石"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "墓石"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "墓石"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓地モニュメント"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓地モニュメント"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓地モニュメント"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "万里の長城 壁部分（前方）"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "万里の長城 壁部分（後部）"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "万里の長城 壁部分（段差）"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "万里の長城 小塔（コーナー）"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "万里の長城 小塔（直立部分）"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "ホホジロザメトレイン",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "ホホジロザメの形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "緑色の舗装歩道"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "緑色の水"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "緑と茶色のタイルの歩道"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "グレーのタイルの歩道"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "グリッド (緑)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "グリッド (紫)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "グリッド (赤)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "グリッド (黄)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "イカしたダンサー"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "エンデバー号"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "ハデスの像"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "鏡の間",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "歪んだ鏡のある建物です",
+    "reference-capacity": "5 guests",
+    "capacity": "定員5名"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "港の波止場"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "防波堤"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "防波堤　コーナー部分"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "防波堤　コーナー部分"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "防波堤（ドック付き）"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "防波堤（漁具付き）"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "防波堤（係留付き）"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "防波堤（係留付き）"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "防波堤（係留付き）"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "防波堤（係留付き）"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "ハーピートレイン",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "寝転んで乗るハーピー型のジェットコースターの列車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "帽子ショップ",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "フォームラバー製の大きな帽子を売る売店です"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "お化け屋敷",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "不気味な廊下と薄気味悪い部屋を持つ、多層式の大きなお化け屋敷です",
+    "reference-capacity": "15 guests",
+    "capacity": "定員15名"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "お化け屋敷",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "不気味な地下牢や投獄された者たちのマネキンがいるお化け屋敷です",
+    "reference-capacity": "16 guests",
+    "capacity": "定員16名"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "ホーンテッド・マンション・ライド",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "特殊な仕掛けと景観が施された多層式のコースを、動力付きの車両が走行する乗物です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "干し草"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "ハート形の木"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "天空の浴場　床"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "天空の浴場　プール"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "天空の浴場　プール　コーナー"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "天空の浴場　プール　角"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "天空の浴場　プール　段差"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天空の浴場　屋根"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天空の浴場　屋根"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天空の浴場　屋根"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天空の浴場　屋根"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "天空の浴場　窓"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天空の浴場　アーチ"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天空の浴場　アーチ"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天空の浴場　アーチ"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天空の浴場　建築"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天空の浴場　建築"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天空の浴場　建築"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天空の浴場　建築"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "天空の浴場　噴水"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "天空の浴場　噴水"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "天空の浴場　階段"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "天空の浴場　階段"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "生垣"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "生垣"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "ヘリポート"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "ヘラクレス"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "ヒバ"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "カバ１"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "カバ２"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "カバ潜水艦",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "水中のコースを、カバの形をした潜水艦に乗り込んで進む乗物です",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "各船5名"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "アメリカサイカチ"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "ホラー・スタイル"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "馬"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "馬の像"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "騎手の像"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "障害物競馬",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "シングルレールコースを馬の形の車両が走行する乗物です",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "各車両2名"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "ホットココア・ショップ",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "ホットチョコレートを売る売店です"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "ホットドッグショップ",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "ホットドッグを売る売店です"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "ホットロッドカー"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "ホットロッドカー"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "ホットロッドレーストレイン",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "ホットロッド形状の空力で打ち上げられたジェットコースターの列車です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "家"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "ホバーバイク",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "未来的なホバーバイク型車両",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "ホバーカー",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "磁気浮上式の近未来的なホバーカーです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "ホバーバイク（飛行）"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "ホバーバイク（飛行）"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "ホバーバイク（スタンド）"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "ホバーバイク（スタンド）"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "ホバーボード",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "ゲストは近未来的なホバーボードに乗り、左右に自由にスイングできます",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "ホバーカー（飛行）"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "ホバーカー（飛行）"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "ホバーカー（スタンド）"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "ホバーカー（スタンド）"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "ハスキー犬車両",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "犬ぞりの形をした動力付き車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "ハイパー・ツイスター車両",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "簡単な膝の安全バーだけが付いた、広々とした列車です",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "ハイパー・ツイスター・トレイン (広い車両)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "型で高い座席のある幅広のコースターで、簡単な膝の安全バーを備えています",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "ハイパーコースター",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "高低差もあり速度も速いですが、逆さにはならず膝にしか安全バーがないので、快適な車両です",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "氷"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "氷"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "アイスクリームショップ",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "アイスクリームを売る売店です"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "アイスキューブ"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "氷の層"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "氷の層"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "氷の宮殿"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "氷の遊園地の入口"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "氷のパイプ　土台"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "氷のパイプ　中間部分"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "氷のパイプ　通気口"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "氷の屋"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "氷の壁"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "アイス・スタイル"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "氷の樽"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "氷の樽"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "氷の樽"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "アイスティーショップ",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "アイスティーを売る売店です"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "イグルー"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "イグルーの屋根"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "イグルーの壁"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "インバーテッド・インパルス・コースター",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "逆向きのローラーコースターで、発着所から加速して発進し、垂直な絶壁を駆け上ると今度は後ろから発着所に戻り、もうひとつの絶壁を後ろ向きに登ります",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "オニヒバ"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "インドのシルクの旗"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "インドのシルクの旗"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "インドのシルクの旗"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "インドのシルクの旗"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "インドのシルクの旗"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "工業的な屋根 コーナー部分"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "工業的な屋根 コーナー部分"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業的な屋根 部分"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "工業的な壁のコーナー部分"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "工業的な壁のコーナー部分"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業的な壁セット"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業的な壁セット"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業的な壁セット"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業的な壁セット"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業的な壁（戸口付き）"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業的な壁（窓付き）"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "インフォーメーションセンター",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "園内の案内図や傘を売る売店です"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "イヌイット"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "イヌイット"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "鉄"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "イタリア糸杉"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "イタリアの警察ツイスター",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "乗客がイタリアパトカーのペアシートに座り、円形に回転する乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "ジャガー車両",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "ジャガーの形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "日本の桜の木"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "日本の桜の木"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "日本的な垣"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "日本的な垣"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "日本的な垣"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "日本の遊園地の入口"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "日本の松"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "日本的な屋"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "日本的な屋"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "日本的な屋"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的なシルクの旗"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "セイヨウカンボク"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "ジャズのバンドメンバー"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "ジャズのバンドメンバー"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "ジャズのバンドメンバー"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "ジャズのバンドメンバー"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "ジェリーベビー"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "ジェリービーン"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "ジェリービーンの壁"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "ジェット飛行機"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "ジェット飛行機"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "ジェット飛行機"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "ジェットパックブースター",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "逆向きに落下する、大型のジェットパックコースター車両です",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "各車両8名"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "ジェット機車両",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "ジェット機の形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "ジェットスキー",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "乗客が自分で操縦できる、ひとり乗りのジェットスキーです",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "各1名"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "馬上槍試合の騎士",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "シングルレールコースを馬上槍試合の騎士の形の車両が走行する乗物です",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "各車両2名"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "ジャンピング噴水"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "ジャンピング雪玉"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "ジャングル"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "ジャングル風のフェンス"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "ジャングル風のバナー"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "ジャングル風のテーマ"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "ジャングルの木 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "ジャングルの木 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "ジャングルの木（ヒョウ付き）"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "ジャングルの木（蔓植付き）"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "ジャングルドラム・スタイル"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "ジャンク"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "ジュラシック風のバナー"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "ジュラシック風のテーマ"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "ジュラ紀・スタイル"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "カンガルー"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "シャチ潜水艦",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "水中のコースを、シャチの形をした潜水艦に乗り込んで進む乗物です",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "各船5名"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "コアラ車両",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "逆向きフリーフォールのある、コアラの形をした大型コースター車両",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "各車両8名"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "クレムリン　大きな塔　土台"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "クレムリン　大きな塔　中間部分"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "クレムリン　大きな塔　頂上"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "クレムリン　ミナレット部分1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "クレムリン　ミナレット部分2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "クレムリン　ミナレット部分3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "クレムリン　屋根部分1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "クレムリン　屋根部分2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "クレムリン　小さな塔　土台"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "クレムリン　小さな塔　中間部分"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "クレムリン　小さな塔　ミナレット　土台"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "クレムリン　ステップアップの部分1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "クレムリン　ステップアップの部分2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "クレムリンの壁1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "クレムリンの壁2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "クレムリンの壁3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "クレムリンの壁4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "クレムリンの壁5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "クレムリンの壁6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "クレムリンの壁7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "クレムリンの壁8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "リニアモーターコースター",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "リニアモーターで急速発進するローラーコースターで、加速してひねりのある反転を走行します",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "テントウムシ車両",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "てんとう虫形の車両のローラーコースターです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "ランプ"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "ランプ"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "ランプ"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "ランプ"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "ランプ"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "巨大な尖ったマンモスのフェンス"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "巨大な尖ったマンモスのフェンス"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "大きなニレの木"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "巨大なマンモスのフェンス"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "巨大なマンモスのフェンス"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "巨大な隕石火口"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "大きなオーク"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "大きな熱帯雨林の木"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "巨大な赤い隕石火口"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "大きな煙の出る煙突"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "大きなスピーカー"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "大きなトーテムポール"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "レーザーフェンス"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "レーザーフェンス（コーナー）"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "ローンチ・フリーフォール",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "圧搾空気により高いスチールの塔に上がった車両が、重力で下ってくる乗物です",
+    "reference-capacity": "8 passengers",
+    "capacity": "定員8名"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "ローソン糸杉"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "ミニ・サスペンデッド・フライング・コースター",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "シングルレールコースの特殊なデザインの車両から乗客がうつぶせにぶら下がり、コーナーでは左右に振られるコースターです",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "レイダウン・コースター",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "乗客は特別なハーネスにより寝た状態で固定され、ひねりのあるコースを地面に面したり反転したりして走行します",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "レモネード店",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "昔ながらの新鮮なレモネードを販売するショップです"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "レモネードショップ",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "レモネードを売る売店です"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "エレベーター",
+    "reference-description": "Steel lift cabin",
+    "description": "垂直なタワーの各階を移動する際のエレベーターです",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "ユリ"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "リムジントレイン",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "リムジンをモチーフにしたローラーコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "ライオン"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "ライオン車両",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "ライオンの形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "ゴミ箱"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "ゴミ箱"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "ゴミ箱"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "ゴミ箱"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "丸太小屋"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "丸太小屋"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "丸太の屋"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "丸太の屋"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "丸太の屋"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "丸太のサイド煙突"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "丸太の"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "ログ車両",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "丸太の形をした車両のローラーコースターです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "丸太"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "ログ・フリューム",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "水路を進む丸太舟で、急傾斜から水に飛び込み、乗客はずぶぬれになります",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "各ボート4名"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "ロリポップ"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "セイヨウハコヤナギ"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "ジェットコースター車両",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "垂直ループが可能な、膝の安全バーが付いたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "失われた都市　円柱部分"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "失われた都市　円柱部分"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "失われた都市　平屋根部分"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "失われた都市　平屋根部分"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "失われた都市　平屋根部分"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "失われた都市　階段部分"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "失われた都市　階段部分"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "失われた都市　階段部分"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "失われた都市　階段部分"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "失われた都市　階段部分"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "失われた都市　壁のコーナー部分"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "失われた都市　壁のコーナー部分"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "失われた都市　壁のコーナー部分"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "失われた都市　壁のコーナー部分"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "失われた都市　壁部分"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "低木の茂み"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "豪華船 舳先"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "豪華船 中間部分"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "豪華船 船尾"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "暗黒時代のメイス",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "乗客は、回転するアームに取り付けられた座席に座ります.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "各1名"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "空飛ぶ絨毯",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "4本のアームの端に大きな空飛ぶじゅうたんの車両が付き、上下しながら回転する乗物です",
+    "reference-capacity": "12 passengers",
+    "capacity": "定員12名"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "魔法の鎧"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "魔法のヘルメット"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "魔法の盾"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "魔法の剣"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "モクレン"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "マハーラージャ宮殿 アーチ 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "マハーラージャ宮殿 アーチ 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "マハーラージャ宮殿 ドーム"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "マハーラージャ宮殿 ピース"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "マハーラージャ宮殿 ピース"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "マハーラージャ宮殿 ピース"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "マハーラージャ宮殿 タワー土台"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "マハーラージャ宮殿 タワー円柱"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "マハーラージャ宮殿 タワー頂点"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "マハラジャ蒸気機関車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "レプリカの蒸気機関車と給炭車、屋根付きの木製客車からなるミニチュア列車です",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "オシドリのボート",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "前座席の乗客のペダルで動くアヒル型ボート",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "各ボート4名"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "マングローブの木"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "マンタボート",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "マンタボート型の車両のローラーコースターです",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "大理石の屋根"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "大理石の屋根"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "大理石の屋根"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "大理石の屋根"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "マルディグラのダンサー"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "マルディグラのダンサー"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "大テント"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "マシュマロ"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "マシュマロ"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "火星"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "火星風の建物"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "火星人のオブジェクト"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "火星人のオブジェクト"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "火星人のオブジェクト"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "火星人のオブジェクト"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "火星人のオブジェクト"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "火星人風のテーマ"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "火星人風の壁"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "火星スタイル"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "迷路",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "高さ6フィート(約1.8m)の生垣または壁を持つ迷路で、出口が見つからないと出られません"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "肉団子スープショップ",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "中華風の肉団子スープを売る売店です"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "機械風のテーマ"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "メカニカル・スタイル"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "中世風のテーマ"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "中世・スタイル"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "石化した男"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "石化した男"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "石化した男"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "石化した男"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "メリーゴーラウンド",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "昔ながらの木彫りの回転木馬です",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "メッシュのフェンス"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "メッシュのフェンス"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "隕石火口 コーナー"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "隕石火口 コーナー"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "隕石火口 コーナー（内側）"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "隕石火口 壁"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "隕石火口 壁（クリスタル）"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "隕石火口 壁（クリスタル）"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "マイヤーの青ネズの木"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "マイクロバスライド",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "映像に合わせて動く、フラワーパワーのテーマをした水力式モーションシミュレーターポッド",
+    "reference-capacity": "8 passengers",
+    "capacity": "定員8名"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "マイクロバス"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "木造ワイルドマイン",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "小さなトロッコが木製のコースをジグザグに走り、危なっかしくヘアピンを曲がったり急降下したりするスリリングな乗物です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "マイン・カー",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "木製のトロッコ型の個別の車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "鉱山カートトレイン",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "パッド入りの座席と安全バーの付いた木製のコースター",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "採掘小屋"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "採掘小屋"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "鉱山リフトキャビン",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "鉱山で利用される、スチール製のエレベーターキャビン",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "採掘シャフト"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "鉱山風のテーマ"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "マイン・トレイン",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "昔の線路のようなスチールのコースを走る、鉱山列車をイメージしたコースターです",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "各車両2名または4名"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "ミニゴルフ",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "やさしいミニゴルフゲームです",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "ミニヘリコプター",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "スチール製コースを走るヘリコプター型の動力付き車両で、乗客がペダルを使って操作します",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "ミノタウロスの像"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "ミント"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "モダン・スタイル"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "モンキーパズルの木"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "モンスタートラック",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "動力付きで、急斜面もものともしない巨大な四輪駆動車です",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "各車両2名"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "モンテレー糸杉"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "モンテスマ松"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "記念碑　壊れた壁部分"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "記念碑　噴水"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "記念碑　階段部分"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "記念碑　階段部分"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "記念碑　階段部分"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "記念碑　階段部分"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "記念碑　壁のコーナー部分"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "記念碑　壁のコーナー部分"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "記念碑　壁のコーナー部分"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "記念碑　壁のコーナー部分"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "記念碑　壁部分"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "月ジュース",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "最新のソフトドリンクを販売する屋台です"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "モザイクの木造"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "動くシミュレーター",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "映像に合わせて油圧可動式のポッドが動くシミュレーターです",
+    "reference-capacity": "8 passengers",
+    "capacity": "定員8名"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "オートバイレース",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "シングルレールコースをオートバイの形の車両が走行する乗物です",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "オートバイ"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "オートバイ"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "ネズミ車両",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "各車両がネズミの形をした乗物です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "木造ワイルドマウス",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "小さなネズミの形をした車両が木製のコースをちょこまかと走り回り、危なっかしくヘアピンを曲がったり急降下したりするスリリングな乗物です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "泥の屋"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥の壁"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "多次元コースター列車",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "乗客を縦方向に逆さまにできる座席を備えた車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "神話の遊園地の入口"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "神話のテーマ"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "北米土人"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "自然水"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "航海 屋根の柵（コーナー）"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "航海の屋"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "航海の屋"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "航海の屋"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "航海の屋"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "航海の屋"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "航海 屋根の柵"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "航海の壁"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "ネオンのダイナーサイン"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "ネオンのダイナーサイン"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "ネオンのダイナーサイン"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "ネオンのダイナーサイン"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "ネプチューンのツイスター",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "ネプチューン像の周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "ネプチューンのシーフード店",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "ネプチューンの塩辛い食べ物を売る店です"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "ニューヨーク　コーナーのフィラー"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "ニューヨークの遊園地の入口"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "ニューヨーク　コーナーの内側部分"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "ニューヨーク　コーナーの内側部分"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "ニューヨーク　コーナーの内側部分"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "ニューヨーク　コーナーの内側部分"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "ニューヨーク　コーナーの内側屋根部分"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "ニューヨーク　屋根部分"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "ニューヨーク　屋根部分"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "ニューヨーク　屋根部分"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "ニューヨーク　屋根部分"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "ニューヨーク　屋根部分"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "ニューヨーク　壁部分"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "ニューヨーク　壁（物干しロープ付き）"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "ニューヨーク　壁（物干しロープ付き）"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "ニューヨーク　物干しロープ"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "ニューヨーク　物干しロープ"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "入口なし"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "入口なし、乗り場なし"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "北アメリカの遊園地の入口"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "北アメリカのテーマ"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "ドイツトウヒ"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "オーク樽",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "オーク樽のボートが、滝や急流を曲がりくねって流れるスリリングな乗物です",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "各ボート8名"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "黒曜石　高層ビル ドア部分"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "黒曜石　高層ビル 壁部分"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "黒曜石　高層ビル 角（緩やか）"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "黒曜石　高層ビル 角（緩やか）"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "黒曜石　高層ビル 傾斜した壁（緩やか）"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "黒曜石　高層ビル 角（急）"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黒曜石　高層ビル 傾斜した壁（急）"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黒曜石　高層ビル 傾斜した壁（急）"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黒曜石　高層ビル 傾斜した壁（急）"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "黒曜石　高層ビル 壁"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "黒曜石　高層ビル 壁（窓付き）"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "雑居ビル"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "オイル樽"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "オイルポンプ"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "一面に茂った古い木"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "オレンジの水"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "オルガン・スタイル"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "オリエンタル・スタイル"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "装飾建造物"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "装飾建造物"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "装飾建造物"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "装飾の木"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "装飾用の木"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "装飾用の木"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "装飾用の木"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "装飾の木"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "豪華な大理石の壁"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "ダチョウトレイン",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "ダチョウをモチーフにした、立ち乗りのローラーコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "アウトリガーカヌー",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "乗客自身が漕ぐロングカヌーです",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "各カヌー2名"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "パゴダ"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "パゴダ"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "パゴダ"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "パゴダ"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "パゴダ"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "パゴダのバナー"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "パゴダのテーマ"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "パゴダ"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "ヤシの木"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "ヤシの木"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "ヤシの木"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "ヤシの木"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "ヤシの木"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "パンダのゴミ箱"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "パンダのテーマ"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "パンダのトレイン",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "可愛いパンダカーのジェットコースタートレイン",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "遊園地の入口の建物"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "遊園地の入口のゲート"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "農民の小屋"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "ペガサスカート",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "ペガサスが引っ張る動力つきのカート車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "ペンギンボブスレー",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "ペンギンの形をした二人乗りのボブスレー車両",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "1920時代の車"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "1920時代の車"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "1920時代のダイナー"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "暗黒時代の旗"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "1920時代のヨット"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "1920時代のStreet Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "1920時代のトラック"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "1920時代のトラック"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "ガソリンスタンド"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "ピックアップトラック",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "ピックアップトラックの形をした、動力付きの乗物です",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "各車両1名"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "ピンクの水"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "パイプ"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "パイプ部分"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "パイプ部分"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "パイプ部分"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "海賊の旗"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "パイレーツシップ",
+    "reference-description": "Large swinging pirate ship",
+    "description": "前後にスイングする大きなパイレーツです",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "海賊船"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "海賊風のテーマ"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "パイレーツ・スタイル"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "ピザショップ",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "ピザを売る売店です"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "普通"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "普通な大理石の壁"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "トランプの壁"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "トランプの壁"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "台座"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "プラウ"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "シロクマ車両",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "ホッキョクグマの形をした、コースにぶら下がったローラーコースター車両で、乗客は2名ずつ背中合わせに座ります。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "ポール"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "ポール"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "ポール"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "パトカー型トレイン",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "垂直ループが可能な、膝の安全バーが付いたパトロールカーのようなローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "パトカー",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "特殊な反転ターンがある木製のコースを1960年代のパトカーが走行するコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "ポップコーンショップ",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "ポップコーンを売る売店です"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "落とし門のドア"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "落とし門のドア"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "柱"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "マイン・ライド",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "動力付きの鉱山列車がスムーズでひねりのあるコースを進む乗物です",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "各車両2名または4名"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "前史時代の遊園地の入口"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "前史時代のテーマ"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "プレッツェル・ショップ",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "サクサクのプレッツェルを売る売店です"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "原始スープ"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "刑務所のドア"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "刑務所のフェンス"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "刑務所　内側部分"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "刑務所　壁のコーナー"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "刑務所　壁のコーナー"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "刑務所　壁部分"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "刑務所　壁の屋根"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "刑務所　見張り塔"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "刑務所　見張り塔　階段"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "刑務所　見張り塔　階段"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "刑務所　給水塔"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "プテロダクティルス・トレイン",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "コースの下にある快適な座席に座り、究極の先史時代の飛行体験が楽しめるコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "カボチャ"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "カボチャの家"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "ピラミッド"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "行列テレビ"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "レーシングカー",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "レーシングカーの形をした、動力付きの車両です",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "ラプタ・レース",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "シングルレールコースをラプタ形の車両が走行する乗物です",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "各車両2名"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "レース用スピーカー"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "レーダーディッシュ"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "川いかだ",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "川いかだの形のボートが、ゆるやかに曲がりくねった川のコースを進む乗物です",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "各ボート4名"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "ラグタイム・スタイル"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "ガードレール"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "虹色な木造"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "赤レンガ 屋根部分"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "赤レンガ 平面屋根（コーナー部分）"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "赤レンガ 平面屋根（角部分）"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "赤レンガ 屋根部分（内向き）"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "赤レンガの屋1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "赤レンガの屋2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "赤レンガの屋3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "赤レンガの壁1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "赤レンガの壁11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "赤レンガの壁12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "赤レンガの壁13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "赤レンガの壁2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "赤レンガの壁3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "赤レンガの壁4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "赤レンガの壁5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "赤レンガの壁8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "米松"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "米松"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "赤い隕石火口 コーナー"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "赤い隕石火口 コーナー"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "赤い隕石火口 コーナー（内側）"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "赤い隕石火口 壁"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "赤と茶色のタイルの歩道"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "セコイア"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "レトロスタイル・モノレール車両",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "オープンキャビンを持つモノレールです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "逆向きフリーフォールカー",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "逆向きフリーフォールのある、大型コースターです",
+    "reference-capacity": "8 passengers",
+    "capacity": "各車両8名"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "逆向きジェットコースター",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "特殊な反転ターンがある木製のコースをボギー車両が走行するコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "サイ"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "サイ車両",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "サイをモチーフにした直列シートの小型ローラーコースター車両",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "索具"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "リバー・ラピッド",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "円形のボートが、滝や急流のある幅の広い水路を曲がりながら流れて行くスリリングな乗物です",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "各ボート8名"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "三途の川ボート",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "黄泉の国をテーマにしたボートが、ゆるやかに曲がりくねった川のコースを進む乗物です",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "各ボート4名"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "道路"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "1920時代の遊園地の入口"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "1920時代のテーマ"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "1920時代の壁セット"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "ローストソーセージショップ",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "中華風のローストソーセージを売る売店です"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "ロビン・フッドのカヤンプ"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "ロビン・フッドの小屋"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "ロビン・フッドの小屋"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "ロボット"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "ロボット"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "石"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "石"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "ロックンロールの遊園地の入口"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "ロックンロールのテーマ"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "ロックンロールのツアーバス"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "岩の壁"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "ロック・スタイル"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "ロック・スタイル ２番"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "ロック・スタイル ３番"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "ロケットカー",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "車両をロケットに見立てたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "石の木造"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "ローラーコースター賞の像"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "ローラースケートウェイトレス"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "ローマのコロシアム"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "ローマの柱"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "ローマの柱の壁"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "ローマ風　宮殿 コーナー部分"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "ローマ風　宮殿 コーナー部分"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "ローマ風　宮殿 コーナー部分"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "ローマ風　宮殿 コーナー部分"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "ローマ風　宮殿 断面"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "ローマ風　宮殿 断面"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "ローマ風　宮殿 断面"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "ローマ風　宮殿 断面"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "ローマ風　宮殿 末端部分"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "ローマ風　宮殿 末端部分"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "ローマ風　宮殿 柱部分"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "ローマ風　宮殿 柱部分"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "ローマ風　宮殿 柱部分"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "ローマ風　宮殿 柱部分"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "ローマの像"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "ローマの像"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "ローマ寺院"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "ローマ風の壁"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "ローマ風の壁"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "ローマンファンファーレ・スタイル"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "屋根"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "屋根 (灰色)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "屋根 (赤)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "ロトドロップ",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "円形の座席がゆっくりと回りながら高い塔の上まで上がり、落下して磁気ブレーキでリフトに止まります",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "国道66号線サイン"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "ロンドンバス",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "ルートマスターバスのレプリカです",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "各車両10名"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "漕ぎボート",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "乗客が自分で漕ぐ手漕ぎボートです",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "各ボート2名"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "壊れた像"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "滑走路　コーナー部分"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "滑走路　角部分"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "滑走路　コーナーの内側部分"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "滑走路　部分"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "滑走路　部分"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "滑走路　部分"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "錆"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "酒場"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "サンフランシスコ・トラム",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "サンフランシスコ・トラムのレプリカです",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "各車両10名"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "砂"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "砂 (褐)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "砂 (赤)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "砂岩 (茶色)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "砂岩 (灰色)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "砂岩 高層ビル　底 コーナー"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "砂岩 高層ビル　底 コーナー"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "砂岩 高層ビル　底 カーブしたスロープ"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "砂岩 高層ビル　底 コーナー（内側）"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "砂岩 高層ビル　底 スロープ土台"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "砂岩 高層ビル コーナー上部"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "砂岩 高層ビル カーブしたスロープ上部"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "砂岩 高層ビル カーブしたスロープ上部"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "砂岩 高層ビル ドッキングベイ"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "砂岩 高層ビル 玄関口"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "砂岩 高層ビル 充填材"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "砂岩 高層ビル 充填材"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "砂岩 高層ビル コーナー（内側）上部"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "砂岩 高層ビル 中間　コーナー"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "砂岩 高層ビル 中間　コーナー"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "砂岩 高層ビル 中間　カーブしたスロープ"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "砂岩 高層ビル 中間　カーブしたスロープ"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "砂岩 高層ビル 中間　スロープコーナー"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "砂岩 高層ビル　中間　壁部分"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "砂岩 高層ビル　中間　壁部分"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "砂岩 高層ビル　中間　壁部分"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "砂岩 高層ビル　中間　壁部分"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "砂岩 高層ビル　中間　壁部分"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "砂岩 高層ビル　屋根"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "砂岩 高層ビル　屋根の尖塔"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "砂岩 高層ビル　屋根の尖塔"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "砂岩 高層ビル 歩道"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "砂岩 高層ビル 歩道"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "砂岩 歩道　コーナー"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "砂岩 歩道 交差部分"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "砂岩 歩道 末端 部分"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "砂岩 歩道 Tジャンクション"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "衛星"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "衛星放送受信アンテナ"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "スクールバス"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "スクールバストラム",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "北アメリカのスクールバスをテーマにしたミニチュアトラムです",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "各車両10名"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "スコットランド松"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "スクロール看板"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "スクロール看板"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "彫刻"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "彫刻"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "シーフード・ショップ",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "揚げた触手を売る売店です"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "水上飛行機"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "アザラシトレイン",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "アザラシの形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "水上飛行機のピット"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "水上飛行機のピット"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "サーチライト"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "席"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "シヴァ"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "低木と装飾品"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "シャトル"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "シャトル"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "障子の壁"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "サイドワークの歩道"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "バナー"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "歩道用の看板とアイテム"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "シラカバ"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "クィフの歌手"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "展望台",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "展望キャビンが回転しながら高い塔を登ります",
+    "reference-capacity": "20 passengers",
+    "capacity": "定員20名"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "シックスフラッグスのテーマ"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "バーティカル・ドロップ・ジェットコースター",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "超幅広の車両が垂直に切り立ったコースを降下する、究極のフリーフォール体験ができるコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "骸骨"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "スキーリフト車両",
+    "reference-description": "Open cars for chairlift",
+    "description": "屋根のないリフトカーです",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "スキードゥー・バンパーカー",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "スキードゥーの形をしたバンパーカーです",
+    "reference-capacity": "1 person per car",
+    "capacity": "各1名"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "頭蓋骨"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "頭蓋骨"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高層ビル 壁部分"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高層ビル 壁部分"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高層ビル 壁部分"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "スカイワークの歩道"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "高層ビル (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "高層ビル (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "高層ビル 凹型部分"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "高層ビル 凹型屋根"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "高層ビル 凸片部分"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "高層ビル 凸片 Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "高層ビル エスカレーター部分"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "高層ビル エスカレーター部分"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "高層ビル エスカレーター部分"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "高層ビル エスカレーター部分"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "高層ビル エスカレーター部分"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "高層ビル 金属セット 1 凹型部分"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "高層ビル 金属セット 1 凸片部分"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "高層ビル 金属セット 1 壁部分"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "高層ビル 金属セット 2 凹型部分"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "高層ビル 金属セット 2 凹型部分"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "高層ビル 金属セット 2 凸片部分"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "高層ビル 金属セット 2 壁部分"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "高層ビル 金属セット 2 壁部分"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "高層ビル 屋根部分"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "高層ビル 末"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "ナマケモノ車両",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "コースにぶら下がったナマケモノ型の車両が、コーナーで大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "小さな尖ったマンモスのフェンス"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "小さな尖ったマンモスのフェンス"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "小さいはめ歯歯車"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "小さいはめ歯歯車"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "小さいはめ歯歯車"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "小さいはめ歯歯車"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "小さな地球圏"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "小さな隕石火口"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "小さなモノレール車両",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "横の空いた小さなモノレールです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "小さな熱帯雨林の木 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "小さな熱帯雨林の木 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "小さな赤い隕石火口"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "小さなスピーカー"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "煙突 土台"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "煙突 中間"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "カタツムリ"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "雪"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "雪をかぶったバナー"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "雪のカップ",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "スノーマンが中心にいて、その周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "雪と氷のテーマ"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "スノー・スタイル"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "雪をかぶったカフカスモミの木"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "雪をかぶったドイツトウヒ"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "雪をかぶった米松"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "雪をかぶった米松"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "雪玉"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "スノーマン"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "石鹸箱ダービーレース",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "石鹸入れの形をした車両の、シングルレールコースのローラーコースターです",
+    "reference-capacity": "4 riders per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "ぬいぐるみ屋",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "可愛い恐竜のぬいぐるみを売っているお店です"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "南アメリカのテーマ"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "南アメリカの遊園地の入口"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "お土産ショップ",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "ぬいぐるみや傘を売る売店です"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "豆乳ショップ",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "パック入りの豆乳を売る売店です"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "スペース"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "宇宙カプセル"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "宇宙カプセル"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "宇宙のオーブ"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "スペースリング",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "同軸のスペースリングで、全方向に回転する乗物です",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "各1名"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "宇宙ロケット"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "宇宙船　カーゴ部分"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "宇宙船　通信部分"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "宇宙船　コントロールデック"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "宇宙船　断面部分"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "宇宙船　ドッキング部分"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "宇宙船　エンジン部分"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "宇宙船　燃料部分"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "宇宙船　重力部分"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "宇宙船　居室部分"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "宇宙船　理系部分"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "宇宙船　ソーラーパネル"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "宇宙船　ソーラー部分"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "スペース風歩道"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "スペース風のバナー"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "スペース風のテーマ"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "スペース・スタイル"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "スペード型の木"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "スフィンクス"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "クモ"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "釘のフェンス"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "スピニング・ワイルド・マウス車両",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "ネズミの形をした車両がタイトコーナーや短い降下を走り回り、スピンして方向感覚が失われる乗物です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "スパイラル・コースター",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "スパイラルリフトヒルを持つスチール製のコースで、シートが直列しているローラーコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "状の滑り台",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "木製の建物で、中には階段が、外にはらせん状の滑り台があり、マットを使って滑ります"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "スプラッシュ・ボート",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "大定員のボートが幅の広い水路を進んでいき、ベルトコンベヤーで傾斜を上がると加速して一気に急傾斜を下り、水に突っ込んで乗客がずぶ濡れになる乗物です",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "定員16名"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "薄気味悪いテーマ"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "スポーツカー",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "スポーツカーの形をした、動力付きの車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "スポーツ風のテーマ"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "スプートニク"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "スプートニク車両",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "上部のレールからスイングする、スプートニクの形をした車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "リスの形の木"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "駅馬車",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "パッド入りの座席と安全バーがついた、駅馬車の形をしたコースター車両です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "押し寄せる恐竜の群れトレイン",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "猛威を振るう恐竜の群れをテーマにした、立ち乗りのローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "立ち乗りローラーコースター",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "立ち乗りの、ループローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "立ち乗り・ツイスター・コースター",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "特殊な安全装置の付いた幅広の立ち乗りコースターで、スムーズな降下や複数の反転のあるコースを疾走します",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "スターフルーツ・ショップ",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "スターフルーツの飲み物を売る売店です"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "像"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "像"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "像"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "自由の女神像"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "蒸気機関車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "レプリカの蒸気機関車と炭水車、屋根なしの木製客車からなるミニチュア列車です",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "各車両6名"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "屋根の蒸気機関車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "レプリカの蒸気機関車と炭水車、布製の屋根の木製客車からなるミニチュア列車です",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "各車両6名"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "湯気を立てる下水管"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "スチールブロック"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "スチールブロック"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "スチール製のフェンス"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "スチール製の格子"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "スチール壁"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "スチール壁"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "スチール製の壁"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "スチール製の壁"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "スチール製の壁"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "スチール製の壁"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "石器時代の寺"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "石のベンチ"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "石のブロック"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "石の超高層ビル　階段　土台"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石の超高層ビルの壁"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石の超高層ビルの壁"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石の超高層ビルの壁"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石の超高層ビルの壁"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石の超高層ビルの壁"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "石の壁"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "石の壁"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "石の壁"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "石の壁"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "椅子"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "椅子"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "流線型のモノレール車両",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "流線型の先頭車と客車から成る、定員の多いモノレールです",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "各車両5名または10名"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "スタッコ (緑)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "スタッコ (灰色)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "スタッコ (紫)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "スタッコ (赤)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "スタッコ (黄)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "サンドイッチショップ",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "新鮮なサブマリンサンドイッチを売る売店です"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "サブマリンライド",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "水中のコースを、潜水艦に乗り込んで進む乗物です",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "各鑑4名"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "スジョングァ・ショップ",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "韓国風の柿ジュースを売る売店です"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "サマー・スタイル"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "サングラスショップ",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "いろいろな種類のサングラスを取りそろえた売店です"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "沈没船"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "スーパーコンピューター　大きなCPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "スーパーコンピューター　モニター"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "スーパーコンピューター　小さなCPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "支持構造物"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "支持構造物"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "支持構造物"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "サーフボードトレイン",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "特殊な安全装置の付いた、サーフボード型の幅広の立ち乗りコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "サスベンデッド・モノレール・トレーン",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "大定員のモノレールです",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "各車両8名"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "水上飛行機車両",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "ぶら下がった水上飛行機型の車両が大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "サスペンデッド・スイング飛行車両",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "ぶら下がった飛行機型の車両が、コーナーで大きく揺れ動くコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "サスペンデッド・スイング車両",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "車両がコーナーを回る際、大きく揺れ動くようになっている吊り下げ式のローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "吊り橋　土台部分"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "吊り橋　土台部分"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "吊り橋　ケーブル部分"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "吊り橋　中間部分"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "吊り橋　初方面1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "吊り橋　初方面2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "吊り橋　塔方面1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "吊り橋　塔方面2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "シダ綱"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "沼地のベトベト"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "沼地の植物"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "沼地の植物"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "沼地の植物"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "スワンボート",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "前席の乗客がペダルを漕いで進む、白鳥型のボートです",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "各ボート4名"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "スイング車両",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "上部のレールからスイングする、小さい車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "スイング・フロアレス車両",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "チェアリフトタイプの座席に座ってぶら下がるローラーコースターで、コーナーで大きく揺れ動きます",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "スイング・インバータ・シップ",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "アームの片側に船が、片側に重りが付いており、360度回転する乗物です",
+    "reference-capacity": "12 passengers",
+    "capacity": "定員12名"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "石に刺さった剣"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Tシャツ店",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "記念のTシャツを売る売店です"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGVトレイン",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "フランス高速鉄道TGVトレインの形をした、リニアモーターのコースター車両",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNTの樽"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNTの木枠"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNTの雷管"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNTの束"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "大灯"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "大灯"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "高い木製のフェンス"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "ターゲット"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "舗装歩道"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "居酒屋"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "テクノ・スタイル"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "ティピー"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "テレポーターキャビン",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "テレポーテーションのような錯覚を与える未来的なエレベーターキャビン",
+    "reference-capacity": "16 passengers",
+    "capacity": "定員16名"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "寺 壊れた壁部分（頭付き）"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "寺院の屋"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "寺 階段部分"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "寺 階段部分"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "寺 壁　コーナー部分"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "寺 壁　コーナー部分"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "寺 壁　コーナー部分"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "寺 壁　コーナー部分"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "寺院の壁"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "寺 壁部分（頭付き）"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "アパート"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "テニスボール"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "テニスネットの壁"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "テニスネットの壁"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "テント"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "テント小屋"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "シロアリ塚"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "テラスハウス"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "兵馬俑"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "タイムマシン",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "ゲストは特別に設計されたポッドで、タイムトラベルのような錯覚を体験します",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "各1名"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "毒キノコ"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "トボガン車両",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "リュージュ形の座席が直列したローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "りんご飴マーケット",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "りんご飴を販売するお店です"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "リンゴ飴店",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "棒にさしたリンゴアメを売る、リンゴ形の売店です"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "トイレ",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "コンクリートのプレハブでできた、ベーシックなトイレです"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "トイレ",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "ログハウス風の建物のトイレです"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "トイレ",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "コンクリートのプレハブでできた、ベーシックなトイレです"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "小型機関銃ツイスター",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "大きな機関銃のレプリカの周りをペアシートが回る乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "トップスピン",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "大きな回転するアームからぶら下がったゴンドラが前後・上下に回転する乗物です",
+    "reference-capacity": "8 passengers",
+    "capacity": "定員8名"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "トーテムポール"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "公会堂"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "トイランド・スタイル"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "トラバント車両",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "トラバント車の形をしたローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "線路 曲線"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "線路 故障"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "線路 末端"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "線路 分岐"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "線路 直線"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "トラクター"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "昔ながらの遊園地の入口"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "トラム",
+    "reference-description": "Old-timer replica trams",
+    "description": "昔の路面電車のレプリカです",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "各車両10名"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "旅人のトラック"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "宝箱"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "宝箱"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "宝箱"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "投石機ライド",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "暗黒時代の攻城兵器をもとにした、大きな２つのアームからぶら下がったゴンドラが前後・上下に回転する乗物です",
+    "reference-capacity": "8 passengers",
+    "capacity": "定員8名"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "木"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "木"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "トリケラトプス・バンパーカー",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "トリケラトプス形のバンパーカーに乗り、互いにぶつけ合う乗物です",
+    "reference-capacity": "1 person per car",
+    "capacity": "各車両1名"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "三葉虫ボート",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "三葉虫の型のローラーコースター車両です",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "各車両6名"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "チューダー1階の壁"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "チューダー1階の壁1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "チューダー1階の壁1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "チューダー1階の壁2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "チューダー1階の壁2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "チューダー1階の壁3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "チューダー1階の壁3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "チューダー1階の壁4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "チューダー1階の壁4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "チューダー1階の壁5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "チューダー1階の壁5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "チューダー1階の壁6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "チューダー1階の壁7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "チューダー1階の壁8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "チューダーの屋1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "チューダーの屋1（延出片）"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "チューダーの屋2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "チューダーの屋3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "チューダーの屋4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "チューダーの壁1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "チューダーの壁2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "チューダーの壁3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "チューダーの壁4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "カメボート",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "丸い小型ボートで、乗客が操作する中央部のモーターで動きます",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "各ボート2名"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "ツイスト",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "3本の回転する長いアームの先に、それぞれペアシートが付いた乗物です",
+    "reference-capacity": "18 passengers",
+    "capacity": "定員18名"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "ツイスト",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "ハート形のひねりを持つローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "ツイスト (逆走で始まる)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "ハート形のひねりを持つローラーコースター(逆向きスタート)です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "ツイスター・ジェットコースター",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "さまざまな反転を持つスムーズなスチールコースを滑走する幅広のローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFOの事故現場"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "ユニコーン像"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "都会風のテーマ"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "都市・スタイル"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "ヴァルキリー"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "ヴァルキリー"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "ヴァルキリー・トレイン",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "ワルキューレをモチーフにした、垂直落下が可能な幅広車両のローラーコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "縦の3D看板"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "インバーテッド・バーティカル・シャトル",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "乗客はコースの下にぶら下げられ、垂直なコースを後ろ向きに登って降下し、ループとひねり、きつい反転を走行します",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "つるの木"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "ヴィンテージカー",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "クラシックスタイルの動力付き車両が、あらかじめ決められたコースを進む乗物です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "バージニア・リール",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "円形の車両が木製のコース上を回転しながらジグザグに進んで行く乗物です",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "空々"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "火山"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "火山と小さな木"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "ボスキングサリ"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "ワゴン"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "ワゴン"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "ワゴンの車輪"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "壁"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "壁のアーチ"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "通路付きの壁"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "壁と屋根"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "クルミの木"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "ワシントンの像"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "スズメバチ"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "水を使用したテーマ"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "ウォータージェット"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "排水管"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "ウォーター・トライサイクル",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "浮力を持った車輪の、ペダル漕ぎ三輪車です",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "各車両2名"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "ウォーター・スタイル"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "滝"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "土壁の屋"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "土壁の屋"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "土壁の屋"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "土壁"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "武器セット"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "シダレヤナギ"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "車輪"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "ウィスキー樽"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "ウィスキー樽"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "白ビショップ"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "白キング"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "白ナイト"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "白ポーン"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "ウラジロハコヤナギ"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "ホワイトクイーン"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "ホワイトルーク"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "大西部風テーマ"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "ワイルドウエスト・スタイル"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "風で削られた 凹片屋部分"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "風で削られた 凹片壁部分"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "風で削られた 凹片な壁部分"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "風で削られた 凸片屋部分"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "風で削られた 凸片な壁部分"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "風で削られた 凸片な壁部分"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "風で削られた 床部分"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "風で削られた 床部分"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "風で削られた　岩石層の土台"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "風で削られた　岩石層の土台"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "風で削られた　岩石層の中間部分"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "風で削られた　岩石層の中間部分"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "風で削られた　岩石層の中間部分"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "風で削られた　岩石層の中間部分"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "風で削られた　岩石層の頂上"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "風で削られた　岩石層の頂上"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "風で削られた　平屋根部分"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "風で削られた　平屋根部分"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "風で削られた　平屋根部分"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "風で削られた 壁部分"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "風車"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "窓"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "窓"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "窓"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "魔女のスープショップ",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "濃厚だしのスープを販売するお店です"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "大釜の周りの魔女"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "幼虫車両",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "小さな幼虫の形をしたローラーコースター車両です",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "各車両2名"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "不思議の国のテーマ"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "ワンタンスープ店",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "ワンタンスープを売る売店です"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "木"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "木 (黒)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "木 (赤)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "木製のフェンス（つる付き）"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "木製のフェンス（つる付き）"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "木製のフェンス（枯れたつる付き）"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "木製のフェンス（枯れたつる付き）"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "木製のフェンス（枯れたつる付き）"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "人食い植物と木製のフェンス"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "木"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "木製ブロック"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "木製のカート"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "木製のフェンス"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "木製のフェンスの壁"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "木造の歩道"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "木製の柱の壁"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木製の柱の壁"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木製の柱の壁"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木製の柱の壁"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "木のコースター・トレーン",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "木のコースター・トレーン (6人乗り)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターです",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "木のコースター・トレーン (6人乗り, 逆走)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "膝の安全バーが付いた、パッド入りの座席を持つ木製のコースターで、座席が後ろ向きになっています",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "各車両6名"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "木造のサイドフリクション車両",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "ベーシックな車両の、サイドフリクションローラーコースターです",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "木製のバナー"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "木製の壁"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "木製の壁"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "木製の壁"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "木製の壁"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "難破した飛行機"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "黄色いタクシートレイン",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "長い黄色のタクシーの形をしたギガコースタートレーン",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "各車両4名"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "イチイの木"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "ゼブラ"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "ゼウスの像"
+  }
+}

--- a/objects/ko-KR.json
+++ b/objects/ko-KR.json
@@ -1,0 +1,9582 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'골리앗' 팻말"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'메두사' 팻말"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'니트로' 팻말"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'텍사스 자이언트' 팻말"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920년대 레이싱 카",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920년대 레이싱 카 테마의 고 카트에 타고 레이스를 펼치는 놀이기구",
+    "reference-capacity": "Single-seater",
+    "capacity": "1인승"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950년대 자동차"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950년대 자동차"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950년대 로켓"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950년대 로켓",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "수직으로 솟은 트랙을 오르기 위해 역에서 급가속한 뒤, 다시 역방향으로 되돌아와 역을 통과해서 뒷쪽의 또다른 수직 트랙을 올라가는 인버티드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D 영화관",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "둥근 구 모양의 건물 안에서 3D 영화를 상영하는 영화관",
+    "reference-capacity": "20 guests",
+    "capacity": "손님 20명"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D 팻말"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D 팻말"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4인승 인버티드 롤러코스터 차량",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "거대한 루프, 트위스트와 급격한 낙하 트랙을 따라 이동하며, 탑승객이 트랙 아래에 매달린 좌석에 앉는 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6인승 봅슬레이 차량",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "2명씩 3줄로 앉을 수 있는 하나의 봅슬레이 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "호주 원주민 토착 예술 세트 조각"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "원주민 평면 타일"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "원주민 뱀 예술작품"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "원주민의 혼이 담긴 예술 작품"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "추상적"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "추상적인 테마"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "독성 녹색 물"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "활화도"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "인도 코끼리 성체"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "어른 판다"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "아프리카식 공원 입구"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "아프리카 테마"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "에어 파워드 버티컬 코스터 차량",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "아주 짜릿한 공기 압축 방식으로 발진하여 차량이 수직 트랙을 향해 속력을 높인 뒤, 꼭대기에 다다르면 다시 수직으로 하강하며 다시 탑승장에 도착하는 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "비행선 모노레일 차량",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "유선형의 전두부와 후두부 차량을 가진 대용량의 모노레일 차량",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "차량당 승객 8명"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "알레포 파인 나무"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "외계인의 역사적 구조물"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "외계인의 역사적 구조물"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "외계 식물"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "외계 식물"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "대형 외계 채광창"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "소형 외계 채광창"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "대형 외계 구조물"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "대형 외계 구조물"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "대형 외계 구조물"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "소형 외계 구조물"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "소형 외계 구조물"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "소형 외계 구조물"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "외계 탑 하단"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "외계 탑 중간"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "외계 탑 상단"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "외계 나무"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "외계 나무"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "악어 모양의 나무"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "미식축구"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "미식축구"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "아메리칸 풋볼 헬멧"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "미국 스타일 증기 기관차",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "부드러운 천으로 된 지붕을 가진 나무 객차와 증기 기관차 모형으로 이루어진 모형 증기 기관차 차량",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "아나콘다 차량",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "간단한 안전바가 있는 널찍한 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "꼬치에 꽂힌 동물 요리"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "움직이는 풍선"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "캠프 파이어"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "움직이는 천리안"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "움직이는 아르고호 승무원"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "움직이는 아르고호 승무원"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "움직이는 아르고호 승무원"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "움직이는 우주비행사"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "움직이며 불을 밝히는 혈거인"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "움직이는 체인 소녀"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "움직이는 문중 사람"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "움직이는 흑기사"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "움직이는 흑기사"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "움직이는 잠자리"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "움직이는 새장 안의 독수리"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "움직이는 나쁜 외계인"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "움직이는 나쁜 외계인"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "움직이는 나쁜 외계인"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "움직이는 소방관"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "움직이는 대포"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "움직이는 폭력배"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "움직이는 착한 외계인"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "움직이는 착한 외계인"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "움직이는 착한 외계인"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "움직이는 기사"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "움직이는 기사"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "움직이는 메두사"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "움직이는 경찰관"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "움직이는 로빈 후드"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "움직이는 해골 군대"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "움직이는 해골 군대"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "움직이는 해골 군대"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "움직이는 우주 전사"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "움직이는 스테고사우르스"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "움직이는 티라노사우르스"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "움직이는 트리케라톱스"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "움직이는 파도 왕"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "움직이는 전갈"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "움직이는 전갈"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "날개를 움직이는 익룡"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "남극 테마"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "암컷 영양"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "수컷 영양"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "영양 한 쌍"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "반중력 LCD 광고판"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "반중력 LCD 광고판"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "화살 과녁"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "애리조나삼목"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "아트 데코 구석 조각"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "철책이 있는 아트 데코 구석"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "울타리가 있는 아트 데코 구석"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "창문이 있는 아트 데코 구석"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "창문이 있는 아트 데코 구석"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "창문이 있는 아트 데코 구석"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "아르데코 음식 상점",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "국수와 신선한 레모네이드를 파는 가게"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "아트 데코 반전된 구석 조각"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "아트 데코 반전된 구석 조각"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "아트 데코 지붕 조각"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "아트 데코 상단 구석 조각"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "아트 데코 상단 구석 조각"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "아트 데코 상단 구석 조각"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "아트 데코 상단 조각"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "아트 데코 상단 조각"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "아트 데코 벽 조각"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "문이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "철책이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "철책이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "철책이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "철책이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "창문이 있는 아트 데코 벽"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "창문이 있는 아트 데코 벽"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "연결식 롤러코스터 차량",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "하나의 열로 된 짧은 차량과 개방된 전면부를 가진 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "잿더미 보도"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "정령이 있는 물푸레나무"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "아시아 테마"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "징"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "사시나무"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "아틀라스 동상"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "아토미움"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "오스트레일리아식 공원 입구"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "오스트레일리아 테마"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "오스트레일리아 분수 세트 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "오스트레일리아 분수 세트 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "자동차 차량",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "자동차 모양의 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B급 영화 대형 문어"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B급 영화 대형 거미"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B급 영화 자이언트 스파이더 라이드",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "거대한 B급 영화에서 나오는 거미 주변을 회전하는 좌석에 손님이 짝을 지어 타는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "아기 인도 코끼리"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "아기 판다"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "배드민턴 라켓"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "배드민턴 라켓"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "공 모양 초롱"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "공 모양 초롱"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "풍선 가게",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "헬륨이 든 풍선을 파는 기념품 가게"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "대나무 수풀"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "대나무 주추"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "대나무 지붕"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "대나무 지붕"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "대나무 지붕"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "죽순"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "대나무 벽"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "밴드 멤버"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "밴드 멤버"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "밴드 멤버"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "밴드 멤버"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "은행"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "곡예 비행기 코스터",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "거대한 루프, 트위스트와 급격한 낙하 트랙을 따라 이동하며, 탑승객이 트랙 아래에 매달린 좌석에 앉는 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "통"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "통"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "통"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "통"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "기본 블록"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "기본 블록"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "기본 블록"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "기본 블록"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "공성 망치 차량",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "한 줄로 된 좌석과 나선형 리프트 힐이 있는 강철 트랙 롤러코스터",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "고기 국수 가게",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "중국식 고기 국수를 파는 가게"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "의자"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "나무 의자"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "의자"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "벤치"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "뱅갈 호랑이 차량",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "하트라인 트위스트에서 사용할 수 있는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "모노레일 자전거",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "탑승자가 직접 페달을 밟으면 강철 모노레일 트랙 위를 움직이는 특별한 자전거",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "자전거 당 1명의 탑승객"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "빅벤과 영국 국회 의사당"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "대형 구"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "자전거를 타는 사람"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "검은색 비숍"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "런던 택시",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "런던 택시 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "흑사병 차량",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "반원형 트랙의 커브와 뱅킹만을 따라 이동하는 봅슬레이 모양의 차량을 타고 이리 저리 꼬여있는 트랙을 따라 내려오는 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "검은색 킹"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "검은색 나이트"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "검은색 폰"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "흑양목"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "검은색 퀸"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "검은색 룩"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "외계 전망탑",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "높은 탑을 따라 올라가면서 회전하는 전망대 객실",
+    "reference-capacity": "20 passengers",
+    "capacity": "승객 20명"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "블록"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "블록"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "봅슬레이 차량",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "2인승 열차로 구성된 연결식 열차",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "끓고 있는 솥"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "뼈"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "뼈 울타리"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "뼈"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "부메랑"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "부메랑 차량",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "아주 짜릿한 공기 압축 방식으로 발진하여 차량이 수직 트랙을 향해 속력을 높인 뒤, 꼭대기에 다다르면 다시 수직으로 하강하며 다시 탑승장에 도착하는 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "벽돌 벽"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "벽돌 벽"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "벽돌 벽"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "영국식 우편함"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "영국 공중전화 박스"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "부서진 동상"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "부서진 바퀴"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "갈색 타맥 보도"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "거품이 이는 타르갱"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "바구니"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "건물"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "건물"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "신칸센 코스터",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "일본 신칸센 테마의 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "부들"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "범퍼 보트",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "중앙 모터에 의해 움직이며 탑승객이 조종할 수 있는 원형의 작은 보트",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "보트당 2명의 승객"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "부표"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "부표"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "햄버거 가게",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "햄버거를 파는 햄버거 모양의 건물"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "수풀"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "나비"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "탈의실 베란다"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "탈의실 베란다"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "탈의실 지붕 조각"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "탈의실 지붕 조각"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "탈의실 지붕 조각"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "탈의실 파라솔"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "탈의실 벽 조각"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "캐비지 야자"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "선인장"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "선인장"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "선인장"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "선인장"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "선인장"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "캠퍼다운 느릅나무"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "카나리아 야자수"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "사탕"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "사탕"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "사탕"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "사탕 스틱"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "사탕 나무"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "사탕 나무"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "사탕 나무"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "사탕 스타일"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "솜사탕 가게",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "분홍색 솜사탕을 파는 솜사탕 모양의 건물"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "대포"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "대포"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "대포알"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "카누",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "탑승객이 스스로 페달을 밟는 긴 카누",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "카누당 2명의 승객"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "천막 지붕"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "캔버스 텐트"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "카니발 플로트 라이드 - 나비 차량",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "나비 퍼레이드 차량 모양의 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "카니발 플로트 라이드 - 개구리 차량",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "개구리 퍼레이드 차량 모양의 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "카니발 플로트 라이드 - 도마뱀 차량",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "도마뱀 퍼레이드 차량 모양의 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "카트 수갱"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "ATM 기기",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "손님들이 가진 돈이 떨어졌을 때 돈을 찾을 수 있는 ATM 기기"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "성 (갈색)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "성 (회색)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "성 구석 조각"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "성 구석 조각"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "성 입구"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "반전된 성 구석"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "성 내리닫이 쇠창살문"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "성벽"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "성벽 구석"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "성벽 구석"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "성벽 구석"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "반전된 성벽 구석"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "성 탑"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "성 탑"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "성탑"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "성탑"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "성탑"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "성탑"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "성탑 구석 조각"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "성탑 구석 조각"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "성탑 구석 조각"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "성탑 직선 조각"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "성탑 T 조각"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "성탑 T 조각"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "성벽"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "소 두개골"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "코카시안 전나무"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "가마솥"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "동굴 입구"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "석기시대 차",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "석기시대의 고 카트에 타고 레이스를 펼치는 놀이기구",
+    "reference-capacity": "Single-seater",
+    "capacity": "1인승"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "레바논삼목"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "케르베로스 차량",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "탑승객들이 간단한 무릎 안전바만 있는 부드러운 열차에 타고 언덕을 넘으며, 많은 무중력 시간과 함께 크고 부드러운 낙하와 꼬여있는 트랙을 즐기는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "리프트 차량",
+    "reference-description": "Open cars for chairlift",
+    "description": "철제 리프트 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "체스판 블록"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "체셔 고양이",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "트랙을 따라 이동하는 고양이 모양의 차량",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "치킨 너겟 가게",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "프라이드 치킨 너겟을 파는 가게"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "중국 삼나무"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "용"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "차이니즈 드래곤헤드 라이드",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "스스로 운전하는 전기 범퍼카 차량",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "차이니즈 정크 스윙 라이드",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "반대편에 균형추가 있는 지지대에 달려있어 완전히 360도로 회전하는 배 모양의 놀이기구",
+    "reference-capacity": "12 passengers",
+    "capacity": "승객 12명"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "감자칩 가게",
+    "reference-description": "A hut selling chips",
+    "description": "감자칩을 파는 가게"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "감자튀김 가게",
+    "reference-description": "A stall selling chips",
+    "description": "감자튀김을 파는 가게"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "초콜릿 바"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "서킷 보도"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "서커스",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "안에서 서커스 동물 쇼를 진행하는 커다란 텐트",
+    "reference-capacity": "30 guests",
+    "capacity": "손님 30명"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "서커스"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "고전 / 로마"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "고전 스타일 팻말"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "클래식/로마 테마"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "클레오파트라의 바늘"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "넝쿨 나무"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "시계"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "클럽스 모양 나무"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "코스터 보트",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "보트 모양의 롤러코스터 차량",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "보트당 6명의 승객"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "커피 컵 라이드",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "커피 가게",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "커피 한 잔을 파는 예술적인 모습의 상점"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "톱니바퀴"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "톱니바퀴"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "톱니바퀴"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "톱니바퀴"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "콜라 사탕"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "콜로네이드"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "노간주나무"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "참나무"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "주목"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "컴팩트 인버티드 코스터 차량",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "트랙 밑에 매달린 좌석에 2명씩 마주보고 짝지어 앉아 루프와 트위스트와 급격한 전이 트랙을 지나는 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "콘도르 차량",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "하나의 레일로 이루어진 트랙에 매달린 콘도르 모양의 차량에 얼굴을 아래로 한 자세로 타고 코너를 돌 때마다 이리 저리 자유롭게 흔들리는 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 승객 4명"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "콩가 뱀장어 차량",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "어깨 안전바가 있는 뱀장어 모양의 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "침엽수 생울타리"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "침엽수 생울타리"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "컨베이어 벨트 구석"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "컨베이어 벨트 구석 역방향"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "컨베이어 벨트 끄트머리"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "컨베이어 벨트 상승"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "곧은 컨베이어 벨트"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "쿠키 가게",
+    "reference-description": "A stall selling giant cookies",
+    "description": "커다란 쿠키를 파는 가게"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "멋진 녀석"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "나선 롤러코스터 차량",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "어깨 안전바가 있는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "물결 무늬 지붕 조각"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "물결 무늬 강철 기반"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "물결 무늬 강철 지붕"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "물결 무늬 강철 벽"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "물결 무늬 벽 조각"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "코르시카 소나무"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "카우보이 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "카우보이 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "벽돌 보도"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "오싹한 테마"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "악어 보트",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "수로를 따라 이동하다가 긴 낙하를 지나며 물을 튀겨 탑승객을 홀딱 젖게 만드는 악어 모양의 보트",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "보트당 4명의 승객"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "비뚤어진 집",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "사람들이 비뚤어진 방과 각진 복도를 통과하면서 방향을 헷갈리게 만드는 건물",
+    "reference-capacity": "5 guests",
+    "capacity": "손님 5명"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "큐피드 분수"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "곡선형 블록"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "곡선형 블록"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "곡선형 진흙 벽 조각"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "곡선형 진흙 벽 조각"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "곡선형 진흙 벽 조각"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "곡선형 지붕"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "곡선형 지붕"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "곡선형 벽"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "곡선형 벽"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "사용자 음악 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "사용자 음악 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "사이클롭스 라이드",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "대형 사이클롭스의 눈을 운전하는 놀이기구",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "사이클롭스 동상"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "데이지 가로등"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "댐 타워"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "암흑시대 공원 입구"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "암흑시대 테마"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "암흑 시대 마을 구석 지붕 조각"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "암흑 시대 마을 구석 지붕 조각"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "반전된 암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "반전된 암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "암흑 시대 마을 하단 구석 조각"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "암흑 시대 마을 하단 벽 조각"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "암흑 시대 마을 지붕 조각"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "굴뚝이 있는 암흑 시대 마을 지붕"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "암흑 시대 마을 상단 구석 조각"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "암흑 시대 마을 상단 벽 조각"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "암흑 시대 마을 상단 벽 조각"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "암흑 시대 마을 상단 벽 조각"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "암흑 시대 마을 상단 벽 조각"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "암흑 시대 마을 상단 벽 조각"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "암흑 시대 마을 창가 화단"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "암흑 시대 마을 창가 화단"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "암흑 시대 마을 창가 화단 지붕"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "암흑 시대 마을 창가 화단 지붕"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "암흑 시대 마을 창가 화단 지붕"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "암흑 시대 마을 창가 화단 지붕"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "암흑 시대 터번"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "죽은 나무"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "죽은 나무"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "죽은 나무"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "아랍식 보트",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "탑승객이 스스로 페달을 밟는, 장식된 낚시 배",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "보트당 2명의 승객"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "다이아몬드 카트"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "다이아몬드 라이드",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "다이아몬드 수갱"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "다이아몬드 모양 나무"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "디제리두"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "보트",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "반원형 또는 밀폐형 원형 튜브 트랙을 따라 이동하는 공기 주입식 고무 보트",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "보트당 2명의 승객"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "공룡"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "공룡"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "공룡"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "공룡"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "공룡"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "공룡 알 라이드",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "탑승객 두 명이 움직이는 어미 공룡 주위를 도는 좌석에 앉아 즐기는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "지저분한 보도"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "범퍼카",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "스스로 운전하는 전기 범퍼카 차량",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "범퍼카 비트 스타일"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "돌고래 제트스키",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "탑승객이 스스로 운전할 수 있는 돌고래 모양 단일 좌석의 제트 스키",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "차량당 1명의 탑승객"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "돌고래 분수"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "돌고래 동상"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "출입구"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "출입구"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "출입구"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "2층 회전목마",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "나무로 조각된 말이 있는 전통적인 회전 목마",
+    "reference-capacity": "32 passengers",
+    "capacity": "승객 32명"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "2층 전망탑",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "높은 탑을 따라 올라가면서 회전하는 2층 전망대 객실",
+    "reference-capacity": "32 passengers",
+    "capacity": "승객 32명"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "도넛 가게",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "도넛을 파는 가게"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "칙칙한 대형 탑 기본"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "칙칙한 대형 탑 부서진 기본"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "칙칙한 대형 탑 중간 조각"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "칙칙한 대형 탑 상단"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "칙칙한 뾰족탑 조각 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "칙칙한 뾰족탑 조각 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "칙칙한 뾰족탑 조각 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "칙칙한 지붕 조각 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "칙칙한 지붕 조각 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "칙칙한 지붕 조각 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "칙칙한 지붕 조각 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "칙칙하고 작은 탑 기본"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "칙칙하고 작은 뾰족탑 기본"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "칙칙하고 작은 탑 상단 또는 중간 섹션"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "칙칙한 계단 조각 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "칙칙하고 점진적인 조각 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "칙칙한 벽 조각 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "칙칙한 벽 조각 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "칙칙한 벽 조각 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "칙칙한 벽 조각 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "칙칙한 벽 조각 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "칙칙한 벽 조각 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "칙칙한 벽 조각 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "칙칙한 벽 조각 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "칙칙한 벽 조각 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "칙칙한 벽 조각 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "칙칙한 벽 조각 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "드래곤 공격"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "드래곤 코스터",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "드래곤 테마의 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "잠자리 차량",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "하나의 레일로 이루어진 트랙에 매달린 특수 차량에 타고 코너를 돌 때마다 이리 저리 자유롭게 흔들리는 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 승객 2명"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "음료수 가게",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "탄산음료를 파는 캔 모양의 상점"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "이스터 섬 조각상"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "이집트식 기둥"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "이집트 동상"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "이집트 스타일 팻말"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "이집트 테마"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "이집트 벽"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "이집트 스타일"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "에펠 탑"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "전기 울타리"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "부서진 전기 울타리"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "전기 울타리 구석 조각"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "반전된 전기 울타리 구석 조각"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "전등이 달린 전기 울타리"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "코끼리 분수"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "빈 카트"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "에뮤"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "엔터프라이즈",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "원형 놀이기구에 매달린 객실에 탑승하면 처음에 회전하기 시작하여 이후에 지지대에 의해 기울어진 채로 회전하는 놀이기구",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "유칼립투스 나무"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "유럽 테마"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "유럽 낙엽송"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "유럽식 공원 입구"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "나쁜 사무라이"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "파베르의 달걀 라이드",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "페이스오프 차량",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "앞쪽이나 뒤쪽을 보고 2명씩 마주보고 짝지어 앉아 루프와 트위스트와 급격한 전이 트랙을 지나는 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "축제 오르간 스타일"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "판타지 스타일"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "농기구"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "살찐 부처상"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "잔칫상"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "울타리"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "울타리"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "울타리"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "울타리와 벽"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "관람차",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "개방형 의자를 가진 대형 회전 관람차",
+    "reference-capacity": "32 passengers",
+    "capacity": "승객 32명"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "불타는 신호"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "파이팅 카이트 라이드",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "파이팅 나이트 범퍼카",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "말 테마의 범퍼카에서 마상 창 시합을 하는 느낌을 받게 해주는 놀이기구",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "파이어 크래커 라이드",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "원형 놀이기구에 매달린 객실에 탑승하면 처음에 회전하기 시작하여 이후에 지지대에 의해 기울어진 채로 회전하는 놀이기구",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "소화전"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "응급 치료소",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "속이 메스꺼운 손님들이 빨리 회복할 수 있는 장소"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "낚시 구멍"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "고정된 동상"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "불꽃"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "먹이를 먹는 홍학"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "쳐다보는 홍학"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "몸치장을 하는 홍학"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "플로어리스 트위스터 차량",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "꼬여있는 트랙과 여러 전이를 미끄러지듯 통과하면서 승객들에게 광활한 허공을 느끼게 해주는, 바닥이 없는 넓은 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "꽃"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "가든 파워 라이드",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "중앙 모터에 의해 움직이며 탑승객이 조종할 수 있는 꽃 모양의 작은 보트",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "차량당 승객 1명"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "사랑과 평화 티셔츠",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "꽃무늬 티셔츠를 파는 상점"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "플라잉 보트",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "비행정 모양의 차량이 꼬인 커브와 낙하로 구성된 롤러코스터 트랙을 따라 내려온 뒤 물보라를 일으키며 부드럽게 강 섹션으로 내려오는 놀이기구",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "보트당 6명의 승객"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "플라잉 롤러코스터 차량",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "탑승객에게 정말로 나는 듯한 경험을 주기 위해, 트랙 밑에 달린 편안한 좌석에 앉아서 꼬여있는 트랙을 따라 움직이는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "비행 접시",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "스스로 운전하는 호버크래프트 차량",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "축구"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "풋볼 차량",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 풋볼 모양의 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "선악과 나무"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "숲 속 나무"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "분수"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "분수"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "4인승 인버티드 헤어핀 차량",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "급회전과 급경사를 가진 지그재그 모양의 트랙 아래를 달리는 개별 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "프라이드 치킨 가게",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "프라이드 치킨 한 통을 파는 가게"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "볶음쌀국수 가게",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "중국식 볶음쌀국수를 파는 가게"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "떨어진 젤리"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "떨어진 젤리"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "과일 나무"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "과일 나무"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "과일 아이스크림 가게",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "과일 아이스크림을 파는 가게"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "펀 하우스",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "움직이는 벽과 바닥이 지나가는 탑승객들의 방향을 헷갈리게 만드는 건물",
+    "reference-capacity": "5 guests",
+    "capacity": "손님 5명"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "퍼넬 케이크 가게",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "퍼넬 케이크를 파는 가게"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "미래 테마"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "초현대적 공원 입구"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "교수대"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "갱스터 차량",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "역에서 선형 유도 모터에 의해 가속되어 꼬여있는 트랙을 빠른 속도로 통과하는 1920년대 테마의 갱스터 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "꽃"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "정원"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "게이샤"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "일반 상점"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "젠틀 스타일"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "기하학적인 분수"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "기하학적인 조형물"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "기하학적인 조형물"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "기하학적인 조형물"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "기하학적인 조형물"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "기하학적인 조형물"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "조지아식 평평한 지붕 구석"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "조지아식 평평한 지붕 가장자리 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "조지아식 평평한 지붕 가장자리 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "조지아식 지면 바닥 벽 조각 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "조지아식 지면 바닥 벽 조각 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "조지아식 지면 바닥 벽 조각 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "조지아식 지면 바닥 벽 조각 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "조지아식 지면 바닥 벽 조각 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "조지아식 지면 바닥 벽 조각 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "조지아식 현관문 벽 조각 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "조지아식 지붕 끄트머리 조각 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "조지아식 지붕 끄트머리 조각 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "조지아식 지붕 조각 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "조지아식 지붕 조각 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "조지아식 지붕 조각 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "조지아식 지붕 조각 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "조지아식 지붕 조각 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "조지아식 지붕 조각 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "조지아식 벽 조각 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "조지아식 벽 조각 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "조지아식 벽 조각 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "조지아식 벽 조각 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "조지아식 벽 조각 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "조지아식 벽 조각 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "간헐천"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "고스트 트레인 차량",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "으스스한 풍경과 특별한 효과 주변을 지나며 여러 높낮이를 오르내리는 괴물 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "대형 베이스 기타"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "대형 강낭콩 줄기"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "대형 강낭콩 줄기"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "대형 사탕 테마"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "대형 당근"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "대형 공룡 발자국"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "대형 드럼 키트"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "대형 양치식물"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "대형 정원 테마"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "대형 풀"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "대형 기타"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "대형 맹그로브 나무"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "자이언트 판다"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "대형 호박"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "대형 눈송이"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "대형 눈송이"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "대형 눈송이"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "기가 코스터 차량",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "90m 이상의 부드러운 낙하와 상승이 가능한 거대한 강철 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "기린 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "기린 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "기린 동상"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "유리 지붕"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "유리 지붕"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "유리 벽"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "유리 벽"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "유리 벽"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "유리 벽"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "고 카트",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "스스로 운전하는 페트롤 엔진의 고 카트",
+    "reference-capacity": "single-seater",
+    "capacity": "1인승"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "황금 라마"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "황금 조각상 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "황금 조각상 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "금부처상"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "황금 양모"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "골든 노송나무"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "징"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "좋은 사무라이"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "고릴라 차량",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 고릴라 모양의 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "묘비"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "묘비"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "묘비"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "묘비"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "묘지 기념비"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "묘지 기념물"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "묘지 기념비"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "중국 만리장성 앞쪽 벽 조각"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "중국 만리장성 뒤쪽 벽 조각"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "중국 만리장성 중간 벽 조각"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "중국 만리장성 구석 탑"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "중국 만리장성 직선 탑"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "대백상어 차량",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "어깨 안전바가 있는 대백상어 모양의 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "녹색 타맥 보도"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "녹색 물"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "근사한 춤꾼"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS 인데버"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "하데스 동상"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "거울의 방",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "보는 사람의 상을 왜곡시키는, 휘어진 거울이 있는 건물",
+    "reference-capacity": "5 guests",
+    "capacity": "손님 5명"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "항구"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "항구 벽"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "항구 벽 구석 조각"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "항구 벽 구석 조각"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "항구 벽"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "항구 벽과 낚시 도구"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "항구 벽과 정박소"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "항구 벽과 정박소"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "항구 벽과 정박소"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "항구 벽과 정박소"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "하피 차량",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "누운 자세로 탑승하는 특수 차량에 탑승하여 꼬인 트랙과 전이를 앞이나 뒤로 누운 자세로 즐기는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "모자 가게",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "품이 큰 모자를 파는 기념품 가게"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "귀신의 집",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "무서운 복도와 으스스한 방이 있는 대형 테마 건물",
+    "reference-capacity": "15 guests",
+    "capacity": "손님 15명"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "유령의 감옥",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "지나가는 사람들을 겁주기 위해 지하 감옥에 감금된 마네킹 인형이 있는 건물",
+    "reference-capacity": "16 guests",
+    "capacity": "손님 16명"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "귀신의 집 차량",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "으스스한 풍경과 특별한 효과 주변을 지나며 여러 높낮이를 오르내리는 괴물 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "건초"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "하트 모양 나무"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "천상의 욕실 바닥"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "천상의 욕실 풀"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "천상의 욕실 풀 구석"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "천상의 욕실 풀 가장자리"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "천상의 욕실 풀 계단"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "천상의 욕실 지붕"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "천상의 욕실 지붕"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "천상의 욕실 지붕"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "천상의 욕실 지붕"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "천상의 욕실 창문"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "천상의 욕실 아치형 구조물"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "천상의 욕실 아치형 구조물"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "천상의 욕실 아치형 구조물"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "천상의 욕실 건축물"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "천상의 욕실 건축물"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "천상의 욕실 건축물"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "천상의 욕실 건축물"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "천상의 욕실 분수"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "천상의 욕실 분수"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "천상의 욕실 계단"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "천상의 욕실 계단"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "생울타리"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "생울타리"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "헬리패드"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "헤라클레스"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "히바"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "하마 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "하마 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "하마 잠수함",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "수면 아래 코스를 이동하는 잠수함에 탑승하는 놀이기구",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "차량당 5명의 승객"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "수엽나무"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "호러 스타일"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "말"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "말 동상"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "말을 탄 사람 동상"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "말 차량",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "단선 롤러코스터 트랙을 따라 달리는 말 모양의 차량에 탑승하는 놀이기구",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "핫초코 가게",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "핫초코 음료를 파는 가게"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "핫도그 가게",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "핫도그를 파는 가게"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "개조된 자동차"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "개조된 자동차"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "개조 자동차 차량",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "아주 짜릿한 공기 압축 방식으로 발진하여 차량이 수직 트랙을 향해 속력을 높인 뒤, 꼭대기에 다다르면 다시 수직으로 하강하며 다시 탑승장에 도착하는 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "집"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "호버 바이크",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "탑승객들이 미래에서 볼 만한 자전거 모양의 차량에 타고 단일 레일 트랙을 따라 이동하는 놀이기구",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "호버 카",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "미래의 호버 차량같은 느낌을 주기 위해 자기 부상 기술이 탑재된 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "나는 호버바이크"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "나는 호버바이크"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "서 있는 호버바이크"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "서 있는 호버바이크"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "호버보드",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "탑승객이 미래에서 볼 만한 호버보드 위에 올라타 코너를 돌 때마다 이리 저리 자유롭게 흔들리는 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 승객 2명"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "나는 호버카"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "나는 호버카"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "서 있는 호버카"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "서 있는 호버카"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "허스키 카",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "트랙을 따라 이동하는 허스키 썰매 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "하이퍼 트위스터 차량",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "간단한 무릎 안전바를 가진 널찍한 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "하이퍼 트위스터 차량 (광폭형)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "향상된 탑승감과 간단한 무릎 안전바를 갖고 있는 넓은 4인승 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "하이퍼코스터 차량",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "무릎 안전바만 있는 편안한 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "아이스크림 콘 가게",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "아이스크림 콘을 파는 가게"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "얼음 큐브"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "결빙"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "결빙"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "얼음성"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "얼음 공원 입구"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "얼음 파이프 기본"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "얼음 파이프 섹션"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "얼음 배기관"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "눈 지붕"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "얼음 벽"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "얼음 스타일"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "눈 덮인 통"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "눈 덮인 통"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "눈 덮인 통"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "아이스티 가게",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "아이스티 음료를 파는 가게"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "이글루"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "이글루 천장"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "이글루 벽"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "임펄스 차량",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "수직으로 솟은 트랙을 오르기 위해 역에서 급가속한 뒤, 다시 역방향으로 되돌아와 역을 통과해서 뒷쪽의 또다른 수직 트랙을 올라가는 인버티드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "미국 삼나무"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "인디언 실크 깃발"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "인디언 실크 깃발"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "인디언 실크 깃발"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "인디언 실크 깃발"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "인디언 실크 깃발"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "산업 지붕 구석 조각"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "산업 지붕 구석 조각"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "산업 지붕 조각"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "산업 벽 구석 조각"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "산업 벽 구석 조각"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "산업 벽 세트"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "산업 벽 세트"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "산업 벽 세트"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "산업 벽 세트"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "출입구가 있는 산업 벽"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "창문이 있는 산업 벽"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "안내소",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "손님들이 공원 지도를 얻거나 우산을 살 수 있는 상점"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "이누이트"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "이누이트"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "서양노송나무"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "이탈리안 폴리스 라이드",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "재규어 라이드",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "개별적인 차량이 부드러운 트위스트 낙하를 짜임새 있게 내려오는 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "벚나무"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "벚나무"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "일본식 공원 입구"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "일본 소나무"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "쇼지 지붕"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "쇼지 지붕"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "쇼지 지붕"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "일본식 실크 깃발"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "까마귀밥나무"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "재즈 밴드 멤버"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "재즈 밴드 멤버"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "재즈 밴드 멤버"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "재즈 밴드 멤버"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "젤리빈"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "젤리빈"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "젤리빈 벽"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "제트 항공기"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "제트 항공기"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "제트 항공기"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "제트 팩 부스터",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "탑승객이 트랙의 수직 섹션을 따라 발사되는 차량에 탑승하는 놀이기구",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "차량당 8명의 승객"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "제트여객기 차량",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "개별적인 차량이 부드러운 트위스트 낙하를 짜임새 있게 내려오는 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "제트 스키",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "탑승객이 스스로 운전할 수 있는 단일 좌석의 제트 스키",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "차량당 1명의 탑승자"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "기사 차량",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "단선 롤러코스터 트랙을 따라 달리는 말 모양의 차량에 탑승하는 놀이기구",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "도약하는 분수"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "도약하는 눈덩이"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "정글"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "정글 울타리"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "정글 스타일 팻말"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "정글 테마"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "정글의 나무 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "정글 나무 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "표범이 있는 정글의 나무"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "포도가 열린 정글의 나무"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "정글 북 스타일"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "잔해"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "쥐라기 스타일 팻말"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "쥐라기 테마"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "쥐라기 스타일"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "캥거루"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "범고래 잠수함",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "수면 아래 코스를 이동하는 잠수함에 탑승하는 놀이기구",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "차량당 5명의 승객"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "코알라 차량",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "역방향 자유낙하 코스터를 위한 대형 코스터 차량",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "차량당 8명의 승객"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "크렘린 대형 탑 기본"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "크렘린 대형 탑 중간 조각"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "크렘린 대형 탑 상단"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "크렘린 성탑 조각 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "크렘린 성탑 조각 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "크렘린 성탑 조각 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "크렘린 지붕 조각 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "크렘린 지붕 조각 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "크렘린 작은 탑 기본"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "크렘린 작은 탑 중간 섹션"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "크렘린 작은 뾰족탑 기본"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "크렘린 점진적 벽 조각 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "크렘린 점진적 벽 조각 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "크렘린 벽 조각 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "크렘린 벽 조각 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "크렘린 벽 조각 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "크렘린 벽 조각 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "크렘린 벽 조각 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "크렘린 벽 조각 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "크렘린 벽 조각 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "크렘린 벽 조각 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM 발진 롤러코스터 차량",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "역에서 선형 유도 모터에 의해 가속되어 꼬여있는 트랙을 빠른 속도로 통과하는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "무당벌레 차량",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "작은 무당벌레 모양의 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "가로등"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "가로등"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "가로등"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "가로등"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "가로등"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "크게 각진 매머드 울타리"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "크게 각진 매머드 울타리"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "대형 느릅나무"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "대형 매머드 울타리"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "대형 매머드 울타리"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "대형 운석 크레이터"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "대형 오크"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "큰 열대우림 속 나무"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "대형 붉은색 크레이터"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "연기 나는 대형 굴뚝"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "대형 스피커"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "커다란 토템 기둥"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "레이저 울타리"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "레이저 울타리 구석"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "발진 자유낙하 차량",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "압축 공기에 의해 높은 철제 탑을 향해 쏘아올려진 다음 자유 낙하하는 자유 낙하 차량",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "로슨 노송나무"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "레이 다운 차량",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "하나의 레일로 이루어진 트랙에 매달린 특수 차량에 얼굴을 아래로 한 자세로 타고 코너를 돌 때마다 이리 저리 자유롭게 흔들리는 차량",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "차량당 승객 1명"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "레이 다운 롤러코스터 차량",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "누운 자세로 탑승하는 특수 차량에 탑승하여 꼬인 트랙과 전이를 앞이나 뒤로 누운 자세로 즐기는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "레모네이드 시장 상점",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "신선한 레모네이드를 파는 오래된 테마의 가게"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "레모네이드 가게",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "신선한 레모네이드 음료를 파는 가게"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "엘리베이터",
+    "reference-description": "Steel lift cabin",
+    "description": "손님들이 엘리베이터에 타서 수직 탑을 따라 위나 아래 층으로 이동하는 놀이기구",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "백합"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "리무진 롤러코스터",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "리무진 테마의 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "사자"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "사자 차량",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "개별적인 차량이 부드러운 트위스트 낙하를 짜임새 있게 내려오는 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "쓰레기통"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "쓰레기통"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "쓰레기통"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "쓰레기통"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "통나무 집"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "통나무"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "통나무집 지붕 조각"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "통나무집 지붕 조각"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "통나무집 지붕 조각"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "통나무집 측면 굴뚝"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "통나무집 벽 조각"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "통나무 차량",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "작은 통나무 모양의 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "나무"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "통나무 보트",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "수로를 따라 이동하다가 긴 낙하를 지나며 물을 튀겨 탑승객을 홀딱 젖게 만드는 통나무 모양의 보트",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "보트당 4명의 승객"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "막대 사탕"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "양버들"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "롤러코스터 차량",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "무릎 안전바가 있으며 수직 루프를 돌 수 있는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "잃어버린 도시 기둥 조각"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "잃어버린 도시 기둥 조각"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "잃어버린 도시 평평한 지붕 조각"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "잃어버린 도시 평평한 지붕 조각"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "잃어버린 도시 평평한 지붕 조각"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "잃어버린 도시 계단 조각"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "잃어버린 도시 계단 조각"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "잃어버린 도시 계단 조각"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "잃어버린 도시 계단 조각"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "잃어버린 도시 계단 조각"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "잃어버린 도시 벽 구석 조각"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "잃어버린 도시 벽 구석 조각"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "잃어버린 도시 벽 구석 조각"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "잃어버린 도시 벽 구석 조각"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "잃어버린 도시 벽 조각"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "키 작은 수풀"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "호화 여객선 선두"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "호화 여객선 중간 섹션"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "호화 여객선 선미"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "메이스 라이드",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "탑승객이 모터에 의해 회전하는 팔에 달린 의자에 앉아서 즐기는 놀이기구",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "의자당 1명의 승객"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "마법의 양탄자",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "양쪽 끝에 있는 4개의 관절 구조에 의해 원형으로 오르락 내리락하는 커다란 마법 양탄자 테마의 차량",
+    "reference-capacity": "12 passengers",
+    "capacity": "승객 12명"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "마법 아머"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "마법 헬멧"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "마법 방패"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "마법 검"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "목련"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "마하라자 궁전 아치 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "마하라자 궁전 아치 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "마하라자 궁전 돔"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "마하라자 궁전 조각"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "마하라자 궁전 조각"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "마하라자 궁전 조각"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "마하라자 궁전 탑 기본"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "마하라자 궁전 탑 기둥"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "마하라자 궁전 탑 상단"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "마하라자 증기 기관차",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "부드러운 천으로 된 지붕을 가진 나무 객차와 증기 기관차 모형으로 이루어진 모형 증기 기관차 차량",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "객차당 6명의 승객"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "원앙새 보트",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "앞쪽 좌석의 탑승객이 페달을 직접 밟아 움직이는 원앙새 모양의 보트",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "보트당 4명의 승객"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "맹그로브 나무"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "쥐가오리 보트",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "쥐가오리 모양을 한 코스터 보트",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "보트당 6명의 승객"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "대리석 지붕"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "대리석 지붕"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "대리석 지붕"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "대리석 지붕"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "마디 그라 댄서"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "마디 그라 댄서"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "대형 천막"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "마시멜로"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "마시멜로"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "화성 건물"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "화성 물체"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "화성 물체"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "화성 물체"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "화성 물체"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "화성 물체"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "화성 테마"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "화성식 벽"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "화성 스타일"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "미로",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "1.8m 높이의 울타리나 벽으로 구성되어 있고, 손님들이 출구를 찾을 때까지 돌아다녀야 하는 미로",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "고기 완자탕 가게",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "중국식 고기 완자탕을 파는 가게"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "기계 테마"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "기계적인 스타일"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "중세 테마"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "중세 스타일"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "돌이 된 사람"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "돌이 된 사람"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "돌이 된 사람"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "돌이 된 사람"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "회전목마",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "나무로 조각된 말이 있는 전통적인 회전 목마",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "그물 철책"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "그물 철책"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "운석 크레이터 구석"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "운석 크레이터 구석"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "운석 크레이터 반전된 구석"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "운석 크레이터 벽"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "수정이 있는 운석 크레이터 벽"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "수정이 있는 운석 크레이터 벽"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "메이어 향나무"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "마이크로버스 라이드",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "수압식 관절에 의해 흔들리고 움직이는 모션 시뮬레이터 안에서 영화를 보는 놀이기구",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "마이크로버스"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "우든 와일드 광산 차량",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "지그재그 모양의 나무 트랙을 달리면서 급격한 커브와 낙하를 통과하면 트랙을 벗어날 듯 위태롭게 기울어지는 작은 광산 트럭.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "탄광 차량",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "나무 탄광 트럭처럼 생긴 개별 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "탄광 카트 차량",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "푹신한 좌석과 무릎 안전바가 있는 나무 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "탄광 건물"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "탄광 건물"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "탄광 엘리베이터 차량",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "탄광에서 주로 사용하는 철제 엘리베이터",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "갱도"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "광산 테마"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "탄광 차량",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "오래된 선로 트랙처럼 보이지만 튼튼한 강철로 만든 롤러코스터 트랙을 따라 달리는, 광산 차량을 테마로 한 롤러코스터 차량",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "차량당 2명 또는 4명의 승객"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "미니 골프",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "모형 골프 게임",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "미니 헬리콥터",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "탑승자가 페달을 밟아서 철제 트랙을 따라 움직이는 헬리콥터 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "미노타우로스 상"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "민트"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "현대적인 스타일"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "칠레삼나무"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "몬스터 트럭",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "급경사를 오를 수 있는 초대형 4 x 4 트럭",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "트럭당 2명의 승객"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "왕느릅나무"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "몬테수마 소나무"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "기념물 부서진 벽 조각"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "기념물 분수"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "기념물 계단 조각"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "기념물 계단 조각"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "기념물 계단 조각"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "기념물 계단 조각"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "기념물 벽 구석 조각"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "기념물 벽 구석 조각"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "기념물 벽 구석 조각"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "기념물 벽 구석 조각"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "기념물 벽 조각"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "달빛 주스",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "최신 청량음료를 파는 가게"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "모자이크 보도"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "모션 시뮬레이터",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "유압식 관절에 의해 흔들리며 움직이는 모션 시뮬레이터 안에서 영화를 보는 놀이기구",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "모터바이크 차량",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "단선 롤러코스터 트랙을 따라 달리는 오토바이 모양의 차량에 탑승하는 놀이기구",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "자전거당 2명의 승객"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "오토바이"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "오토바이"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "쥐 차량",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "쥐처럼 생긴 개별 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "우든 와일드 마우스 차량",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "나무 트랙 위를 달리면서 급격한 헤어핀 코너와 급등·급락을 지나면서 트랙을 벗어날 듯 위태롭게 기울어지는 작은 쥐 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "진흙 지붕 조각"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "진흙 벽 조각"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "멀티 디멘션 코스터 차량",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "탑승객의 머리와 발을 뒤집어버리는 등의 회전 좌석을 가진 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "신화 입구"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "신화 테마"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "아메리카 원주민"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "기본 물"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "해상 구석 지붕 울타리"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "해상 지붕 조각"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "해상 지붕 조각"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "해상 지붕 조각"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "해상 지붕 조각"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "해상 지붕 조각"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "해상 지붕 울타리"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "해상 벽 조각"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "식당 네온 사인"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "식당 네온 사인"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "식당 네온 사인"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "식당 네온 사인"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "넵튠 라이드",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "탑승객 두 명이 움직이는 포세이돈 동상 주위를 도는 좌석에 앉아 즐기는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "포세이돈의 해산물 가게",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "포세이돈의 짭짤한 음식을 파는 가게"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "뉴욕 구석 충전제"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "뉴욕식 입구"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "반전된 뉴욕 구석 조각"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "반전된 뉴욕 구석 조각"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "반전된 뉴욕 구석 조각"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "반전된 뉴욕 구석 조각"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "반전된 뉴욕 구석 지붕"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "뉴욕 지붕 조각"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "뉴욕 지붕 조각"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "뉴욕 지붕 조각"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "뉴욕 지붕 조각"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "뉴욕 지붕 조각"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "뉴욕 벽 조각"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "선이 있는 뉴욕 벽"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "선이 있는 뉴욕 벽"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "뉴욕 빨랫줄"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "뉴욕 빨랫줄"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "입구 없음"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "감추기, 승강장도 감추기"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "북아메리카식 공원 입구"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "북아메리카 테마"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "노르웨이 가문비나무"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "참나무 통 보트",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "구불구불한 광폭형 수로를 따라 이동하다가 폭포를 통과하면서 탑승객을 젖게 만들고, 거품 급류를 지나며 스릴을 선사하는 참나무 통 모양의 보트",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "보트당 8명의 승객"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "흑요석 마천루 문 조각"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "흑요석 마천루 지붕 조각"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "흑요석 마천루 앝은 경사 구석"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "흑요석 마천루 얕은 경사 구석"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "흑요석 마천루 얕은 경사 벽"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "흑요석 마천루 급한 경사 구석"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "흑요석 마천루 급한 경사 벽"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "흑요석 마천루 급한 경사 벽"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "흑요석 마천루 급한 경사 벽"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "흑요석 마천루 벽"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "창문이 있는 흑요석 마천루 벽"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "사무 빌딩"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "기름통"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "오일 펌프"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "오래된 잡초 나무"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "오렌지색 물"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "오르간 스타일"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "동양 스타일"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "장식용 구조물"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "장식용 구조물"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "장식용 구조물"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "장식용 나무"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "장식용 나무"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "장식용 나무"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "장식용 나무"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "장식용 나무"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "화려하게 장식된 대리석 벽"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "타조 차량",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "손님이 일어선 자세로 탑승하는 루핑 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "아웃리거 카누",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "탑승객들이 스스로 페달을 밟는 긴 카누",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "카누당 2명의 승객"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "탑"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "탑"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "탑"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "탑"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "탑"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "탑 스타일 팻말"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "탑 테마"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "탑"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "야자수"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "야자수"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "야자수"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "야자수"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "야자수"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "판다 휴지통"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "판다 테마 공원"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "판다 열차",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "귀여운 판다 차량이 달린 롤러코스터 열차",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "차량 당 승객 1명"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "공원 입구 건물"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "공원 출입구"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "소작농 막사"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "페가수스 차량",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "트랙을 따라 이동하는 페가수스가 끄는 수레 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "펭귄 차량",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "반원형 트랙의 커브와 뱅킹만을 따라 이동하는 봅슬레이 모양의 차량을 타고 이리 저리 꼬여있는 트랙을 따라 내려오는 놀이기구",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "시대적인 자동차"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "시대적인 자동차"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "시대적인 식당차"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "시대적인 깃발"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "기간 항해 요트"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "기간 가로등"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "시대적인 트럭"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "시대적인 트럭"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "주유소"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "소형 트럭",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "소형 트럭 모양의 차량",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "트럭당 승객 1명"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "파이프"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "파이프 섹션"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "파이프 섹션"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "파이프 섹션"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "해적 깃발"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "바이킹",
+    "reference-description": "Large swinging pirate ship",
+    "description": "흔들리는 거대한 해적선",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "해적선"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "해적 테마"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "해적 스타일"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "피자 가게",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "피자 조각을 파는 가게"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "일반"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "평탄한 대리석 벽"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "잡초"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "잡초"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "트럼프 벽"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "트럼프 벽"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "주춧돌"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "쟁기"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "북극곰 차량",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "앞쪽이나 뒤쪽을 보고 2명씩 마주보고 짝지어 앉아 루프와 트위스트와 급격한 전이 트랙을 지나는 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "막대기"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "막대기"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "기둥"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "경찰차 차량",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "손님이 일어선 자세로 탑승하는 루핑 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "경찰차",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "특수한 반전 섹션 위에서 앞뒤가 뒤집히는 나무 트랙 위를 운행하는 1960년대 테마의 경찰 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "팝콘 가게",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "팝콘 한 바구니를 가득 채워 파는 가게"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "성문"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "성문"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "기둥"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "동력 탄광 차량",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "부드럽게 꼬인 트랙 구조를 따라 달리는 동력 탄광 차량",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "차량당 2명 또는 4명의 승객"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "선사시대 공원 입구"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "선사시대 테마"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "프레첼 가게",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "바삭한 프레첼을 파는 가게"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "원생액"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "감옥 문"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "감옥 울타리"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "반전된 감옥 조각"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "감옥 벽 구석"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "감옥 벽 구석"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "감옥 벽 조각"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "감옥 벽 지붕"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "감옥 감시탑"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "감옥 감시탑 계단"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "감옥 감시탑 계단"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "감옥 급수탑"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "익룡 차량",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "탑승객에게 정말로 선사 시대를 나는 듯한 경험을 주기 위해, 트랙 밑에 달린 편안한 좌석에 앉아서 꼬여있는 트랙을 따라 움직이는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "호박"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "호박 집"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "피라미드"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "대기줄 TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "레이싱 카",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "레이싱 카 모양의 차량",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "차량당 승객 1명"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "랩터 레이서 코스터",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "단선 롤러코스터 트랙을 따라 달리는 랩터 모양의 차량에 탑승하는 놀이기구",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "레이싱 스피커 장치"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "레이더 접시"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "뗏목",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "구불구불한 강 모양의 트랙을 따라 얌전히 이동하는 뗏목 모양의 보트",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "래프트당 4명의 승객"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "래그타임 스타일"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "철책"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "무지개 보도"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "붉은 벽돌 구석 지붕 조각"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "붉은 벽돌 평평한 지붕 구석"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "붉은 벽돌 평평한 지붕 가장자리 조각"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "붉은 벽돌 뒤집한 지붕 조각"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "붉은 벽돌 지붕 조각 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "붉은 벽돌 지붕 조각 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "붉은 벽돌 지붕 조각 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "붉은 벽돌 벽 조각 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "붉은 벽돌 벽 조각 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "붉은 벽돌 벽 조각 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "붉은 벽돌 벽 조각 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "붉은 벽돌 벽 조각 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "붉은 벽돌 벽 조각 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "붉은 벽돌 벽 조각 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "붉은 벽돌 벽 조각 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "붉은 벽돌 벽 조각 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "붉은잣나무"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "붉은잣나무"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "붉은색 운석 크레이터 구석"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "붉은색 운석 크레이터 구석"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "반전된 붉은 유성 크레이터 구석"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "붉은 유성 크레이터 벽"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "삼나무"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "복고풍 모노레일 차량",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "개방형 객차를 가진 모노레일 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "역방향 자유낙하 차량",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "역방향 자유낙하 코스터를 위한 대형 코스터 차량",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "반전 차량",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "특수한 반전 섹션 위에서 앞뒤가 뒤집히는 나무 트랙 위를 운행하는 불안한 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "코뿔소"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "코뿔소 차량",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "한 줄로 된 좌석과 나선형 리프트 힐이 있는 강철 트랙 롤러코스터",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "지붕"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "리버 래피드",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "구불구불한 광폭형 수로를 따라 이동하다가 폭포를 통과하면서 탑승객을 젖게 만들고, 거품 급류를 지나며 스릴을 선사하는 원형 보트",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "보트당 8명의 승객"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "스틱스 강 보트",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "강 모양의 트랙을 따라 조용히 흘러가는 보트",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "보트당 4명의 승객"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "도로"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "광란의 20년대 공원 입구"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "광란의 20년대 테마"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "광란의 20년대 벽 세트"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "구운 소시지 가게",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "중국식 구운 소시지를 파는 가게"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "로빈 후드의 캠프"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "로빈 후드의 막사"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "로빈 후드의 막사"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "로봇"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "로봇"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "로큰롤 공원 입구"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "로큰롤 테마"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "록 밴드 관광 버스"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "바위 벽"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "록 스타일"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "록 스타일 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "록 스타일 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "로켓 차량",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "로켓처럼 꾸며져 있는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "돌무더기 보도"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "롤러코스터 어워드 상"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "롤러스케이팅 웨이트리스"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "로마 콜로세움"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "로마식 기둥"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "로마식 기둥 벽"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "로마궁 구석 조각"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "로마궁 구석 조각"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "로마궁 구석 조각"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "로마궁 구석 조각"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "로마궁 교차 조각"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "로마궁 교차 조각"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "로마궁 교차 조각"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "로마궁 교차 조각"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "로마궁 끝 조각"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "로마궁 끝 조각"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "로마궁 직선 조각"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "로마 궁 직선 조각"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "로마궁 직선 조각"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "로마 궁 직선 조각"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "로마식 동상"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "로마식 동상"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "로마 사원"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "로마식 벽"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "로마식 벽"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "로마 팡파르 스타일"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "천장"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "자이로드롭",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "고리 모양의 좌석이 부드럽게 회전하면서 탑 꼭대기로 들어올려진 뒤에 자유낙하하고, 자기 제동에 의해 바닥에 부드럽게 정지하는 놀이기구",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "66번도 팻말"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "런던 버스",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "유명한 런던 루트마스터 버스의 모형",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "차량당 10명의 승객"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "보트 대여",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "탑승객들이 스스로 노를 저을 수 있는 보트",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "보트당 2명의 승객"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "부서진 동상"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "활주로 구석 조각"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "활주로 가장자리 조각"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "반전된 활주로 구석 조각"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "활주로 조각"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "활주로 조각"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "활주로 조각"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "주점"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "샌프란시스코 전차",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "전차 모형",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "차량당 10명의 승객"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "사암 마천루 하단 구석"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "사암 마천루 바닥 곡선형 경사"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "반전된 사암 마천루 바닥 구석"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "사암 마천루 바닥 경사 기본"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "사암 마천루 구석 꼭대기"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "사암 마천루 곡선형 경사 상단"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "사암 마천루 곡선형 경사 꼭대기"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "사암 마천루 도킹 베이"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "사암 마천루 출입문"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "사암 마천루 필러"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "사암 마천루 충전재"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "반전된 사암 마천루 구석 상단"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "사암 마천루 중간 구석"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "사암 마천루 중앙 구석"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "사암 마천루 중간 곡선형 경사"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "사암 마천루 중앙 곡선형 경사"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "사암 마천루 중간 경사 구석"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "사암 마천루 중앙 벽 조각"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "사암 마천루 중앙 벽 조각"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "사암 마천루 중간 벽 조각"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "사암 마천루 중앙 벽 섹션"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "사암 마천루 중앙 벽 조각"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "사암 마천루 지붕"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "사암 마천루 지붕 첨탑"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "사암 마천루 지붕 첨탑"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "사암 마천루 보도"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "사암 마천루 보도"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "사암 도보 구석"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "사암 도보 교차 조각"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "사암 도보 끝 조각"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "사암 도보 T자형 교차로"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "위성"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "위성 접시"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "스쿨 버스"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "스쿨 버스 라이드",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "노란 버스 테마의 모형 전차",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "차량당 10명의 승객"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "스코틀랜드 소나무"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "스크롤링 전광판"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "전광판"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "조각품"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "조각품"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "해산물 가게",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "구운 문어 다리를 파는 가게"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "수상비행기"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "물개 롤러코스터",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "나선 모양 트랙과 루프를 도는 구성을 지닌 강철 트랙의 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "수상기 피트"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "수상기 피트"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "서치라이트"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "의자"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "시바"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "관목"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "관목"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "관목과 장식품"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "셔틀콕"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "셔틀콕"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "쇼지 벽"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "포장 보도"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "팻말"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "팻말과 보도 아이템"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "자작나무"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "밤 무대 가수"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "전망탑",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "높은 탑을 따라 올라가면서 회전하는 전망대 객실",
+    "reference-capacity": "20 passengers",
+    "capacity": "승객 20명"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "식스 플래그 테마"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "6인승 트위스터 차량",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "자유 낙하의 극한 경험을 선사하기 위해 완전히 수직 경사 트랙을 따라 하강하는 아주 폭이 넓은 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "해골"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "스키 리프트 의자",
+    "reference-description": "Open cars for chairlift",
+    "description": "체어 리프트를 위한 개방형 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "설상 스쿠터 범퍼카",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "스스로 운전하는 전기 범퍼카 차량",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 승객"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "뼈"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "해골"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "마천루 벽 조각"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "마천루 벽 조각"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "마천루 벽 조각"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "공중 보도"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "마천루 오목한 조각"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "마천루 오목한 지붕"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "마천루 볼록한 조각"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "마천루 볼록한 지붕"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "마천루 엘리베이터 조각"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "마천루 엘리베이터 조각"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "마천루 리프트 조각 조각"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "마천루 리프트 조각 조각"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "마천루 리프트 조각 조각"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "마천루 철제 세트 1 오목한 조각"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "마천루 철제 세트 1 볼록한 조각"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "마천루 철제 세트 1 벽 조각"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "마천루 철제 세트 2 오목한 조각"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "마천루 철제 세트 2 오목한 조각"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "마천루 철제 세트 2 볼록한 조각"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "마천루 철제 세트 2 벽 조각"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "마천루 철제 세트 2 벽 조각"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "마천루 지붕 조각"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "마천루 끝"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "나무늘보 라이드",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 나무늘보 모양의 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "작게 각진 매머드 울타리"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "작게 각진 매머드 울타리"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "작은 톱니바퀴"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "작은 톱니바퀴"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "작은 톱니바퀴"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "작은 톱니바퀴"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "작은 지오스피어"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "소형 운석 크레이터"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "소형 모노레일 차량",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "측면이 개방되어 있는 소형 모노레일 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "작은 열대우림 나무 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "작은 열대우림 나무 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "소형 붉은색 크레이터"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "소형 스피커"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "굴뚝 기본"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "굴뚝 중간"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "달팽이"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "눈 / 얼음"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "눈 쌓인 팻말"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "스노우 컵",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "탑승객이 짝지어 좌석에 앉아 눈사람을 기준으로 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "눈과 얼음 테마"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "눈 스타일"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "눈 쌓인 코카시안 전나무"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "눈 덮인 노르웨이 가문비나무"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "눈 쌓인 붉은잣나무"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "눈 쌓인 붉은잣나무"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "눈덩이"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "눈사람"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "조립 경주차",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "하나의 레일로 이루어진 롤러코스터 트랙을 이동하는 조립 경주차 모양의 차량",
+    "reference-capacity": "4 riders per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "봉제인형 가게",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "귀엽고 부드러운 공룡 인형을 파는 가게"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "남아메리카 테마"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "남아메리카식 공원 입구"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "기념품 상점",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "귀여운 장난감 기념품과 우산을 파는 가게"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "두유 가게",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "두유 곽을 파는 가게"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "우주"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "우주 캡슐"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "우주 캡슐"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "천체"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "스페이스 링",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "동심원 모양의 고리가 탑승자를 어느 방향이든 회전시킬 수 있는 놀이기구",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "각 1명"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "우주 로켓"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "우주선 화물 섹션"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "우주선 통신 섹션"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "우주선 컨트롤 덱"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "우주선 교차 섹션"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "우주선 도킹 섹션"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "우주선 엔진 섹션"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "우주선 연료 섹션"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "우주선 중력 섹션"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "우주선 거주 섹션"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "우주선 과학 섹션"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "우주선 태양열 판넬"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "우주선 태양열 섹션"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "우주 스타일 보도"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "우주 스타일 팻말"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "우주 테마"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "우주 스타일"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "스페이드 모양의 나무"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "스핑크스"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "거미"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "침 달린 울타리"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "회전 와일드 마우스 차량",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "급격한 코너와 짧은 낙하를 지나면서 속도를 내고, 차량의 부드러운 회전이 탑승객의 방향 감각을 잃게 만드는 쥐 모양의 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "스파이럴 롤러코스터 차량",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "한 줄로 된 좌석과 나선형 리프트 힐이 있는 강철 트랙 롤러코스터",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "나선 미끄럼틀",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "내부의 계단을 타고 올라가서 외부의 나선형 미끄럼틀을 매트를 타고 내려오는 목재 건물",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "스플래시 보트",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "광폭형 수로를 따라 이동하며 컨베이어 벨트로 경사를 오른 다음, 급경사로 가속하여 탑승객을 커다란 물보라로 홀딱 젖게 만드는 대용량의 보트",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "보트당 16명의 승객"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "으스스한 테마"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "스포츠 카",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "스포츠 카 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "스포츠 테마"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "스푸트니크"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "스푸트니크 차량",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "하나의 레일로 이루어진 트랙에 매달린 특수 차량에 얼굴을 아래로 한 자세로 타고 코너를 돌 때마다 이리 저리 자유롭게 흔들리는 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 승객 2명"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "다람쥐 모양의 나무"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "역마차 롤러코스터",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "좌석이 넓고 무릎에만 안전바가 있는 우든 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "공룡 무리 차량",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "질주하는 공룡 무리 모습의 차량을 타고 가는 루핑 롤러 코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "스탠드 업 롤러코스터 차량",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "손님이 일어선 자세로 탑승하는 루핑 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "스탠드 업 트위스터 열차",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "탑승자들이 선 자세로 낙하와 여러 특수 트랙을 즐길 수 있도록 특수하게 디자인된 안전바가 있는 넓은 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "스타프루트 음료 가게",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "스타푸르트 음료를 파는 가게"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "동상"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "동상"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "동상"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "자유의 여신상"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "증기 기관차",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "나무 객차와 증기 기관차 모형으로 이루어진 모형 증기 기관차 차량",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "객차당 6명의 승객"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "천장이 있는 증기 기관차",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "부드러운 천으로 된 지붕을 가진 나무 객차와 증기 기관차 모형으로 이루어진 모형 증기 기관차 차량",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "객차당 6명의 승객"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "증기 배출"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "강철 블록"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "강철 블록"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "강철 울타리"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "강철 격자"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "강철 벽"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "석기시대 사원"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "석재 의자"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "돌 블록"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "석재 마천루 계단 기본"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "석재 마천루 벽 조각"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "석재 마천루 벽 조각"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "석재 마천루 벽 조각"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "석재 마천루 벽 조각"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "석재 마천루 벽 조각"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "돌 벽"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "돌 벽"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "돌 벽"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "돌 벽"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "변"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "의자"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "유선형 모노레일 차량",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "유선형의 전두부와 후두부 차량을 가진 대용량의 모노레일 차량",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "차량당 5명 또는 10명의 승객"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "샌드위치 가게",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "신선한 서브마린 샌드위치를 파는 가게"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "잠수함",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "수면 아래 코스를 이동하는 잠수함에 탑승하는 놀이기구",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "잠수함당 4명의 승객"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "수정과 가게",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "한국식 수정과를 파는 가게"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "여름 스타일"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "선글라스 가게",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "다양한 종류의 선글라스를 파는 가게"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "침몰선"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "수퍼 컴퓨터 대형 CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "수퍼 컴퓨터 모니터"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "수퍼 컴퓨터 소형 CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "지지대 구조물"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "지지대 구조물"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "지지대 구조물"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "서핑 차량",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "탑승자들이 선 자세로 낙하와 여러 특수 트랙을 즐길 수 있도록 특수하게 디자인된 안전바가 있는 넓은 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "서스펜디드 모노레일 차량",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "대용량의 모노레일 차량",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "차량당 8명의 승객"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "수상비행기 차량",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "서스펜디드 스윙잉 에어로플레인 차량",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 비행기 모양의 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "서스펜디드 스윙잉 차량",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "차량이 코너를 돌면 자유롭게 흔들거리게 만들어진 서스펜디드 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "현수교 기본 조각"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "현수교 기본 간격 조각"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "현수교 케이블 조각"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "현수교 중간 섹션 조각"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "현수교 시작 측면 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "현수교 시작 측면 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "현수교 탑 측면 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "현수교 탑 측면 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "슾지 양치식물"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "늪지대"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "슾지 식물"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "슾지 식물"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "슾지 식물"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "백조 보트",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "앞쪽 좌석의 탑승객이 페달을 직접 밟아 움직이는 백조 모양의 보트",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "보트당 4명의 승객"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "스윙잉 차량",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "레일을 따라 흔들거리는 작은 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "스윙잉 플로어리스 차량",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "코너를 돌면 차량이 자유롭게 흔들리고, 체어 리프트 스타일의 좌석이 있는 매달린 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "360도 바이킹",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "반대편에 균형추가 있는 지지대에 달려있어 완전히 360도로 회전하는 배 모양의 놀이기구",
+    "reference-capacity": "12 passengers",
+    "capacity": "승객 12명"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "돌에 꽂힌 검"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "티셔츠 가게",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "티셔츠 기념품을 판매하는 가게"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV 차량",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "역에서 선형 유도 모터에 의해 가속되어 꼬여있는 트랙을 빠른 속도로 통과하는 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT 통"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT 상자"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT 기폭장치"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT 무더기"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "키 큰 초롱"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "키 큰 초롱"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "키 큰 나무 울타리"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "과녁"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "타맥 보도"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "터번"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "테크노 스타일"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "원뿔형 천막"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "텔레포터 차량",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "탑승객이 수직 탑을 따라 이동하는 엘리베이터에 올라타 여러 높이를 손쉽게 이동하는 놀이기구",
+    "reference-capacity": "16 passengers",
+    "capacity": "승객 16명"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "머리가 있는 사원의 부서진 벽 조각"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "사원 지붕 조각"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "사원 계단 조각"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "사원 계단 조각"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "사원 벽 구석 조각"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "사원 벽 구석 조각"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "사원 벽 구석 조각"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "사원 벽 구석 조각"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "사원 벽 조각"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "머리가 있는 사원 벽 조각"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "다세대 주택"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "테니스 공"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "테니스 네트 벽"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "테니스 네트 벽"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "텐트"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "원뿔형 천막"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "흰개미 언덕"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "테라스 하우스"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "병마용"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "타임 머신",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "특수하게 고안된 구에 앉아, 시간 여행의 환상을 경험하는 놀이기구",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "손님 1명"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "독버섯"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "터보건 썰매 차량",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "한 줄로 탑승하는 터보건 썰매 모양의 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "사과 토피 사탕 시장 상점",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "끈적거리는 사과 토피 사탕을 파는 가게"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "사과 토피 사탕 가게",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "사과 토피 사탕을 막대기에 꽂아 파는 사과 모양의 가게"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "화장실",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "조립식 콘크리트 건물 안에 있는 기본형 화장실"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "화장실",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "통나무 객실 형 건물 안에 있는 화장실"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "화장실",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "조립식 콘크리트 건물 안에 있는 기본형 화장실"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "기관 단총 라이드",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "거대한 기관 단총 모형 주변을 회전하는 좌석에 손님이 짝을 지어 타는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "톱 스핀",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "대형 회전 팔 구조에 매달려있고 앞뒤로 공중제비를 도는 곤돌라에 탑승하는 놀이기구",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "토템 폴"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "시청"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "장난감나라 스타일"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "러시아 차량",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "자동차 모양의 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "굽은 트랙"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "끊어진 트랙"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "끄트머리 트랙"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "분기 트랙"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "직선 트랙"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "트랙터"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "기본 공원 입구"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "전차",
+    "reference-description": "Old-timer replica trams",
+    "description": "옛날 스타일의 전차 모형",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "차량당 10명의 승객"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "여행자 밴"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "보물 상자"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "보물 상자"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "보물 상자"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "투석기 라이드",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "승객들이 암흑 시대의 공성 병기를 기반으로 한 두 개의 거대한 팔에 달린 차량에 타는 놀이기구",
+    "reference-capacity": "8 passengers",
+    "capacity": "승객 8명"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "나무"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "나무"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "트리케라톱스 범퍼카",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "트리케라톱스 모양의 범퍼카에 타고 서로 함께 부딛히는 차량",
+    "reference-capacity": "1 person per car",
+    "capacity": "차량당 1명의 손님"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "삼엽충 보트",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "삼엽충 모양의 차량이 꼬인 커브와 낙하로 구성된 롤러코스터 트랙을 따라 내려온 뒤 물보라를 일으키며 부드럽게 강 섹션으로 내려오는 놀이기구",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "보트당 6명의 승객"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "튜더식 지면 바닥 벽 조각"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "튜더식 지면 바닥 벽 조각 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "튜더식 지면 바닥 벽 조각 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "튜더식 지면 바닥 벽 조각 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "튜더식 지면 바닥 벽 조각 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "튜더식 지면 바닥 벽 조각 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "튜더식 지면 바닥 벽 조각 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "튜더식 지면 바닥 벽 조각 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "튜더식 지면 바닥 벽 조각 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "튜더식 지면 바닥 벽 조각 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "튜더식 지면 바닥 벽 조각 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "튜더식 지면 바닥 벽 조각 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "튜더식 지면 바닥 벽 조각 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "튜더식 지면 바닥 벽 조각 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "튜더식 지붕 조각 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "튜더식 지붕 조각 1 확장 조각"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "튜더식 지붕 조각 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "튜더식 지붕 조각 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "튜더식 지붕 조각 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "튜더식 벽 조각 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "튜더식 벽 조각 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "튜더식 벽 조각 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "튜더식 벽 조각 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "거북이 보트",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "중앙 모터에 의해 움직이며 탑승객이 조종할 수 있는 원형의 작은 보트",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "보트당 2명의 승객"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "트위스트",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "탑승객이 세 개의 긴 회전 팔 구조 끝에 있는 좌석에 짝지어 앉아 빙글빙글 도는 놀이기구",
+    "reference-capacity": "18 passengers",
+    "capacity": "승객 18명"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "트위스터 차량",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "하트라인 트위스트에 적합한 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "트위스터 차량 (역방향)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "하트라인 트위스트에 적합한 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "트위스터 열차",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "여러 종류의 루프를 돌면서 부드러운 강철 트랙을 달리는 넓은 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO 추락 현장"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "유니콘 동상"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "도시 테마"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "도시 스타일"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "발키리"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "발키리"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "발키리 차량",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "자유 낙하의 극한 경험을 선사하기 위해 완전히 수직 경사 트랙을 따라 하강하는 아주 폭이 넓은 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "수직 3D 팻말"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "수직 셔틀 차량",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "트랙 밑에 매달린 차량에 앉아서, 수직 트랙을 따라 뒤쪽 방향으로 올라간 다음 루프와 트위스트를 향해 낙하하는 놀이기구",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "덩굴"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "빈티지 차량",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "트랙을 따라 이동하는 빈티지 모양의 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "버지니아 릴 차량",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "나무 트랙을 이리 저리 따라 이동함에 따라 빙글빙글 돌아가는 원형 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "화산"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "작은 나무가 있는 화산"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "나도싸리"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "마차"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "마차"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "수레바퀴"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "벽"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "벽 아치"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "벽과 지붕"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "호두나무"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "워싱턴 동상"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "말벌"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "인공 폭포 테마"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "물 분사"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "물 분출"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "수중 세발자전거",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "물에 뜨는 바퀴를 가진 페달 달린 세발자전거",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "세발자전거당 2명의 승객"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "수중 스타일"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "폭포"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "초벽 지붕"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "초벽 지붕"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "초벽 지붕"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "초벽 벽"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "무기 세트"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "수양버들"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "바퀴"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "위스키 통"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "위스키 통"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "흰색 비숍"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "흰색 킹"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "흰색 나이트"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "흰색 폰"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "사시나무"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "흰색 퀸"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "하얀색 룩"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "황량한 서부 테마"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "서부 스타일"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "풍화된 오목한 지붕 구석"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "풍화된 오목한 벽 구석"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "풍화된 오목한 벽 구석"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "풍화된 볼록한 지붕 구석"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "풍화된 볼록한 벽 구석"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "풍화된 볼록한 벽 구석"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "풍화된 바닥 조각"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "풍화된 바닥 조각"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "풍화된 바위 층 기반"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "풍화된 바위 층 기반"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "풍화된 바위 층 중간 섹션"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "풍화된 바위 층 중간 섹션"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "풍화된 바위 층 중간 섹션"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "풍화된 바위 층 중간 섹션"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "풍화된 바위 층 꼭대기"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "풍화된 바위 층 꼭대기"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "풍화된 지붕 평평한 지붕 조각"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "풍화된 지붕 평평한 지붕 조각"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "풍화된 지붕 평평한 지붕 조각"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "풍화된 벽 기본"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "풍화된 벽 기본"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "풍화된 벽 조각"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "풍화된 벽 조각"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "풍화된 벽 조각"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "풍화된 벽 조각"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "풍차"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "창문"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "창문"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "창문"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "마녀의 비약 수프",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "걸쭉한 죽 스타일의 수프를 파는 가게"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "가마솥 근처의 마녀"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "애벌레 차량",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "작은 유충 모양의 차량이 있는 롤러코스터 차량",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "차량당 2명의 승객"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "동화나라 테마"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "만둣국 가게",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "만둣국을 파는 가게"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "넝쿨이 자란 나무 울타리"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "넝쿨이 자란 나무 울타리"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "죽은 넝쿨이 있는 나무 울타리"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "죽은 넝쿨이 있는 나무 울타리"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "죽은 넝쿨이 있는 나무 울타리"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "식인 식물 나무 울타리"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "나무"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "나무 블록"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "나무 수레"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "나무 울타리 벽"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "나무 보도"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "나무 울타리"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "나무 울타리"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "나무 울타리"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "나무 울타리"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "우든 롤러코스터 차량",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "푹신한 좌석과 무릎 안전바가 있는 나무 롤러코스터 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "우든 롤러코스터 차량 (6인승)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "푹신한 좌석과 무릎 안전바가 있는 나무 롤러코스터 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "우든 롤러코스터 차량 (6인승, 역방향)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "푹신한 좌석과 무릎 안전바가 있고, 뒤쪽을 본 채로 앉아서 달리는 나무 롤러코스터 차량",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "차량당 6명의 승객"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "우든 사이드 프릭션 차량",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "사이드 프릭션 롤러코스터를 위한 기본 차량",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "나무 팻말"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "나무 벽"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "나무 벽"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "나무 벽"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "나무 벽"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "난파된 수상비행기"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "옐로 택시 차량",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "90m 이상의 부드러운 낙하와 상승이 가능한 거대한 강철 롤러코스터",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "차량당 4명의 승객"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "주목나무"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "얼룩말"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "제우드 동상"
+  }
+}

--- a/objects/nb-NO.json
+++ b/objects/nb-NO.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D kino",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstrakt"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Base Block"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Candy style"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Lerret"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Bankautomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Slott (brun)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Slott (grå)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Sirkus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Klassisk / romersk"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Skjevt hus",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Custom music 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Custom music 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Radiobiler",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Dodgems beat style"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptian style"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Fairground organ style"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasy style"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Pariserhjul",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Førstehjelp",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flyvende tallerkner",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Gentle style"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Spøkelseshus",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horror style"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ice style"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Informasjonskiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungel"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungle drums style"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurassic style"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Tømmer"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Flyvende teppe",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Martian style"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labyrint",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanical style"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medieval style"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Karusell",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Minigolf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Minihelikoptere",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern style"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucker",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Bevegelsessimulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Ingen inngang"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Ingen inngang, ingen plattform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Organ style"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oriental style"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratskip",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratskip"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirates style"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Standard"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime style"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock style"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock style 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock style 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roman fanfare style"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Rotofall",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snø / is"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snow style"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Romfart"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Romringer",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Space style"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiralsklietårn",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splashbåter",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Summer style"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Roterende skip",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Techno style"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Topp spinn",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Toyland style"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twister",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Urban style"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Water style"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wild west style"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Tre"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/nl-NL.json
+++ b/objects/nl-NL.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath'-bord"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa'-bord"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro'-bord"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant'-bord"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Jarentwintig-raceauto's",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Passagiers racen in go-karts die er uitzien als raceauto's uit de jaren '20.",
+    "reference-capacity": "Single-seater",
+    "capacity": "1 persoon per kart"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Jaren 50-auto"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Jaren 50-auto"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Raket jaren '50"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Raketten uit de jaren '50",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes in de vorm van een raket uit de jaren '50, die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D-bioscoop",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Bioscoop in een bolvormig gebouw waarin 3D-films worden getoond.",
+    "reference-capacity": "20 guests",
+    "capacity": "20 passagiers"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D-bord"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D-bord"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Vierpersoonstrein",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Passagiers zitten in stoelen die onder de baan hangen terwijl ze door grote loopings, twists en grote adembenemende afdelingen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Zespersoonsbob",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Passagiers rijden over een kronkelende baan, waarbij ze enkel worden geleid door de ronding en banking van de halfronde baan.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per bob"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Stuk Aboriginalkunst"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Tegel Aboriginals"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Slangkunstwerk Aboriginals"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Spiritueel kunstwerk Aboriginals"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract thema"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Gifgroen water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Actieve vulkanische uitlaat"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Volwassen Indische olifant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Volwassen Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Parkingang in Afrikaanse stijl"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Afrikaans thema"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Trein voor luchtaangedreven verticale achtbaan",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Na een enerverende pneumatische lancering rijdt de trein met hogere snelheid over een verticale baan, over de top, en vervolgens over de andere kant weer naar beneden om terug te keren naar het station.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Zeppelin",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Monorailtreinen met een hoge capaciteit.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagiers per karretje"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppoden"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Vreemde historische bouwsels"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Vreemde historische bouwsels"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Buitenaardse Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Buitenaardse Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Groot buitenaards bovenlicht"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Klein buitenaards bovenlicht"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grote buitenaardse constructie"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grote buitenaardse constructie"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Grote buitenaardse constructie"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Kleine buitenaardse constructie"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Kleine buitenaardse constructie"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Kleine buitenaardse constructie"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Onderkant buitenaardse toren"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Midden buitenaardse toren"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Bovenkant buitenaardse toren"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Buitenaardse boom"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Buitenaardse boom"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Boom in alligatorvorm"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Helm American football"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Amerikaanse stoomtrein",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniatuurstroomtrein bestaande uit een replicastoomlocomotief en tender, die wagons met stoffen overdekking voorttrekt.",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagiers per wagon"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anacondatrein",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Comfortabele treinen met enkel schootbeugels.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Beest aan het spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Ballonnen"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Geanimeerd Kampvuur"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronisch Alles Ziend Oog"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut-animatronic"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut-animatronic"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut-animatronic"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronisch Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronische vuurmakende holbewoner"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronische geketende maagd"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronische Stamgenoot"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronische Duistere Ridder"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronische Duistere Ridder"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Libellen-animatronics"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronische adelaar op kooi"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronisch Slecht Buitenaards Wezen"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronisch Slecht Buitenaards Wezen"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronisch Slecht Buitenaards Wezen"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Brandweermananimatronic"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronisch Schietend kanon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Gangsteranimatronic"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronisch Goed Buitenaards Wezen"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronisch Goed Buitenaards Wezen"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronisch Goed Buitenaards Wezen"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Ridderanimatronic"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Ridderanimatronic"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Medusa-animatronic"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Politieagent-animatronic"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Robin Hood-animatronic"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Leger van skelettenanimatronics"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Leger van skelettenanimatronics"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Leger van skelettenanimatronics"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Ruimteopzichter-animatronic"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronische Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "T-Rex-animatronic"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronische Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Wuivende koninganimatronic"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronische aanvallende Schorpioen"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronische aanvallende Schorpioen"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronische wiekende Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarcticathema"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Vrouwtjesantilope"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Mannetjesantilope"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Paar Antilopen"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antizwaartekracht LCD-reclamebord"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antizwaartekracht LCD-reclamebord"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Schietschijf"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Cipres uit Arizona"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Bochtstuk Art Deco"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Bocht met railing Art Deco"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Bocht met railing Art Deco"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Bocht met vensters Art Deco"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Bocht met vensters Art Deco"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Bocht met vensters Art Deco"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Artdeco-kraam",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Een kraam waar noedels en frisse limonade worden verkocht."
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Omgekeerd Bochtstuk Art Deco"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Omgekeerd Bochtstuk Art Deco"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Dakstuk Art Deco"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Bovenbochtstuk Art Deco"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Bovenbochtstuk Art Deco"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Bovenbochtstuk Art Deco"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Bovenstuk Art Deco"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Bovenstuk Art Deco"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Stuk muur in artdecostijl"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Muur met deur Art Deco"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muur met railing Art Deco"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muur met railing Art Deco"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muur met railing Art Deco"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Muur met railing Art Deco"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muur met vensters Art Deco"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Muur met vensters Art Deco"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Gelede achtbaantrein",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Achtbaantrein met korte karretjes van één rij en een open voorkant.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Voetpad met aslaag"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Es met Nimfen"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Aziatisch thema"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Aziatische Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Espenboom"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlasstandbeeld"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Parkingang in Australische stijl"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australisch thema"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australisch stuk Fontein 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australisch stuk Fontein 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Autokarretjes",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Achtbaankarretjes in de vorm van een auto.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-film reuzenoctopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-film reuzenspin"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-filmspin-twist",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Passagiers zitten per twee in stoelen die rond een reuzenspin uit een B-film draaien.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Jong van een Indische olifants"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badmintonracket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badmintonracket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Bolvormige Lantaarn"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Bolvormige Lantaarn"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Ballonnenkraam",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Een souvenirkraam waar met helium gevulde ballonnen worden verkocht."
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboestruik"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Sokkel van Bamboe"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboedak"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboedak"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboedak"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboescheuten"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboemuur"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Bandlid"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Bandlid"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Bandlid"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Bandlid"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Stuntvliegerstrein",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Een omgekeerde achtbaantrein wordt het station uit gelanceerd en gaat een verticale kronkelende baan op, waarna deze terugzakt, door het station heengaat en achteruit een ander stuk verticale baan opgaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Vat"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Vat"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Vat"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Vat"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Basisblok"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Basisblok"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Basisblok"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Basisblok"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Stormramkarretjes",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Een compacte achtbaan met een spiraalvormige kettingheuvel en karretjes waarin de passagiers achter elkaar zitten.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Rundernoedelkraam",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Een kraam waar Chinese rundernoedels worden verkocht."
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bank"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Krukjes"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengaalsetijgerkarretjes",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Achtbaankarretjes die geschikt zijn voor heartline twists.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Fietsen",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Speciale fietsen rijden over een stalen monorail, voortbewogen door het trappen van de passagiers.",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 persoon per fiets"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben en de Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Grote Geosfeer"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motorrijder"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Zwarte loper"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Londonse taxi's",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Elektrische voertuigen in de vorm van een Londense taxi.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Zwartedoodbobslee",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagiers rijden over een kronkelende baan in ratvormige karretjes, waarbij ze enkel worden geleid door de ronding en banking van de halfronde baan.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Zwarte koning"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Zwart paard"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Zwarte pion"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Zwarte populier"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Zwarte dame"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Zwarte toren"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Klodder uit de ruimte",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Draaiende gethematiseerde observatiecabine die langs een verticale toren omhoog gaat.",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagiers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobslee-trein",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagiers rijden over een kronkelende baan, waarbij ze enkel worden geleid door de ronding en banking van de halfronde baan.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Kookpot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bot"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Hek van botten"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Beenderen"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boemerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boemerangtrein",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Na een enerverende pneumatische lancering rijdt de trein met hogere snelheid over een verticale baan, over de top, en vervolgens over de andere kant weer naar beneden om terug te keren naar het station.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Stenen"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Baksteenmuur"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Baksteenmuur"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Baksteenmuur"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Engelse Brievenbus"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Engelse Telefooncel"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Kapot beeld"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Kapot wiel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Voetpad van bruin asfalt"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Bruine klinkers"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Borrelende teerpoel"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Emmer"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Gebouw"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Gebouw"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Shinkansentrein",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Achtbaan met treinen in de vorm van de Japanse Shinkansen (kogeltrein).",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Riet"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Botsboten",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Kleine ronde bootjes, aangedreven door een centrale motor en bestuurd door de passagiers.",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagiers per boot"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boei"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boei"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Hamburgerbar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Een hamburgervormig gebouw dat hamburgers verkoopt."
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Struik"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Vlinder"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Deur Hut"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Deur Hut"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Stuk dak Hut"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Stuk dak Hut"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Stuk dak Hut"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Bovenkant Hut"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Stuk muur Hut"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Koolpalm"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdowniep"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canarische dadelpalm"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Snoep"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Snoep"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Snoep"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Snoepreep"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Snoepboom"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Snoepboom"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Snoepboom"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Snoepstijl"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Suikerspinkraam",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Een suikerspinvormige kraam waar roze suikerspinnen worden verkocht."
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Kanon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Kanon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Kanonkogels"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Kano's",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lange kano's waarin de passagiers zelf roeien.",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagiers per kano"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Zeildak"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvastent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Vlinderwagentjes",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Elektrische carnivalsoptochtwagentjes in de vorm van een vlinder.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Kikkerwagentjes",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Elektrische carnivalsoptochtwagentjes in de vorm van een kikker.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Hagediswagentjes",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Elektrische carnivalsoptochtwagentjes in de vorm van een hagedis.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Schacht voor mijnkarretjes"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Geldautomaat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Een geldautomaat die de bezoekers kunnen gebruiken als ze bijna door hun contante geld heen zijn."
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Kasteel (bruin)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Kasteel (grijs)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Bochtstuk kasteel"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Bochtstuk kasteel"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Ingang kasteel"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Omgekeerde bocht kasteel"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Kasteel Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Bolwerken kasteel"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Bocht bolwerken kasteel"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Bocht bolwerken kasteel"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Bocht bolwerken kasteel"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Omgekeerde bocht bolwerken kasteel"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Kasteeltoren"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Bochtstuk kasteeltoren"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Bochtstuk kasteeltoren"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Kruising kasteeltoren"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Recht stuk kasteeltoren"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "T-stuk kasteeltoren"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "T-stuk kasteeltoren"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Kasteelmuur"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Schedel Vee"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Kaukasische spar"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Ketel"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Ingang grot"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Holbewoners-go-karts",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Passagiers racen in go-karts met een steentijdthema.",
+    "reference-capacity": "Single-seater",
+    "capacity": "1 persoon per kart"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Libanese ceder"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberustrein",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Bezoekers zitten in comfortabele treinen met enkel eenvoudige schootbeugels terwijl ze door soepele afdalingen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Stoeltjesliftkarretjes",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open stoeltjesliftkarretjes.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Dambord-basisblok"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Schaakbord"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Elektrische voertuigen in de vorm van een kat.",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passagiers per kat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Kipnuggetskraam",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Een kraam waar kipnuggets worden verkocht."
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese ceder"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese draak"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese drakenkoppen",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Vliegende schotels die de passagiers zelf besturen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese jonk",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Chinese jonk die is bevestigd aan een arm met een contragewicht, en 360 graden kan draaien.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagiers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Frietkot",
+    "reference-description": "A hut selling chips",
+    "description": "Een kraam waar friet wordt verkocht."
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Frietkraam",
+    "reference-description": "A stall selling chips",
+    "description": "Een kraam waar friet wordt verkocht."
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocoladereep"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Printplaat-voetpad"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Een dierennummer in een circustent.",
+    "reference-capacity": "30 guests",
+    "capacity": "30 bezoekers"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Klassiek / Romeins"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Lichtkrant in Romeinse stijl"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Klassiek/Romeins thema"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Naald van Cleopatra"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Klimmende wijnstokboom"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Klok"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Klaverenboom"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Boten",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Achtbaankarretjes in de vorm van een boot.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagiers per boot"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Koffiepot-twist",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Koffiewinkel",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Een winkel in artdecostijl waar kopjes koffie worden verkocht."
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Tandrad"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Tandrad"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Tandrad"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Tandrad"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Colasnoep"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Zuilenrij"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Gewone jeneverbes"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Gewone eik"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Gewone taxusboom"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Trein voor compacte omgekeerde achtbaan",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Passagiers zitten in stoelparen die onder de baan hangen terwijl ze door kronkelende en scherpe omkeringen gaan.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condortrein",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Bezoekers hangen in Condorvormige treinen onder de baan met enkel schouderbeugels en krijgen zo de ervaring dat ze vliegen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Palingtrein",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Een compacte stalen achtbaan waar de palingvormige trein door schroeven en loopings gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Heg van coniferen"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Heg van coniferen"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Hoekstuk Lopende Band"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Lopende Band Hoek Omkering"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Eindstuk Lopende Band"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Stijgend stuk Lopende Band"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Recht stuk Lopende Band"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Koekwinkel",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Een kraam waar grote koeken worden verkocht."
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Stoere knul"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Trein voor stalen schroefachtbaan",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Een compacte stalen achtbaan waar de trein door schroeven en loopings gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Geplooid stuk dak"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Basisblok van geplooid staal"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Geplooid stalen dak"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Geplooide stalen muur"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Geplooid stuk muur"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsicaanse den"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Voetpad met onregelmatig plaveisel"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Eng thema"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Krokodillenbootjes",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Boten in de vorm van een krokodil varen door een waterbak, waarbij ze van steile hellingen afdalen om de passagiers te doorweken.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagiers per boot"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Gebouw met scheve kamers en gangen die de bezoekers desoriënteren.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 bezoekers"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupidofontein"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Gebogen blok"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Gebogen blok"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogen stuk muur van Aarde"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogen stuk muur van Aarde"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Gebogen stuk muur van Aarde"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Gebogen dak"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Gebogen dak"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Gebogen muur"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Gebogen muur"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Extra muziek 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Extra muziek 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclopenogen",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Passagiers rijden in het oog van een grote cycloop.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclopenstandbeeld"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Lamp in madeliefjesvorm"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Toren op Dam"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Parkingang in middeleeuwse stijl"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "'Donkere eeuwen'-thema"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Bochtstuk dak middeleeuws dorp"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Bochtstuk dak middeleeuws dorp"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Omgekeerd dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Omgekeerd dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Benedenstuk bocht middeleeuws dorp"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Benedenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dakstuk middeleeuws dorp"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dak met schoorsteen middeleeuws dorp"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Bovenstuk bocht middeleeuws dorp"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Bovenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Bovenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Bovenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Bovenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Bovenstuk muur middeleeuws dorp"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dak vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dak vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dak vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dak vensterraam middeleeuws dorp"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Middeleeuwse taveerne"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dode boom"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dode boom"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dode boom"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhowbootjes",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decoratieve vissersboot waarbij de passagiers zelf trappen.",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagiers per boot"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Mijnspoor met karretje vol diamanten"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamant-twist",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Mijnschacht met diamanten"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Ruitenboom"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Didgeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Opblaasbootjes",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Passagiers glijden in opblaasboten door een kronkelende halfopen of compleet gesloten glijbaan.",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passagiers per bootje"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurus"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaurusei-twist",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Passagiers zitten per twee in stoelen die rond een bewegende moederdinosaurus draaien.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Modder"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Onverhard voetpad"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Botsauto's",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Elektrische wagentjes die de passagiers zelf besturen.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per botsauto"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Botsautostijl"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolfijnenbootjes",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Eénpersoonsvoertuigen in de vorm van een dolfijn die de bezoekers zelf kunnen besturen.",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 persoon per voertuig"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolfijnenfontein"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolfijnenstandbeeld"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Deur"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Deur"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Deur"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Dubbeldekscarrousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditionele overdekte dubbeldekscarrousel met uit hout gesneden paarden.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagiers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Dubbelsdekscabine",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Draaiende observatiecabine met twee dekken die langs een verticale toren omhoog gaat.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagiers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Donutkraam",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Een kraam waar donuts worden verkocht."
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Vale basis grote toren"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Vale kapotte basis grote toren"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Vaal middengedeelte grote toren"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Vale top grote toren"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Vaal stuk Minaret 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Vaal stuk Minaret 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Vaal stuk Minaret 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Vaal stuk dak 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Vaal stuk dak 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Vaal stuk dak 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Vaal stuk dak 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Vale basis kleine toren"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Vale basis kleine Minaret-toren"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Vale top of middengedeelte kleine toren"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Vaal Uitspringend stuk 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Vaal Uitspringend stuk 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Vaal stuk dak 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Vaal stuk dak 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Vaal stuk dak 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Vaal stuk dak 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Vaal stuk dak 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Vaal stuk dak 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Vaal stuk dak 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Vaal stuk dak 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Vaal stuk dak 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Vaal stuk dak 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Vaal stuk dak 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Aanvallende draak"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Drakentreinen",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Achtbaan met als draken vormgegeven wagentjes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per wagentje"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Libellenkarretjes",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Passagiers zitten in kleine karretjes die onder een enkele rail hangen en naar buiten zwaaien in de bochten.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Frisdrankkraam",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Een kraam in de vorm van vier blikjes waar frisdrank wordt verkocht."
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Beeld Paaseiland 1"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptische zuil"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptisch beeld"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Lichtkrant in Egyptische stijl"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptisch thema"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptische muur"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptische stijl"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffeltoren"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Elektrisch hek"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Kapot elektrisch hek"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Bochtstuk elektrisch hek"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk elektrisch hek"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Elektrisch hek met licht"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Olifantenfontein"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Mijnspoor met leeg karretje"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emoe"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Draaiend wiel met hangende passagierscabines, dat eerst gaat draaien en vervolgens wordt opgetild door een steunarm.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptusboom"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europees thema"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Europese lariks"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Parkingang in Europese stijl"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Slechte Samoerai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé-twist",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Omgekeerde shuttle",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Passagiers zitten in stoelparen die onder de baan hangen terwijl ze door kronkelende en scherpe omkeringen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Kermisorgelstijl"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasiestijl"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Landbouwwerktuigen"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Dikke Boeddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feesttafel"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Hek"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Besneeuwd hek"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Hek"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Hekken en muren"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Reuzenrad",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Groot draaiend rad met open stoeltjes.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagiers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Vuurbaken"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Havik-twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Riddergevecht-botsauto's",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "De passagiers strijden om de eer in paardvormige botsauto's.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per botsauto"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Voetzoekerenterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Draaiend wiel met hangende passagierscabines, dat eerst gaat draaien en vervolgens wordt opgetild door een steunarm.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Brandweerkraan"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Eerste hulp",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Een gebouw waar misselijke bezoekers sneller kunnen opknappen."
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Visgat"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Gerepareerd beeld"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Vlammen"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Etende flamingo"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Rondkijkende flamingo"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo die veren gladstrijkt"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Twistertrein zonder vloer",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Brede achtbaantreinen zonder vloer, die de passagiers het gevoel geeft in de open lucht te zijn terwijl ze langs de kronkelende baan en door meerdere omkeringen glijden.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Bloem"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flowerpower-schotels",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Vliegende schotels in de vorm van een bloem die de passagiers zelf besturen",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "'Flower Power'-t-shirtkraam",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Een kraam waar t-shirts met bloemmotief worden verkocht."
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Vliegende boten",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Bootvormige karretjes rijden over achtbaanrails, waardoor ze hellende bochten en diepe afdalingen kunnen maken, waarna ze in bakken water neerplonzen en rustig een stukje kunnen varen.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagiers per boot"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Trein voor vliegachtbaan",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Bezoekers hangen in treinen onder de baan met enkel schouderbeugels en krijgen zo de ervaring dat ze vliegen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Vliegende schotels",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Vliegende schotels die de passagiers zelf besturen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Voetbal"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Voetbalkarretjes",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes in de vorm van een enorme voetbal, die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Boom verboden vrucht"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Woudbomen"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontein"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontein"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Vierpersoonskarretje",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Losse karretjes hangen onder een zigzaggende baan met haarspeldbochten en scherpe afdalingen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Gebakkenkipkraam",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Een kraam waar bakjes gebakken kip worden verkocht."
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Rijstnoedelkraam",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Een kraam waar Chinese gebakken rijstnoedels worden verkocht."
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruitsnoepje"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruitsnoepje"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruitboom"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruitboom"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Vruchtenijskraam",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Een gethematiseerde kraam waar vruchtenijs wordt verkocht."
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Gebouw met bewegende muren en vloeren om de bezoekers te desoriënteren.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 bezoekers"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Oliebollenkraam",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Een kraam waar oliebollen worden verkocht."
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Toekomstthema"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristische parkingang"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Galgen"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangsterautotrein",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Achtbaantreinen in de stijl van een gangsterauto uit de jaren '20 worden door lineaire inductiemotoren het station uit gelanceerd en razen door een kronkelende baan die vaak over de kop gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Bloemen"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Rustige stijl"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometrische Fontein"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisch beeld"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisch beeld"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisch beeld"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisch beeld"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisch beeld"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Hoekstuk plat dak in Georgiaanse stijl"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Rand plat dak in Georgiaanse stijl 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Rand plat dak in Georgiaanse stijl 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Grondstuk muur in Georgiaanse stijl 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Grondstuk muur in Georgiaanse stijl 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Grondstuk muur in Georgiaanse stijl 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Grondstuk muur in Georgiaanse stijl 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Grondstuk muur in Georgiaanse stijl 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Grondstuk muur in Georgiaanse stijl 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Stuk dak in Georgiaanse stijl 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Eindstuk dak in Georgiaanse stijl 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Eindstuk dak in Georgiaanse stijl 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Stuk dak in Georgiaanse stijl 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Stuk dak in Georgiaanse stijl 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Stuk dak in Georgiaanse stijl 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Stuk dak in Georgiaanse stijl 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Stuk dak in Georgiaanse stijl 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Stuk dak in Georgiaanse stijl 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Stuk muur in Georgiaanse stijl 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Stuk muur in Georgiaanse stijl 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Stuk muur in Georgiaanse stijl 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Stuk muur in Georgiaanse stijl 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Stuk muur in Georgiaanse stijl 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Stuk muur in Georgiaanse stijl 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geisers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Spooktreinkarretjes",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Aangedreven monstervormige karretjes rijden over een baan, die over meerdere hoogteniveau loopt, langs spookachtig decor en special effects.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Reusachtige basgitaar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Gigantische bonenstaak"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Gigantische bonenstaak"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Gigantisch-snoep-thema"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Gigantisch varen"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Enorme pootafdruk Dinosaurus"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Reusachtig Drumstel"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Gigantisch varen"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Gigantische-tuin-thema"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Gigantisch gras"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Reusachtige gitaar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Enorme mangroveboom"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Reuzenpanda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Gigantische pompoen"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische sneeuwvlok"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische sneeuwvlok"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Gigantische sneeuwvlok"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga-achtbaantrein",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Een gigantische stalen achtbaan die in staat is tot soepele afdalingen en heuvels die hoger zijn dan 90 meter.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffenstandbeeld"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glazen dak"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glazen dak"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glaswand"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Go-karts met benzinemotor die de passagiers zelf besturen.",
+    "reference-capacity": "single-seater",
+    "capacity": "1 persoon per kart"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gouden Lama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gouden standbeeld 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gouden standbeeld 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Gouden Boeddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Gouden vlies"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Gouden hinokicipres"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Goede Samoerai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorillakarretjes",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes in de vorm van een gorilla, die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Gras"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Kluiten gras"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grafsteen"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grafsteen"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grafsteen"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grafsteen"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Grafmonument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Grafmonument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Grafmonument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Stuk Chinese Muur (voorkant)"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Stuk Chinese Muur (achterkant)"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Stuk Chinese Muur met trap"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Geschuttoren Chinese Muur (hoekstuk)"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Geschuttoren Chinese Muur"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Haaientrein",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trein in de vorm van een grote witte haai.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Voetpad van groen asfalt"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Groen water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Groene en bruine klinkers"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grijze klinkers"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Groen raster"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Paars raster"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Rood raster"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Geel raster"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Gave Danser"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hadesstandbeeld"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Spiegelpaleis",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Gebouw met gebogen spiegels die de weerspiegeling van de bezoekers vervormen.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 bezoekers"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Havendok"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Havenmuur"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Havenmuur bochtstuk"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Havenmuur bochtstuk"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Havenmuur met Dok"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Havenmuur met visuitrusting"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Havenmuur met ankerpunt"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Havenmuur met ankerpunt"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Havenmuur met ankerpunt"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Havenmuur met ankerpunt"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpijenkarretjes",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Passagiers worden door middel van een speciale beugel in een liggende positie vastgehouden, waarna ze op hun rug of met hun gezicht naar de grond door kronkelende stukken baan en omkeringen heen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hoedenkraam",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Een souvenirkraam waar grote piepschuimen hoeden worden verkocht."
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Spookhuis",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Groot gethematiseerd gebouw met enge gangen en spookachtige kamers.",
+    "reference-capacity": "15 guests",
+    "capacity": "15 bezoekers"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Spookgevangenis",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Gebouw met kerkers en poppen van opgesloten mensen, om de bezoekers die er doorheen lopen angst aan te jagen.",
+    "reference-capacity": "16 guests",
+    "capacity": "16 bezoekers"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Doombuggy's",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Aangedreven karretjes rijden over een baan, die over meerdere hoogteniveau loopt, langs decor en special effects.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Baal hooi"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Hartenboom"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Vloer hemels bad"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Hemels bad"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Bocht hemels bad"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Rand hemels bad"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Treden hemels bad"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dak hemels bad"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dak hemels bad"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dak hemels bad"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dak hemels bad"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Venster hemels bad"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Boog Hemelse baden"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Boog Hemelse baden"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Boog Hemelse baden"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architectuur Hemelse baden"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architectuur Hemelse baden"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architectuur Hemelse baden"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architectuur Hemelse baden"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontein Hemelse baden"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontein Hemelse baden"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Trap Hemelse baden"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Trap Hemelse baden"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Heg"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Heg"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Landingsplaats Helikopter"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hibacipres"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Nijlpaard"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Nijlpaard"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Nijlpaardonderzeeërs",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Passagiers rijden over een onderwaterparcours in onderzeeërs.",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passagiers per onderzeeër"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Valse christusdoorn"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Horrorstijl"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Paard"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Paardenstandbeeld"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Ruiterstandbeeld"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Paarden",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Losse karretjes in de vorm van een paard.",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 passagiers per paard"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Warmechocolademelkkraam",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Een kraam waar warme chocolademelk wordt verkocht."
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hotdogkraam",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Een kraam waar hotdogs worden verkocht."
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod-auto"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod-auto"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hotrodtrein",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Na een enerverende pneumatische lancering rijdt de trein met hogere snelheid over een verticale baan, over de top, en vervolgens over de andere kant weer naar beneden om terug te keren naar het station.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Huis"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Zweeffietsen",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Passagiers zitten op futuristische fietsvormige voertuigen die over een enkele rail lopen.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagiers per zweeffiets"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Zweefwagens",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Door middel van maglev-technologie wordt de illusie van futuristische zweefwagens gecreëerd.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Vliegende Zweefmotorfiets"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Vliegende Zweefmotorfiets"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Zweefmotorfiets op Stander"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Zweefmotorfiets op Stander"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboardkarretjes",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Passagiers zitten op een futuristisch hoverboard dat onder een enkele rail hangt en naar buiten zwaait in de bochten.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Vliegende zweefauto"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Vliegende zweefauto"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Zweefauto op sokkel"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Zweefauto op sokkel"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskiewagentjes",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Elektrische voertuigen in de vorm van een huskieslee.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-twistertreinen",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Ruime treinen met eenvoudige schootbeugels.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-twistertreinen (brede karretjes)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Brede karretjes met vier verhoogde stoelen naast elkaar en eenvoudige schootbeugels.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster-trein",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Een achtbaan zonder omkeringen met grote heuvels, een hoge snelheid, en comfortabele treinen met enkel schootbeugels.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "IJs"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "IJs"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Roomijskraam",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Een kraam waar roomijs wordt verkocht."
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "IJsblok"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "IJsformatie"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "IJsformatie"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "IJskasteel"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Parkingang in ijsstijl"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "IJspijp Basis"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Stuk IJspijp"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "IJspijp Luchtopening"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "IJsdak"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "IJsmuur"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "IJsstijl"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Bevroren Vaten"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Bevroren Vaten"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Bevroren Vaten"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "IJstheekraam",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Een kraam waar ijsthee wordt verkocht."
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Iglo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Iglodak"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Iglomuur"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Iglomuur"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Muur Iglo"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse-trein",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Een omgekeerde achtbaantrein wordt het station uit gelanceerd en gaat een verticale kronkelende baan op, waarna deze terugzakt, door het station heengaat en achteruit een ander stuk verticale baan opgaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Wierookceder"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische vlag van zijde"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische vlag van zijde"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische vlag van zijde"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische vlag van zijde"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indische vlag van zijde"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Dak Bochtstuk Industrie"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Dak Bochtstuk Industrie"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Dakstuk Industrie"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Muur Bochtstuk Industrie"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Muur Bochtstuk Industrie"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Muren Industrie"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Muren Industrie"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Muren Industrie"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Muren Industrie"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Muur met deuropening Industrie"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Muur met venster Industrie"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Informatiekiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Een kiosk waar bezoekers kaarten van het park en paraplu's kunnen kopen."
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Eskimo"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Eskimo"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "IJzer"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italiaanse cipres"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Carabinieri-twist",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguarkarretjes",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Achtbaankarretjes in de vorm van een jaguar.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Bloeiende Japanse Kersenboom"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanse Kersenboom"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japans hek"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japans hek"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japans hek"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Parkingang in Japanse stijl"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanse Pijnboom"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japans dak"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japans dak"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japans dak"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanse vlag van zijde"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanse Gelderse Roos"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Lid Jazzband"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Lid Jazzband"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Lid Jazzband"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Lid Jazzband"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Snoepje"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Zuurtje"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Muur van zuurtjes"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Straalvliegtuig"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Straalvliegtuig"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Straalvliegtuig"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jetpack-booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Passagiers zitten in een voertuig dat gelanceerd wordt over een verticale baan.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagiers"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Straalvliegtuigachtbaan",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Een compacte achtbaan met individuele karretjes en steile, kronkelende afdalingen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jetski's",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Eénpersoons jetski's die de bezoekers zelf kunnen besturen.",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 persoon per jetski"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Duellerende ridders",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Passagiers zitten op paardvormige voertuigen die over een enkele rail lopen.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagiers per paard"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Fonteinen"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Springende sneeuwballen"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Junglehek"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Lichtkrant in junglestijl"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Junglethema"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungleboom 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungleboom 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungleboom met luipaarden"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungleboom met lianen"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Jungledrumsstijl"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Rommel"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Lichtkrant in Jurastijl"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassisch thema"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Jurastijl"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangoeroe"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Orka-onderzeeërs",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Passagiers rijden over een onderwaterparcours in onderzeeërs.",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passagiers per onderzeeër"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koalakarretje",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Grote wagen voor de achterwaartstevrijevalachtbaan.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagiers"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Grote basis toren Kremlin"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Groot middengedeelte toren Kremlin"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Grote top toren Kremlin"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Stuk Kremlin-Minaret 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Stuk Kremlin-Minaret 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Stuk Kremlin-Minaret 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Stuk dak Kremlin 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Stuk dak Kremlin 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kleine basis toren Kremlin"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kleine middengedeelte Minaret-toren Kremlin"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Basis kleine Minaret-toren Kremlin"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Uitspringend stuk muur Kremlin 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Uitspringend stuk muur Kremlin 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Stuk muur Kremlin 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Stuk muur Kremlin 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Stuk muur Kremlin 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Stuk muur Kremlin 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Stuk muur Kremlin 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Stuk muur Kremlin 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Stuk muur Kremlin 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Stuk muur Kremlin 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Trein voor LIM-lanceringsachtbaan",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Achtbaantreinen worden door lineaire inductiemotoren het station uit gelanceerd en razen door een kronkelende baan die vaak over de kop gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Lieveheersbeestjestreinen",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Achtbaantrein met kleine karretjes in de vorm van een lieveheersbeestje.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Mammoethek onder grote hoek"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Mammoethek onder grote hoek"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Grote iep"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Groot mammoethek"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Groot mammoethek"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Grote meteoorkrater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Grote eik"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Regenwoudboom 4"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Grote rode meteoorkrater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Grote rokende schoorsteen"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Grote Luidspreker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Grote Totempaal"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laseromheining"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Bocht Laseromheining"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Wagen voor gelanceerde vrije val",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Een vrijevalwagen wordt pneumatisch langs een hoge stalen toren gelanceerd en gaat daarna in een vrije val weer naar beneden.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Californische cipres"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Liggende karretjes",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Passagiers zitten in kleine karretjes die onder een enkele rail hangen en naar buiten zwaaien in de bochten.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Trein voor liggende achtbaan",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Passagiers worden door middel van een speciale beugel in een liggende positie vastgehouden, waarna ze op hun rug of met hun gezicht naar de grond door kronkelende stukken baan en omkeringen heen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Marktkraam met limonade",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Een marktkraam waar ouderwetse, frisse limonade wordt verkocht."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Limonadekraam",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Een kraam waar verfrissende limonade wordt verkocht."
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Liftcabine",
+    "reference-description": "Steel lift cabin",
+    "description": "Stalen liftcabine.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lelie"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousinetrein",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Achtbaan met treinen in de vorm van een limousine",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Leeuw"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Leeuwenkarretjes",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Achtbaankarretjes in de vorm van een leeuw.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Vuilnisbak"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Vuilnisbak"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Vuilnisbak"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Vuilnisbak"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Blokhut"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Blokhut"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Stuk dak blokhut"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Stuk dak blokhut"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Stuk dak blokhut"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Zijschoorsteen blokhut"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Stuk muur blokhut"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Boomstronktreinen",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Achtbaantrein met kleine karretjes in de vorm van een boomstronk.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Palen"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Boomstammen",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Boten in de vorm van een boomstam varen door een waterbak, waarbij ze van steile hellingen afdalen om de passagiers te doorweken.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagiers per boot"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Snoep"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardijse populier"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Achtbaantrein",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Achtbaantrein met schootbeugels, die door loopings kan rijden.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Stuk zuil Verloren Stad"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Stuk zuil Verloren Stad"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Plat stuk dak Verloren Stad"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Plat stuk dak Verloren Stad"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Plat stuk dak Verloren Stad"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Stuk trap Verloren Stad"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Stuk trap Verloren Stad"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Stuk trap Verloren Stad"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Stuk trap Verloren Stad"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Stuk trap Verloren Stad"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Stuk muur Verloren Stad"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Lage Struik"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Boeg luxueus schip"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Middenstuk luxueus schip"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Achtersteven luxueus schip"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Goedendags",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Passagiers zitten op stoel in de vorm van een goedendag die ronddraait aan een paal.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 bezoeker per stoel"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Vliegend tapijt",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Een grote wagen in de vorm van een vliegend tapijt draait rond aan de uiteinden van vier draaiarmen.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagiers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magisch harnas"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magische helm"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magisch schild"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magisch zwaard"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Boog 1 Maharadjapaleis"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Boog 2 Maharadjapaleis"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Koepel Maharadjapaleis"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Stuk Maharadjapaleis"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Stuk Maharadjapaleis"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Stuk Maharadjapaleis"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Basis Toren Maharadjapaleis"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Hoge Toren Maharadjapaleis"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Bovenkant Toren Maharadjapaleis"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharadja-stoomtrein",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniatuurstroomtrein bestaande uit een replicastoomlocomotief en tender, die dichte houten wagons voorttrekt.",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagiers per wagon"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarijneendbootjes",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Boot in de vorm van een mandarijneend, die wordt voortbewogen door het trappen van de passagiers op de eerste rij.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagiers per boot"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangroveboom"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta's",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Achtbaankarretjes in de vorm van een manta (adelaarsrog).",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagiers per boot"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Dak van marmer"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Dak van marmer"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Dak van marmer"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Dak van marmer"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Carnavalsdanseres"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Carnavalsdanseres"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Feesttent"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Spekkie"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Spekkie"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Buitenaards"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Buitenaards gebouw"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Buitenaards object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Buitenaards object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Buitenaards object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Buitenaards object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Buitenaards object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Marsthema"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Buitenaardse muur"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marsstijl"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Doolhof",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Bezoekers lopen door een doolhof van 1,8m hoge heggen of muren, en kunnen er pas uit wanneer ze de uitgang vinden."
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Soep-met-balletjeskraam",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Een kraam waar Chinese soep met balletjes wordt verkocht."
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanisch thema"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mechanische stijl"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Middeleeuws thema"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Middeleeuwse stijl"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "In steen veranderde mannen"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "In steen veranderde mannen"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "In steen veranderde mannen"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "In steen veranderde mannen"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Draaimolen",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditionele draaimolen met uit hout gesneden paarden.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Gaashek"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Gaashek"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Bocht meteoorkrater"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Bocht meteoorkrater"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Omgekeerde bocht meteoorkrater"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Muur meteoorkrater"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Muur meteoorkrater met kristallen"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Muur meteoorkrater met kristallen"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Blauwe jeneverbes"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Hippiebus",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Passagiers bekijken een film in de cabine van een bewegingssimulator die wordt gedraaid en bewogen door een hydraulische arm.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Hippiebus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mijnkarretjes",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Kleine mijnkarretjes.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mijnkarretjes",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Losse karretjes in de vorm van een houten mijnkarretje.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mijnkarretjes",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Houten achtbaantrein met gevoerde zittingen en schootbeugels.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mijnhut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mijnhut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mijnlift",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Bezoekers gaan in een lift in een toren omhoog of omlaag om naar een ander hoogteniveau te komen.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mijnschacht"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mijnthema"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mijntrein",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Achtbaantreinen in de vorm van een mijntrein razen over stalen achtbaanrails die er uitziet als een oude spoorbaan.",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "4 passagiers per karretje (voorste karretje 2)"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Minigolf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Een rustig spelletje minigolf.",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Minihelikopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Aangedreven karretjes in de vorm van een helikopter rijden over een stalen baan, bestuurd door het trappen van de passagiers.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaurusstandbeeld"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Moderne stijl"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Apenboom"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monstertrucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Gigantische elektrische 4x4-trucks die steile hellingen kunnen nemen.",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passagiers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Montereycipres"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pijnboom"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Kapot stuk monumentale muur"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumentale fontein"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Stuk monumentale trap"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Stuk monumentale trap"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Stuk monumentale trap"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Stuk monumentale trap"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Stuk monumentale muur"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Maansap",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Een kraam waar de nieuwste soorten frisdrank worden verkocht."
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mozaïek-voetpad"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Bewegingssimulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Passagiers bekijken een film in de cabine van een bewegingssimulator die wordt gedraaid en bewogen door een hydraulische arm.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorfietsen",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Losse karretjes in de vorm van een motorfiets.",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 passagiers per motorfiets"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorfiets"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorfiets"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Muiskarretjes",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Losse karretjes in de vorm van een muis.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Muiskarretjes",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Losse muisvormige karretjes.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Stuk dak van Aarde"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Lemen muur"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multidimensieachtbaantrein",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Karretjes met stoelen die de passagiers halsoverkop kunnen laten tollen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Parkingang in mythologische stijl"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythologisch thema"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indiaan"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natuurlijk water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautisch Hek Hoekstuk dak"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautisch stuk dak"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisch stuk muur"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonembleem cafetaria"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonembleem cafetaria"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonembleem cafetaria"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neonembleem cafetaria"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptunus-twist",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Passagiers zitten per twee in stoelen die rond een bewegend standbeeld van Neptunus draaien.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptunus' zeevruchtenkraam",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Een kraam met Neptunus' zoute lekkernijen."
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Vulstuk bocht New York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Ingang New York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk New York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk New York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk New York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk New York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Omgekeerd Bochtdak New York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Dakstuk New York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Dakstuk New York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Dakstuk New York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Dakstuk New York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Dakstuk New York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Muurstuk New York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muur met waslijn New York"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Muur met waslijn New York"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Waslijn New York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Waslijn New York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Geen ingang"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Geen ingang, geen perron"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Parkingang in Noord-Amerikaanse stijl"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Noord-Amerikaans thema"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Noorse spar"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Eikenvaten",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Eikenhouten vaten varen door een brede waterbak, waarbij ze de passagiers opwinden door watervallen en schuimende stroomversnellingen.",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagiers per boot"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Deurstuk wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Dakstuk wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Bocht flauwe helling wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Bocht flauwe helling wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Muur flauwe helling wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Bocht steile helling wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Steile Muur wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Steile Muur wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Steile Muur wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Muur wolkenkrabber van Lavaglas"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Muur met Venster wolkenkrabber van Lavaglas"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Kantoorgebouw"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Olievat"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oliepomp"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Oude verwilderde boom"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Oranje water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgelstijl"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oosterse stijl"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Decoratief raamwerk"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Decoratief raamwerk"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Decoratief raamwerk"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Sierboom"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Sierboom"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Sierboom"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Sierboom"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Sierboom"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Gedecoreerde marmeren muur"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Struisvogeltrein",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Een achtbaan met loopings waar de passagiers in de karretjes staan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outriggerkano's",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Lange kano's waarin de passagiers zelf roeien.",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagiers per kano"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Lichtkrant in pagodestijl"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagodethema"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagodetoren"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palmboom"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmboom"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palmboom"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palmboom"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palmboom"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Vuilnisbak in pandavorm"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Pandathema"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Pandatreinen",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Achtbaantrein met kleine karretjes in de vorm van een panda.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Parkingang met gebouw"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Parkingang met ijzeren poorten"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Boerenhut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasuskarretjes",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Elektrische voertuigen in de vorm van een kar die wordt voortgetrokken door Pegasus.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Pinguïnbobslee",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagiers rijden over een kronkelende baan, waarbij ze enkel worden geleid door de ronding en banking van de halfronde baan.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Oldtimer"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Oldtimer"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Historisch cafetaria"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Historische vlag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Historisch zeiljacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Antieke straatlantaarns"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Oldtimertruck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Oldtimertruck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Benzinepomp"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickuptrucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Elektrische voertuigen in de vorm van een pickuptruck.",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passagier per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Roze water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pijp"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pijpgedeelte"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pijpgedeelte"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pijpgedeelte"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Piratenvlag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Schommelschip",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Groot schommelend piratenschip",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratenschip"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Piratenthema"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Piratenstijl"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizzakraam",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Een kraam waar stukken pizza worden verkocht."
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Standaard"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Gesloten marmeren muur"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Muur van speelkaarten"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Muur van speelkaarten"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Fundament"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Ploeg"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "IJsbeerkarretjes",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Passagiers zitten in paren, met het gezicht naar voren of achteren, en gaan door scherpe omkeringen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Paal"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Paal"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Palen"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Politietrein",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Achtbaantrein met schootbeugels, die door loopings kan rijden.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Politieautokarretjes",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Karretjes die er uitzien als een Amerikaanse politieauto uit de jaren '60 rijden op een houten baan en kunnen omkeren op speciale stukken baan.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcornkraam",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Een kraam waar grote emmers popcorn worden verkocht."
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Muur met valhek"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Muur met valhek"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Paal"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Aangedreven mijntrein",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Aangedreven mijntreinen rijden over een soepele en kronkelende baan.",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "4 passagiers per karretje (voorste karretje 2)"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Parkingang in prehistorische stijl"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistorisch thema"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Krakelingenkraam",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Een kraam waar knapperige zoute krakelingen worden verkocht."
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Oersoep"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Gevangenisdeur"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Gevangenishek"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omgekeerd stuk gevangenis"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Bocht gevangenismuur"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Bocht gevangenismuur"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Stuk gevangenismuur"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Gevangenisdak"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Wachttoren gevangenis"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Trappen wachttoren gevangenis"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Trappen wachttoren gevangenis"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Watertoren gevangenis"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyltrein",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Bezoekers hangen in comfortabele treinen onder de baan met enkel schouderbeugels en krijgen zo de ultieme prehistorische vliegervaring.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pompoen"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pompoenhuis"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Piramide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Wachtrij-tv"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Raceauto's",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Elektrische voertuigen in de vorm van een raceauto.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Velociraptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Passagiers zitten op velociraptorvormige voertuigen die over een enkele rail lopen.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagiers per velociraptor"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Raceluidspreker"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Schotelvormige Radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Overdekte vlotten",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Boten in de vorm van een vlot varen rustig door een waterbak.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagiers per vlot"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtimestijl"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Traliewerk"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Regenboogvoetpad"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Hoekstuk dak van rode baksteen"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Hoekstuk voor plat dak van rode baksteen"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Randstuk voor plat dak van rode baksteen"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Omgekeerd stuk dak van rode baksteen"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Stuk dak van rode baksteen 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Stuk dak van rode baksteen 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Stuk dak van rode baksteen 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Stuk muur van rode baksteen 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Stuk muur van rode baksteen 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Stuk muur van rode baksteen 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Stuk muur van rode baksteen 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Stuk muur van rode baksteen 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Stuk muur van rode baksteen 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Stuk muur van rode baksteen 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Stuk muur van rode baksteen 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Stuk muur van rode baksteen 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Rode spar"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Rode spar"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Bocht rode meteoorkrater"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Bocht rode meteoorkrater"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Rode Omgekeerde Bocht Meteoorkrater"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Muur rode meteoorkrater"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Rode en bruine klinkers"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood-boom"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-monorailtreinen",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorailtreinen met open karretjes.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Wagen voor achterwaartse vrije val",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Grote wagen voor de achterwaartstevrijevalachtbaan.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Omkeerbare karretjes",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Karretjes met draaistellen rijden op een houten baan en kunnen omkeren op speciale stukken baan.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rinoceros"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Neushoornkarretjes",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Een compacte achtbaan met een spiraalvormige kettingheuvel en karretjes waarin de passagiers achter elkaar zitten.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Touwwerk"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Wildwaterbootjes",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Ronde boten varen door een brede waterbak, waarbij ze de passagiers opwinden door watervallen en schuimende stroomversnellingen.",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagiers per boot"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Styxbootjes",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Bezoekers varen in het bootje van Charon door een waterbak.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagiers per bootje"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Weg"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Parkingang in 'Roaring Twenties'-stijl"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "'Roaring Twenties'-thema"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "'Roaring Twenties'-muren"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Gebradenworstkraam",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Een kraam waar Chinese gebraden worst wordt verkocht."
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hoods kamp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rotswand"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rotsen"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Parkingang in 'rock 'n roll'-stijl"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "'Rock 'n roll'-thema"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Tourbus Rock Band"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rotsmuur"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rockstijl"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rockstijl 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rockstijl 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Raketkarretjes",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Achtbaankarretjes in de vorm van een raket.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rotsachtig voetpad"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Beeld Onderscheiding Achtbaan"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Serveerster op rolschaatsen"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Romeinse Zuil"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Romeinse zuilenmuur"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Bochtstuk Romeins paleis"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Bochtstuk Romeins paleis"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Bochtstuk Romeins paleis"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Bochtstuk Romeins paleis"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kruising Romeins paleis"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kruising Romeins paleis"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kruising Romeins paleis"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Kruising Romeins paleis"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Eindstuk Romeins paleis"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Eindstuk Romeins paleis"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Recht stuk Romeins paleis"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Recht stuk Romeins paleis"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Recht stuk Romeins paleis"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Recht stuk Romeins paleis"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Romeins beeld"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Romeins beeld"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Romeinse tempel"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Romeinse muur"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Romeinse muur"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Romeinsefanfarestijl"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Dak"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Grijze dakpannen"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Rode dakpannen"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Een ring van stoelen wordt naar de bovenkant van een hoge toren getrokken terwijl hij rustig ronddraait, waarna hij losgelaten wordt in een vrije val, waarna hij beneden rustig wordt afgeremd door middel van magnetische remmen.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Verkeersbord weg 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Londense bus",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replica van de beroemde Londense Routemasters.",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagiers per bus"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Roeiboten",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Boten waarin passagiers zelf roeien.",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagiers per boot"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Vervallen beeld"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Bochtstuk startbaan"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Randstuk startbaan"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Omgekeerd bochtstuk startbaan"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Stuk startbaan"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Stuk startbaan"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Stuk startbaan"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Roest"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Trams uit San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replica's van oude trams uit San Francisco",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagiers per tram"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Zand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Bruin zand"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Rood zand"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Bruine zandsteen"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Grijze zandsteen"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Helling glooiende Onderkant zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Omgekeerde benedenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Hellingonderkant zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Bochtbovenkant zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Bovenkant glooiende helling zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Bovenkant glooiende helling zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Zandstenen wolkenkrabber Aanlegbaai"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Deuropening zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Vulstuk zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Vulstuk zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Omgekeerde Bochtbovenkant zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Middenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Middenbocht zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Helling glooiend midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Helling glooiend midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Bocht helling midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Muurgedeelte midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Muurgedeelte midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Muurgedeelte midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Muurgedeelte midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Muurgedeelte midden zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Dak zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Spits zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Spits zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Looppad zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Looppad zandstenen wolkenkrabber"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Bocht zandstenen Looppad"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Kruising zandstenen Looppad"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Eindstuk zandstenen Looppad"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "T-splitsing zandstenen Looppad"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satelliet"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Schotelvormige Satelliet"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Schoolbus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Schoolbussen",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Replica's van Amerikaanse gele schoolbussen.",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagiers per bus"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Schotse den"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Elektronisch mededelingenbord"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Elektronisch mededelingenbord"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Beeld"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Beeld"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Zeevruchtenkraam",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Een kraam waar gebakken tentakel wordt verkocht."
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Watervliegtuig"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Zeehondentrein",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Een compacte stalen achtbaan waar de trein door schroeven en loopings gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Watervliegtuigpits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Watervliegtuigpits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Zoeklicht"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Stadionstoeltjes"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Struik"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Struik"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Struiken en ornamenten"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttle"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttle"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōjiwand"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Stoep"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Lichtkrant"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Borden en onderdelen voor voetpaden"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Zilverberk"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Zanger met Kuif"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Enkeldekscabine",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Draaiende observatiecabine die langs een verticale toren omhoog gaat.",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagiers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags-thema"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Trein voor verticale achtbaan",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extra brede karretjes rijden over een compleet verticale baan voor de ultieme vrijevalbeleving.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skelet"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Skiliftkarretjes",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open karretjes in skiliftstijl.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Sneeuwscooters",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Elektrische sneeuwscooters die de passagiers zelf besturen",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Schedel"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Schedel"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Stuk muur wolkenkrabber"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Stuk muur wolkenkrabber"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Stuk muur wolkenkrabber"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Printplaat-voetpad zonder leuningen"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Wolkenkrabber A"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Wolkenkrabber B"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Concaaf stuk voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Concaaf dak voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Convex stuk voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Convex dak voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Stuk Lift wolkenkrabber"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Stuk Lift wolkenkrabber"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Stuk Lift wolkenkrabber"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Stuk Lift wolkenkrabber"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Stuk Lift wolkenkrabber"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Metaal Set 1 Concaaf stuk voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Metaal Set 1 Convex stuk voor wolkenkrabber"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Metaal Set 1 stuk muur voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Metaal Set 2 Concaaf stuk voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Metaal Set 2 Concaaf stuk voor wolkenkrabber"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Metaal Set 2 Convex stuk voor wolkenkrabber"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Metaal Set 2 stuk muur voor wolkenkrabber"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Metaal Set 2 stuk muur voor wolkenkrabber"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Stuk wolkenkrabberdak"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Top wolkenkrabber"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Luiaardkarretjes",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes in de vorm van een luiaard, die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Mammoethek onder kleine hoek"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Mammoethek onder kleine hoek"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Klein tandrad"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Klein tandrad"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Klein tandrad"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Klein tandrad"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Kleine Geosfeer"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Kleine meteoorkrater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Kleine monorailkarretjes",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Kleine monorailkarretjes met open zijkanten.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Kleine regenwoudboom 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Kleine regenwoudboom 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Kleine rode meteoorkrater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Kleine Luidspreker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Rookstapel Onderkant"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Rookstapel midden"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Slak"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Sneeuw / IJs"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Besneeuwde lichtkrant"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Sneeuwkopjes",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Passagiers zitten per twee in stoelen die om een sneeuwpop heendraaien.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Sneeuw- en ijsthema"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Sneeuwstijl"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Met sneeuw bedekte kaukasische spar"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Met sneeuw bedekte Noorse spar"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Met sneeuw bedekte rode spar"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Met sneeuw bedekte rode spar"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Sneeuwbal"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Sneeuwpop"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Zeepkisten",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Passagiers zitten in voertuigen in de vorm van een zeepkist die over een enkele rail lopen.",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 passagiers per zeepkist"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Knuffelkraam",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Een kraam waar schattige zachte dinosaurusknuffels worden verkocht."
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Zuid-Amerikaans thema"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Parkingang in Zuid-Amerikaanse stijl"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenirkraam",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Een souvenirkraam waar knuffels en paraplu's worden verkocht."
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Sojamelkkraam",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Een kraam waar pakjes sojamelk worden verkocht."
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Ruimte"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Ruimtecapsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Ruimtecapsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Ruimte-Omwentelingen"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Ruimteringen",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentrische draaiende ringen waarmee de passagiers vrij kunnen draaien in alle richtingen.",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 bezoeker per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Ruimteraket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Vrachtgedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Communicatiegedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Commandodek ruimteschip"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Kruising ruimteschip"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Aanleggedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Motorgedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Brandstofgedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Zwaartekrachtgedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Woongedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Wetenschapgedeelte ruimteschip"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Zonnepanelen ruimteschip"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Zongedeelte ruimteschip"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Voetpad in ruimtestijl"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Lichtkrant in ruimtestijl"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Ruimtethema"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Ruimtestijl"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Schoppenboom"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sfinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spin"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Palissade"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Draaiende karretjes",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Muisvormige karretjes rijden snel door scherpe bochten en korte afdalingen, en draaien daarbij zachtjes rond om de passagiers te desoriënteren.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiraalachtbaantrein",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Een compacte achtbaan met een spiraalvormige kettingheuvel en karretjes waarin de passagiers achter elkaar zitten.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiraalglijbaan",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Houten gebouw met van binnen een trap en van buiten een spiraalglijbaan voor glijmatten."
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Plonsboten",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Boten met een hoge capaciteit varen door een brede waterbak, worden naar boven vervoerd door een lopende band, en gaan met hoge snelheid steile heuvels af om met een grote plons de passagiers te doorweken.",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passagiers per boot"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spookthema"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sportauto's",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Elektrische voertuigen in de vorm van een sportauto.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sportthema"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Spoetnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Spoetnikkarretjes",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Passagiers zitten in karretjes in de vorm van de Spoetnik, die onder een enkele rail hangen en naar buiten zwaaien in de bochten.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Boom in eekhoornvorm"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Postkoetsen",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Houten achtbaantrein met gevoerde zittingen en schootbeugels.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stormende kudde-trein",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Een achtbaan met loopings en voertuigen in de vorm van een op holgeslagen kudde dinosaurussen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per wagentje"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Staande achtbaantrein",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Een achtbaan met loopings waar de passagiers in de karretjes staan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Staande twistertrein",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Brede achtbaantrein met speciaal ontworpen beugels waarin de passagiers moeten staan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Vruchtendrankkraam",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Een kraam waar vruchtendrankjes worden verkocht."
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Beeld"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Beeld"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Beeld"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Vrijheidsbeeld"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Stoomtrein",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniatuurstroomtrein bestaande uit een replicastoomlocomotief en tender, die open houten wagons voorttrekt.",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagiers per wagon"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Stroomtrein met overdekte wagons",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniatuurstroomtrein bestaande uit een replicastoomlocomotief en tender, die wagons met stoffen overdekking voorttrekt.",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagiers per wagon"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Dampend riool"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Stalen blok"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Stalen blok"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Stalen hek"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Stalen traliewerk"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen wand"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen wand"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen muur"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen muur"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen wand"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Stalen muur"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Tempel uit de steentijd"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stenen bank"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Blok steen"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stenen wolkenkrabber Basis Trappen"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stuk muur Stenen wolkenkrabber"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stuk muur Stenen wolkenkrabber"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stuk muur Stenen wolkenkrabber"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stuk muur Stenen wolkenkrabber"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stuk muur Stenen wolkenkrabber"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stenen muur"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stenen muur"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stenen muur"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stenen muur"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Krukje"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Krukjes"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Gestroomlijnde monorailtrein",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Monorailtrein met gestroomlijnde voor- en achterkant en een hoge capaciteit.",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "10 passagiers per karretje (voor en achter 5)"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Groen stucwerk"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Grijs stucwerk"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Paars stucwerk"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Rood stucwerk"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Geel stucwerk"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Broodjeskraam",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Een kraam waar broodjes worden verkocht."
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Onderzeeërs",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Passagiers rijden over een onderwaterparcours in onderzeeërs.",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passagiers per onderzeeër"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwakraam",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Een kraam waar Koreaanse sujeonggwa-drankjes worden verkocht."
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Zomerstijl"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Zonnebrillenkraam",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Een kraam waar allerlei soorten zonnebrillen worden verkocht."
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Gezonken schip"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Grote CPU supercomputer"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor supercomputer"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Kleine CPU supercomputer"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Steunconstructie"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Steunconstructie"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Steunconstructie"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surftrein",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Passagiers staan in de brede achtbaantrein met speciaal ontworpen beugels terwijl ze door soepele afdalingen en meerdere omkeringen razen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Hangende monorailtreinen",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Monorailtreinen met een hoge capaciteit.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagiers per karretje"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Watervliegtuigkarretjes",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Vliegtuigkarretjes",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes in de vorm van een vliegtuig, die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Normale karretjes",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit karretjes die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Basisstuk Hangbrug"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Basisstuk Hangbrug Afstandsstuk"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Kabelgedeelte Hangbrug"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Hangbrug middenstuk"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Begingedeelte Hangbrug 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Begingedeelte Hangbrug 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Torengedeelte Hangbrug 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Torengedeelte Hangbrug 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Moerasvaren"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Moerasslijm"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Moerasplant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Moerasplant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Moerasplant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Zwanenbootjes",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Boten in de vorm van een zwaan, voortgestuwd door het trappen van de passagiers op de eerste rij.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagiers per boot"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Schommelkarretjes",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Kleine karretjes die aan de rail erboven schommelen.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Karretjes zonder vloer",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Omgekeerde achtbaantrein bestaande uit stoeltjesliftachtige karretjes die vrijuit kunnen schommelen als de trein door een bocht gaat.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Loopingschip",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Schip dat is bevestigd aan een arm met een contragewicht, en 360 graden kan draaien.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagiers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Zwaard in de steen"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-shirtkraam",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Een souvenirkraam waar T-shirts worden verkocht."
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV-trein",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Achtbaantreinen worden door lineaire inductiemotoren het station uit gelanceerd en razen door een kronkelende baan die vaak over de kop gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT-vaten"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT-kisten"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT-ontsteker"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT-stapel"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Grote Lantaarn"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Grote Lantaarn"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Hoog houten hek"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Schietschijf"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Voetpad van asfalt"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Herberg"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Technostijl"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Wigwam"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Bezoekers gaan in een lift in een toren omhoog of omlaag om naar een ander hoogteniveau te komen.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagiers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Kapot stuk tempelmuur met hoofd"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Stuk tempeldak"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Stuk tempelmuur (hoekstuk)"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Stuk tempelmuur (hoekstuk)"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Stuk tempelmuur (hoekstuk)"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Stuk tempelmuur (hoekstuk)"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Stuk tempelmuur"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Stuk tempelmuur met hoofd"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Woonhuis"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennisbal"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnetmuur"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnetmuur"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tipi"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termietenheuvel"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Rijtjeshuis"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracottaleger"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Tijdmachine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Bezoekers zitten in een speciaal ontwerpen bol en krijgen de illusie dat ze door de tijd reizen.",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 bezoeker per tijdmachine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Paddenstoel"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Rodelsleekarretjes",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Achtbaankarretjes in de vorm van een rodelslee, waarin de passagiers achter elkaar zitten.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Marktkraam met gevulde appels",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Een marktkraam waar gevulde appels worden verkocht."
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Kraam met gevulde appels",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Een appelvormige kraam waar gevulde appels op een stokje worden verkocht."
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Eenvoudige toiletten in een prefab betonnen gebouw."
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toiletten in een gebouw in blokhutstijl."
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toiletten",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Eenvoudige toiletten in een prefab betonnen gebouw."
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommygun-twist",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Passagiers zitten per twee in stoelen die rond een grote replica van een 'Tommy gun' draaien.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Topspin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passagiers zitten in een gondel die is opgehangen aan grote roterende armen, en worden halsoverkop vooruit en achteruit gedraaid.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totempaal"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Stadhuis"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Speelgoedlandstijl"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabants",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Achtbaankarretjes in de vorm van een Trabant.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per auto"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Mijnspoor met bocht"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Kapot stuk mijnspoor"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Mijnspoor met stootblok"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Mijnspoor met wissel"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Recht stuk mijnspoor"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditionele parkingang"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Replica's van oude trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagiers per tram"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Autobusje"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatkist"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatkist"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Schatkist"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet-topspin",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passagiers zitten in een gondel die is opgehangen aan grote roterende armen, gebaseerd op een middeleeuws belegeringswapen.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagiers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Boom"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Bomen"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratopsbotsauto's",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "De passagiers vatten elkaar bij de horens in triceratopsvormige botsauto's.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagier per botsauto"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobietenboten",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Bootvormige karretjes in de vorm van trilobiet rijden over achtbaanrails, waardoor ze hellende bochten en diepe afdalingen kunnen maken, waarna ze in bakken water neerplonzen en rustig een stukje kunnen varen.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagiers per boot"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Stuk muur nis in Tudorstijl"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Grondstuk muur in Tudorstijl 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Grondstuk muur in Tudorstijl 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Grondstuk muur in Tudorstijl 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Grondstuk muur in Tudorstijl 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Grondstuk muur in Tudorstijl 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Grondstuk muur in Tudorstijl 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Grondstuk muur in Tudorstijl 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Grondstuk muur in Tudorstijl 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Grondstuk muur in Tudorstijl 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Grondstuk muur in Tudorstijl 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Grondstuk muur in Tudorstijl 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Grondstuk muur in Tudorstijl 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Grondstuk muur in Tudorstijl 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Stuk dak in Tudorstijl 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Verlengend stuk dak in Tudorstijl"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Stuk dak in Tudorstijl 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Stuk dak in Tudorstijl 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Stuk dak in Tudorstijl 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Stuk muur in Tudorstijl 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Stuk muur in Tudorstijl 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Stuk muur in Tudorstijl 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Stuk muur in Tudorstijl 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Schildpadbootjes",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Kleine ronde opblaasbootjes, aangedreven door een centrale motor en bestuurd door de passagiers.",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagiers per boot"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Passagiers zitten per twee in stoelen die ronddraaien aan de uiteinden van drie lange draaiarmen.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagiers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twisterkarretjes",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Achtbaankarretjes die geschikt zijn voor heartline twists.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twisterkarretjes (achterstevoren starten)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Achtbaankarretjes die geschikt zijn voor heartline twists.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twistertrein",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Brede achtbaantrein die langs de soepele stalen baan glijdt en door diverse soorten omkeringen gaat.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Plaats van neerstorten UFO"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Eenhoornstandbeeld"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Stadsthema"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Stadsstijl"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Walkure"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Walkure"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Walkurentrein",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extra brede karretjes rijden over een compleet verticale baan voor de ultieme vrijevalbeleving.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Verticaal 3D-bord"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Omgekeerde verticale shuttle",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Passagiers zitten in karretjes die onder de baan hangen, worden achteruit een verticale baan opgetrokken en vervolgens losgelaten, waarna ze door kronkelende en scherpe omkeringen gaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Lianenboom"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Oldtimers",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Elektrische voertuigen in de vorm van een oldtimer.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "1 passagier per karretje"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel-wagentjes",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Ronde karretjes gaan over een zigzaggende houten baan en draaien daarbij rond.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Leegte"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Vulkaan"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Vulkaan met kleine bomen"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Goudenregenboom"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Huifkar"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Huifkar"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagonwiel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Muur"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Muur met boog"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Muur met doorgang"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Muren en daken"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnootboom"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Standbeeld van Washington"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wesp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Waterthema"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Waterstraal"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Waterstraal"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Waterfietsen",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Driewielige waterfietsen met grote raderwielen.",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passagiers per waterfiets"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Waterstijl"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterval"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Vitselstekdak"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Vitselstekdak"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Vitselstekdak"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Vitselstekmuur"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Wapenrusting"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Treurwilg"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wielen"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whiskyvat"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whiskyvaten"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Witte loper"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Witte koning"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Wit paard"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Witte pion"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Witte Populier"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Witte dame"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Witte toren"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wildwestthema"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Wildweststijl"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Door wind gevormde Concave Hoek dak"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Door wind gevormde Concave Hoek Muur"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Door wind gevormde Concave Hoek Muur"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Door wind gevormde Convexe Hoek dak"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Door wind gevormde Convexe Hoek Muur"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Door wind gevormde Convexe Hoek Muur"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Door wind gevormd vloerstuk"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Door wind gevormd vloerstuk"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Door wind gevormde Basis van Rotsformatie"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Door wind gevormde Basis van Rotsformatie"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Door wind gevormd middengedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Door wind gevormd middengedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Door wind gevormd middengedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Door wind gevormd middengedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Door wind gevormd bovenste gedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Door wind gevormd bovenste gedeelte van Rotsformatie"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Door wind gevormd stuk plat dak"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Door wind gevormd stuk plat dak"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Door wind gevormd stuk plat dak"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Door wind gevormde muurbasis"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Door wind gevormde muurbasis"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Door wind gevormd stuk muur"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Door wind gevormd stuk muur"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Door wind gevormd stuk muur"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Door wind gevormd stuk muur"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmolen"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Raam"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Raam"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Raam"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Heksensoep",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Een kraam waar dikke gebonden soep wordt verkocht."
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Heksen rond een ketel"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Rupstreinen",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Achtbaantrein met kleine karretjes in de vorm van een grote rups.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagiers per karretje"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderlandthema"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wantansoepkraam",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Een kraam waar wantansoep wordt verkocht."
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Hout"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Zwarte houten palen"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Rode houten palen"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Houten hek met klimmende wijnstokken"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Houten hek met klimmende wijnstokken"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Houten hek met dode wijnstokken"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Houten hek met dode wijnstokken"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Houten hek met dode wijnstokken"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Houten hek met mensetende plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Hout"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Houten blok"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Houten kar"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Houten schutting"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Houten hek"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Besneeuwde houten schutting"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Houten hek"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Houten schutting"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Houten schutting"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Houten hek"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Houten voetpad"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Hek van houten palen"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Hek van houten palen"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Besneeuwd hek van houten palen"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Hek van houten palen"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Houten achtbaantrein",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Houten achtbaantrein met gevoerde zittingen en schootbeugels.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Houten achtbaantrein (zespersoons)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Houten achtbaantrein met gevoerde zittingen en schootbeugels.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Houten achtbaantrein (zespersoons, achteruit)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Houten achtbaantrein met gevoerde zittingen en schootbeugels, die rijdt met de zittingen naar achteren.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagiers per karretje"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Houten zijfrictiekarretjes",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Eenvoudige karretjes voor de zijfrictieachtbaan.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretjes"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Lichtkrant in mijnstijl"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Houten wand"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Houten wand"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Houten wand"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Houten wand"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Neergestort watervliegtuig"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Taxitrein",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Een gigantische stalen achtbaan met treinen in de vorm van een taxi die in staat is tot soepele afdalingen en heuvels die hoger zijn dan 90 meter.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagiers per karretje"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Taxus"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeusstandbeeld"
+  }
+}

--- a/objects/pl-PL.json
+++ b/objects/pl-PL.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "Napis Goliat"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Napis Meduza"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Napis Nitro"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Olbrzymi napis \"Teksas\""
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Wyścigówki z lat 20.",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Pasażerowie ścigają się w gokartach stylizowanych na samochody z lat 20.",
+    "reference-capacity": "Single-seater",
+    "capacity": "Jednomiejscowe"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Samochód z lat 50."
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Samochód z lat 50."
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Rakieta z lat 50."
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Rakietowy odlot",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Wagoniki tego typu kolejki są wciągane ze stacji na pionowy odcinek toru, po czym zjeżdżają z niego, przejeżdżają z powrotem przez stację i wjeżdżają siłą rozpędu tyłem na drugi pionowy odcinek",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "Kino trójwymiarowe",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Kino wyświetlające trójwymiarowe filmy na ekranie stanowiącym wewnętrzną ścianę kulistego budynku",
+    "reference-capacity": "20 guests",
+    "capacity": "20 widzów"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "Znak 3D"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "Znak 3D"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Kolejka odwrotna",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Pasażerowie siedzą w fotelach podwieszonych pod torem, pokonując wielkie pętle, zakręty i zakręcone zjazdy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Latające zakręty",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Pasażerowie zjeżdżają krętą trasą w wagonach przypominających bobsleje, prowadzonych jedynie przez krzywizny i wychylenia półkolistego toru",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Element dekoracji aborygeńskiej"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Zwykły segment aborygeński"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Dekoracja aborygeńska - wąż"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Dekoracja aborygeńska - duch"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstrakcyjna"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Wystrój abstrakcyjny"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Jaskrawozielona woda"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Wylot aktywnego wulkanu"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Dorosły słoń indyjski"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Dorosła panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Wejście do parku safari"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Wystrój afrykański"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Pneumatyczna kolejka pionowa",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Po rozrywkowym starcie z wyrzutni pneumatycznej wagoniki wjeżdżają po pionowym torze, po czym wykonują pionowy zjazd w dół, z powrotem do stacji",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Lotnicza kolejka jednoszynowa",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Stylizowana kolejka o dużej pojemności z opływowym pierwszym i ostatnim wagonikiem",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasażerów na wagonik"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Sosna z Aleppo"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Pradawne budowle kosmitów"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Pradawne budowle kosmitów"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Roślina kosmitów"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Roślina kosmitów"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Duży lufcik kosmitów"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Mały lufcik kosmitów"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Duża budowla kosmitów"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Duża budowla kosmitów"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Duża budowla kosmitów"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mała budowla kosmitów"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mała budowla kosmitów"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Mała budowla kosmitów"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Wieża kosmitów - dół"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Wieża kosmitów - środek"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Wieża kosmitów - góra"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Drzewo kosmitów"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Drzewo kosmitów"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Drzewo aligatorowe"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Amerykańska piłka futbolowa"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Amerykańska piłka futbolowa"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Hełm do futbolu amerykańskiego"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Amerykańskie pociągi parowe",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniaturowe pociągi składające się z repliki parowozu i tendra, ciągnących drewniane wagony z płóciennymi dachami",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasażerów na wagon"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Przejażdżka na anakondzie",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Przestronne pociągi z prostymi zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Zwierzę na rożnie"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Ruchome baloniki"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Ruchome ognisko"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Mechaniczne wszystkowidzące oko"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Mechaniczny argonauta"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Mechaniczny argonauta"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Mechaniczny argonauta"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Mechaniczny kosmonauta"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Mechaniczny jaskiniowiec rozpalający ogień"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Mechaniczna dziewoja"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Mechaniczny jaskiniowiec"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Mechaniczny rycerz ciemności"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Mechaniczny rycerz ciemności"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Mechaniczne ważki"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Mechaniczny orzeł na klatce"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Mechaniczny zły kosmita"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Mechaniczny zły kosmita"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Mechaniczny zły kosmita"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Mechaniczny strażak"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Mechaniczna strzelająca armata"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Mechaniczny gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Mechaniczny dobry kosmita"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Mechaniczny dobry kosmita"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Mechaniczny dobry kosmita"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Mechaniczny rycerz"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Mechaniczny rycerz"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Mechaniczna meduza"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Mechaniczny policjant"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Mechaniczny Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armia mechanicznych szkieletów"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armia mechanicznych szkieletów"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armia mechanicznych szkieletów"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Mechaniczny żołnierz Kosmosu"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Mechaniczny stegozaur"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Mechaniczny tyranozaur"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Mechaniczny triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Mechaniczny machający król"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Mechaniczny atakujący skorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Mechaniczny atakujący skorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Mechaniczny trzepoczący pterodaktyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Wystrój antarktyczny"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Samica antylopy"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Samiec antylopy"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Para antylop"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antygrawitacyjny ekran LCD"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antygrawitacyjny ekran LCD"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Tarcza łucznicza"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizoński cyprys"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Narożnik art deco"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Narożnik z balustradą art deco"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Narożnik z balustradą art deco"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Narożnik z oknami art deco"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Narożnik z oknami art deco"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Narożnik z oknami art deco"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Kiosk art deco",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Stoisko sprzedające ciasteczka i świeżą lemoniadę"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Odwrócony narożnik art deco"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Odwrócony narożnik art deco"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Segment dachu art deco"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Górny narożnik art deco"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Górny narożnik art deco"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Górny narożnik art deco"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Część górna art deco"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Część górna art deco"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Segment muru art deco"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Ściana z drzwiami art deco"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur z balustradą art deco"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur z balustradą art deco"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur z balustradą art deco"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Mur z balustradą art deco"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Ściana z oknami art deco"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Ściana z oknami art deco"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Segmentowa kolejka górska",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Kolejka z krótkimi pojedynczymi wagonikami z otwartym przodem",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Dróżka żwirowa"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Jesion z nimfami"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Wystrój azjatycki"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gong azjatycki"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Osika"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Posąg Atlasa"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Wejście do parku australoazjatyckiego"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Wystrój australoazjatycki"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australijska fontanna zestaw 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australijska fontanna zestaw 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Czar automobilizmu",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Wagoniki kolejki górskiej w kształcie starych samochodów",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Olbrzymia ośmiornica z kiepskiego dreszczowca"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Olbrzymi pająk z kiepskiego dreszczowca"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Przejażdżka na olbrzymim pająku",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Pasażerowie podróżują parami w stylizowanych siedziskach, okrążających olbrzymiego pająka jak z kiepskiego dreszczowca",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Mały słoń indyjski"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Mała panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Rakieta do badmintona"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Rakieta badmintonowa"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Latarnia balowa"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Latarnia balowa"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Kiosk z balonami",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Stoisko z pamiątkami, w którym można kupić baloniki napełnione helem"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bambusowy busz"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Cokół bambusowy"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Dach bambusowy"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bambusowy róg dachu"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bambusowy róg dachu odwócony"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Pędy Bambusa"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Ściana bambusowa"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Muzyk"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Muzyk"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Muzyk"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Muzyk"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Inwazja agrarna",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Pasażerowie jadą w podwieszanych wagonikach, pokonujących błyskawicznie wielkie pętle, wiraże i długie zjazdy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Beczułka"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Beczułka"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Beczułka"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Beczułka"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Blok podstawy"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Blok podstawy"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Blok podstawy"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Blok podstawy"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Kolejka taranowa",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Zwarta przestrzennie kolejka ze stalowymi torami, spiralnym podjazdem i siedzeniami ustawionymi jedno za drugim",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Kiosk z wołowymi kluseczkami",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Stoisko sprzedające wołowe kluseczki w chińskim stylu"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Ławka"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Ławka"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Ławka"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Ławki"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Tygrys bengalski",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Kolejka górska wykonująca zabójcze zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Rowery jednotorowe",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Specjalne rowery jadące po stalowej jednoszynowej trasie, napędzane przez pedałujących pasażerów",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 pasażer na rower"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben i Parlament Londyński"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Wielka bryła"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Kolarz"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Czarny goniec"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Przejażdżka londyńską taksówką",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Pojazdy z napędem zbudowane na wzór czarnych londyńskich taksówek",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Czarna śmierć",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Pasażerowie zjeżdżają krętym torem w wagonikach w kształcie szczurów, kierowanych jedynie krzywizną i nachyleniem półkolistego toru",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Czarny król"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Czarny skoczek"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Czarny pionek"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Czarna topola"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Czarna królowa"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Czarna wieża"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Potwór z Kosmosu",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Obrotowa kosmiczna kabina obserwacyjna wjeżdżająca na wysoką wieżę",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 pasażerów"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Blok"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Kolejka bobslejowa",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Pasażerowie zjeżdżają krętą trasą w wagonikach przypominających bobsleje, prowadzonych jedynie przez krzywizny i wychylenia półkolistego toru",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Kipiący garnek"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Kość"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Płot kościany"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Kości"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Bumerang",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Po rozrywkowym starcie z wyrzutni pneumatycznej wagoniki wjeżdżają po pionowym torze, po czym wykonują pionowy zjazd w dół, z powrotem do stacji",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Cegła"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Ściana ceglana"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Ściana ceglana"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Ściana ceglana"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Angielska skrzynka pocztowa"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Angielska budka telefoniczna"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Uszkodzony posąg"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Zepsute koło"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brązowa dróżka tłuczniowa"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brązowa Mozaikowa Ścieżka"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bulgocząca smoła"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Kubeł"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Budynek"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Budynek"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Japoński superpociąg",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Kolejka z wagonikami o kształcie nawiązującym do superszybkiego japońskiego ekspresu",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Sitowie"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Gumołódki",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Małe okrągłe pontony napędzane silnikiem zamontowanym centralnie i sterowanym przez pasażerów",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasażerów na łódkę"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boja"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boja"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Bar hamburger",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Budynek w kształcie hamburgera, w którym można kupić hamburgery"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Krzak"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Motyl"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Wejście do budki"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Wejście do budki"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Budka - segment dachu"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Budka - segment dachu"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Budka - segment dachu"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Wierzch budki"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Budka - segment ściany"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Budka - segment ściany"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Budka - segment ściany"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Segment ściany budki"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Segment ściany budki"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Segment ściany budki"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Segment ściany budki"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Segment ściany budki"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Drzewo kapuściane"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Wiąz"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Palma kanaryjska"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Cukierek"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Cukierek"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Cukierek"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Batonik"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Drzewo cukierkowe"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Drzewo cukierkowe"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Drzewo cukierkowe"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Styl cukierkowy"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Kiosk z watą cukrową",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Budynek w kształcie kłębu waty cukrowej, w którym można kupić różową watę cukrową"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Armata"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Armata"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Kule armatnie"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Kajaki",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Długie kajaki, w których pasażerowie sami wiosłują",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 pasażerów na łódkę"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Płócienny dach"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Namiot"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Parada na platformach - motyle",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Wagoniki w kształcie motylich platform",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Parada na platformach - żaby",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Wagoniki w kształcie żabich platform",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Parada na platformach - jaszczurki",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Wagoniki w kształcie jaszczurczych platform",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Szyb kopalniany"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Bankomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Maszynka z pieniędzmi - dla gości, którzy wszystko już wydali"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Zamek (Brązowy)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Zamek (Szary)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Narożnik zamkowy"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Narożnik zamkowy"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Wejście do zamku"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Zamkowy odwrócony narożnik"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Brama zamkowa"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Fortyfikacja zamkowa"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Narożnik fortyfikacji zamkowej"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Narożnik fortyfikacji zamkowej"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Narożnik fortyfikacji zamkowej"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Odwrócony narożnik fortyfikacji zamkowej"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Wieża zamkowa"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Narożnik wieży zamkowej"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Narożnik wieży zamkowej"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Skrzyżowanie wieży zamkowej"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Prosty segment wieży zamkowej"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Segment T wieży zamkowej"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Segment T wieży zamkowej"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Mur zamkowy"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Czaszka bydlęca"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Kaukaska jodła"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Kocioł"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Wejście do jaskini"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Jaskiniowe samochodziki",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Pasażerowie ścigają się gokartami w stylu epoki kamiennej",
+    "reference-capacity": "Single-seater",
+    "capacity": "Jednomiejscowe"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedr libański"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerber",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Pasażerowie jadą w wygodnych wagonikach z zabezpieczeniami obejmującymi w pasie, pokonując wielkie gładkie zjazdy i skomplikowane zakręty, a także liczne wzloty nad wzniesieniami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Latające krzesełka",
+    "reference-description": "Open cars for chairlift",
+    "description": "Kolejka krzesełkowa z otwartymi siedziskami",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Blok szachownicy"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Szachownica"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Koty z Cheshire",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Napędzane pojazdy w kształcie kotów podróżujące wyznaczoną trasą",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 pasażerów na kota"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Kiosk z kotlecikami z kurczaka",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Stoisko sprzedające pieczone kotleciki z kurczaka"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chiński cedr"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chiński smok"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Przejażdżka na chińskim smoku",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Samochodziki z napędem elektrycznym",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na samochód"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Zakręcona dżonka",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Statek jest przymocowany do ramienia z przeciwwagą i wykonuje pełne obroty",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasażerów"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Buda z frytkami",
+    "reference-description": "A hut selling chips",
+    "description": "Budka w której można kupić frytki"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Kiosk z frytkami",
+    "reference-description": "A stall selling chips",
+    "description": "Stoisko sprzedające frytki"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Tabliczka czekolady"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Dróżka obwodowa"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Cyrk",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Cyrk ze zwierzętami występującymi w wielkim namiocie",
+    "reference-capacity": "30 guests",
+    "capacity": "30 widzów"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Cyrk"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Klasyczny / Rzymski"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Drogowskaz klasyczny"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Wystrój klasyczny/rzymski"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Igła Kleopatry"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Pnącze"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Zegar"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Drzewko treflowe"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Kolejka łódkowa",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Wagoniki w kształcie łódek",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasażerów na łódkę"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Filiżanki",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Pasażerowie jadą parami w wagonikach wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Kawiarenka",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Stoisko w stylu art deco sprzedające kawę"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Koło zębate"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Koło zębate"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Koło zębate"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Koło zębate"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola cukierek"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Kolumnada"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Jałowiec"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Dąb"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Cis"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Mała kolejka odwrócona",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Pasażerowie podróżują parami w fotelach podwieszonych pod torem, pokonując pętle i ostre zakręty",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Lot kondora",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Korzystając ze specjalnych uprzęży, korzystający z atrakcji doznają uczucia lotu, w trakcie jazdy pojazdem w kształcie Kondora",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Węgorz",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Niewielka kolejka górska ze stalowym torem. Zestaw wagoników w kształcie węgorza pokonuje liczne korkociągi i pętle",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Żywopłot iglasty"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Żywopłot iglasty"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Pas transmisyjny - zakręt"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Pas transmisyjny - zakręt odwrotny"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Pas transmisyjny - koniec"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Pas transmisyjny - wjazd"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Pas transmisyjny - prosty"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Kiosk z ciasteczkami",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Stoisko sprzedające olbrzymie ciastka"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Fajny gostek"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Kolejka korkociągowa",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Zwarta przestrzennie kolejka ze stalowymi torami, w której wagoniki pokonują korkociągi i pętle",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Segment dachu z blachy falistej"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Podstawa z blachy falistej"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Dach z blachy falistej"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Ściana z blachy falistej"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Falisty segment ściany"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Korsykańska sosna"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Kowboj 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Kowboj 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Zwariowana dróżka"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Wystrój niesamowity"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Krokodyle",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Łódki w kształcie krokodyli podróżują kanałem, ześlizgując się ze stromych zjazdów, aby ochlapać pasażerów",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasażerów na łódkę"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Krzywy dom",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Budynek z powykrzywianymi ścianami i zakręconymi korytarzami, dezorientujący ludzi, którzy do niego wejdą",
+    "reference-capacity": "5 guests",
+    "capacity": "5 widzów"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Fontanna z Kupidynem"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Zakrzywiony blok"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Zakrzywiony blok"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Segment zakrzywionej ściany glinianej"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Segment zakrzywionej ściany glinianej"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Segment zakrzywionej ściany glinianej"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Zakrzywiony dach"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Zakrzywiony dach"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Zakrzywiona ściana"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Zakrzywiona ściana"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Muzyka niestandardowa 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Muzyka niestandardowa 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyklopowa jazda",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Pasażerowie podróżują w oczach wielkich cyklopów",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na wagonik"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Posąg cyklopa"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Lampa-stokrotka"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Wejście do parku Mrocznych Wieków"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Wystrój średniowieczny"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Miasteczko średniowieczne - narożnik dachu"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Miasteczko średniowieczne - narożnik dachu"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Miasteczko średniowieczne - odwrócony segment dachu"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Miasteczko średniowieczne - odwrócony segment dachu"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Miasteczko średniowieczne - dolny narożnik"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Miasteczko średniowieczne - segment dolnej ściany"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Miasteczko średniowieczne - segment dachu"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Miasteczko średniowieczne - segment dachu"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Miasteczko średniowieczne - segment dachu"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Miasteczko średniowieczne - segment dachu"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Miasteczko średniowieczne - dach z kominem"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Miasteczko średniowieczne - górny narożnik"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Miasteczko średniowieczne - segment górnej ściany"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Miasteczko średniowieczne - segment górnej ściany"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Miasteczko średniowieczne - segment górnej ściany"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Miasteczko średniowieczne - segment górnej ściany"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Miasteczko średniowieczne - segment górnej ściany"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Miasteczko średniowieczne - lukarna"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Miasteczko średniowieczne - lukarna"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Miasteczko średniowieczne - dach z lukarną"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Miasteczko średniowieczne - dach z lukarną"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Miasteczko średniowieczne - dach z lukarną"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Miasteczko średniowieczne - dach z lukarną"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Karczma średniowieczna"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Uschłe drzewo"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Uschłe drzewo"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Uschłe drzewo"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Przejażdżka na dawach",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Ozdobne arabskie łodzie rybackie, w których pasażerowie sami wiosłują",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasażerów na łódkę"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Wózek z diamentami"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Brylantowa karuzela",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Pasażerowie jadą w parach siedzisk wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Szyb kopalni diamentów"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Drzewko karowe"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Ślizg pontonowy",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Pasażerowie podróżują w nadmuchiwanych pontonach po zawiłym półkolistym lub rurowym torze",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 pasażerów na ponton"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinozaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinozaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinozaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinozaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinozaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Jaja dinozaura",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Pasażerowie podróżują parami w stylizowanych siedziskach obracających się wokół ruchomej dinozaurowej mamy",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Ziemia"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dróżka ziemna"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Unikajki",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Samochodziki z napędem elektrycznym",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na samochód"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Styl zderzaków (autodromy)"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Przejażdżka na delfinach",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Jednomiejscowe pojazdy w kształcie delfinów, którymi pasażerowie mogą sami kierować",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 osoba na pojazd"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Fontanna z delfinami"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Posąg z delfinami"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Drzwi"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Drzwi"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Drzwi"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Karuzela z konikami",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Tradycyjna zadaszona karuzela z drewnianymi konikami",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasażerów"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Dwupiętrowa wieża obserwacyjna",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Obrotowa piętrowa kabina obserwacyjna wjeżdżająca na wysoką wieżę",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasażerów"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Sklepik z pączkami",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Stoisko sprzedające amerykańskie pączki, zwane też donatami"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Płowa wieża - podstawa"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Płowa wieża - uszkodzona podstawa"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Płowa wieża - część środkowa"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Płowa wieża - szczyt"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Płowy minaret fragment 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Płowy minaret fragment 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Płowy minaret fragment 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Płowy segment dachu 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Płowy segment dachu 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Płowy segment dachu 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Płowy segment dachu 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Płowa wieżyczka - podstawa"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Płowa wieżyczka - podstawa minaretu"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Płowa wieżyczka - szczyt lub część środkowa"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Płowy segment wznoszący 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Płowy segment wznoszący 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Segment płowej ściany 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Segment płowej ściany 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Segment płowej ściany 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Segment płowej ściany 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Segment płowej ściany 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Segment płowej ściany 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Segment płowej ściany 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Segment płowej ściany 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Segment płowej ściany 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Segment płowej ściany 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Segment płowej ściany 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Atakujący smok"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Smocza kolejka",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Kolejka górska z wagonikami opartymi na motywie smoka",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Ważka jazda",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Pasażerowie jadą w specjalnych wagonikach podwieszonych pod jednoszynowym torem, wychylając się swobodnie na zakrętach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Kiosk z napojami",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Stoisko w kształcie puszki sprzedające napoje gazowane"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Posąg z Wyspy Wielkanocnej"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Kolumna egipska"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egipski posąg"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Drogowskaz egipski"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Wystrój egipski"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Ściana egipska"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Styl egipski"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Wieża Eiffela"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Elektryczne ogrodzenie"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Zepsute elektryczne ogrodzenie"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Narożnik elektrycznego ogrodzenia"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Odwrócony narożnik elektrycznego ogrodzenia"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Elektryczne ogrodzenie z lampką"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Słoniowa fontanna"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Pusty wózek"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Krynolina",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Obracające się koło z podwieszanymi wagonikami. Gdy się rozkręci, hydrauliczne ramię podnosi je do pionu",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eukaliptus"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Wystrój europejski"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Europejski modrzew"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Wejście do europejskiego parku"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Zły samuraj"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Przejażdżka jajkami Faberge'a",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Pasażerowie jadą w parach siedzisk wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Odwrócone kapsuły",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Pasażerowie siedzą naprzeciwko siebie, pokonując pętle i ostre zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Styl organów wesołego miasteczka"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Styl fantasty"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Narzędzia rolnicze"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Gruby Budda"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Zastawiony stół"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Płot"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Płot"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Płot"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Płoty i ściany"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Diabelski młyn",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Wielkie obrotowe koło z otwartymi wagonikami",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 pasażerów"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Ognisty sygnał"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Bojowe latawce",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Pasażerowie jadą w parach siedzisk wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Walczący rycerze",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Pasażerowie zderzają się samochodzikami w kształcie koni",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na samochodzik"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Karuzela fajerwerków",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Obracające się koło z podwieszanymi wagonikami. Gdy się rozkręci, hydrauliczne ramię podnosi je do pionu",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Pierwsza pomoc",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Miejsce dla gości, którym zrobiło się niedobrze - tutaj szybciej oprzytomnieją"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Przerębel"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Statua"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Płomienie"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flaming żerujący"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flaming patrzący"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flaming muskający pióra"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Kolejka bezpodłogowa",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Szerokie wagoniki pozbawione podłóg zapewniają pasażerom dobry widok podczas jazdy trasą z wieloma zakrętami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Kwiat"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Dzieci Kwiaty",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Małe pontony w kształcie kwiatów, napędzane centralnie montowanym silnikiem, którym sterują pasażerowie",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 osoba na ponton"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Koszulki dzieci-kwiatów",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stoisko sprzedające koszulki z motywami kwiatowymi"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Latający Holender",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Wagoniki w kształcie latających łodzi jadą po torze z ostrymi zakrętami i stromymi zjazdami, wpadając w odcinki wodne spokojnie płynącej rzeki",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasażerów na łódkę"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Latająca kolejka",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Pasażerowie zasiadają w wygodnych fotelach zawieszonych pod torem i jadą zawiłą trasą, czując się, jakby potrafili latać",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Latające spodki",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Poduszkowce z własnym napędem",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na samochód"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Piłka futbolowa"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Kolejka futbolowa",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi wagonikami w kształcie piłek, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Rajska jabłoń"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Leśne drzewa"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontanna"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontanna"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Kolejka serpentynowa",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Pojedyncze wagoniki jeżdżą podwieszone pod torem z ostrymi zakrętami i gwałtownymi spadkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Stoisko z kurczakami",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Stoisko sprzedające kubełki z pieczonym kurczakiem"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Kiosk ze smażonym ryżem",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Stoisko sprzedające chińskie kluseczki ze smażonego ryżu"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Drops owocowy"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Drops owocowy"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Drzewo owocowe"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Drzewo owocowe"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Kiosk z lodami owocowymi",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Stoisko sprzedające lody owocowe"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Dziwaczny dom",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Budynek składający się z ruchomych ścian i podłóg, dezorientujących ludzi, którzy do niego wejdą",
+    "reference-capacity": "5 guests",
+    "capacity": "5 osób"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Kiosk z makaronikami",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Stoisko sprzedające ciasteczka zwane makaronikami"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Wystrój przyszłościowy"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Wejście do parku futurystycznego"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Szubienica"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangsterska kolejka",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Wagoniki stylizowane na gangsterskie samochody z lat 20. są wystrzeliwane ze stacji za pomocą silnika liniowego i suną po zawiłym torze",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Klomb"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Ogrody"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Gejsza"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Sklep wielobranżowy"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Styl delikatny"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Fontanna geometryczna"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Rzeţba geometryczna"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Rzeţba geometryczna"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Rzeţba geometryczna"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Rzeţba geometryczna"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Rzeţba geometryczna"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgiański narożnik płaskiego dachu"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgiański skraj płaskiego dachu 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgiański skraj płaskiego dachu 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgiański segment ściany parteru 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgiański segment ściany parteru 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgiański segment ściany parteru 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgiański segment ściany parteru 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgiański segment ściany parteru 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgiański segment ściany parteru 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgiański segment ściany parteru 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgiański końcowy segment dachu 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgiański końcowy segment dachu 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgiański segment dachu 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgiański segment dachu 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgiański segment dachu 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgiański segment dachu 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgiański segment dachu 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgiański segment dachu 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgiański segment ściany 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgiański segment ściany 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgiański segment ściany 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgiański segment ściany 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgiański segment ściany 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgiański segment ściany 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Gejzery"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Pociąg widmo",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Napędzane wagoniki o potwornych kształtach jadą po wielopoziomowym torze wśród przerażających dekoracji i efektów specjalnych",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Olbrzymia gitara basowa"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Łodyga olbrzymiej fasoli"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Łodyga olbrzymiej fasoli"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Wystrój cukierkowy"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Olbrzymia marchew"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Ślad olbrzymiego dinozaura"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Olbrzymia perkusja"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Olbrzymia paproć"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Wystrój ogrodu olbrzymów"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Olbrzymia trawa"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Olbrzymia gitara"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Wielki mangrowiec"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Wielka Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Olbrzymia dynia"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Wielka śnieżynka"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Wielka śnieżynka"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Wielka śnieżynka"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Gigajazda",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Wielka stalowa kolejka górska jeżdżąca po łagodnych spadkach i wzniesieniach o wysokości 100 m",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Żyrafa 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Żyrafa 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Posąg żyrafy"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Szklany dach"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Szklany dach"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Szklana ściana"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Szklana ściana"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Szklana ściana"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Szklana ściana"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Gokarty",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Samochodziki z napędem benzynowym",
+    "reference-capacity": "single-seater",
+    "capacity": "1 miejsce"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Złota lama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Złoty posąg 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Złoty posąg 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Złoty Budda"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Złote runo"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Złoty cyprys hinoki"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Dobry samuraj"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Przejażdżka na gorylu",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi wagonikami w kształcie goryli, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Trawa"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Kępy trawy"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Nagrobek"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Nagrobek"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Nagrobek"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Nagrobek"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Pomnik cmentarny"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Pomnik cmentarny"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Pomnik cmentarny"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Wielki Mur Chiński - segment przedniej ściany"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Wielki Mur Chiński - segment tylnej ściany"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Wielki Mur Chiński - wznoszący segment ściany"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Wielki Mur Chiński - wieżyczka narożna"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Wielki Mur Chiński - wieżyczka prosta"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Wielki biały rekin",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Przestronne wagoniki z prostymi zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Zielona dróżka tłuczniowa"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Zielona woda"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Zielona i Brązowa Mozaikowa Ścieżka"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Szara Mozaikowa Ścieżka"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Krata (Zielona)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Krata (Fioletowa)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Krata (Czerwona)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Krata (Żółta)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Stylowa tancerka"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Posąg Hadesa"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Gabinet luster",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Budynek z powykrzywianymi lustrami, zniekształcającymi odbicia gości",
+    "reference-capacity": "5 guests",
+    "capacity": "5 osób"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Dok przystani"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Mur przystani"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Narożnik muru przystani"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Narożnik muru przystani"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Mur przystani z dokiem"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Mur przystani ze sprzętem rybackim"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur przystani z pomostem"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur przystani z pomostem"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur przystani z pomostem"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Mur przystani z pomostem"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Przejażdżka z Harpiami",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Pasażerowie jadą w specjalnych uprzężach, pokonując zawiły tor i nawroty albo na plecach, albo wisząc twarzą w dół",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Stragan z kapeluszami",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Stoisko z pamiątkami sprzedające wielkie piankowe kapelusze"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Nawiedzony dom",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Wielki budynek mieszczący straszliwe korytarze i budzące dreszcz grozy pokoje",
+    "reference-capacity": "15 guests",
+    "capacity": "15 widzów"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Nawiedzone kazamaty",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Budynek z lochami i manekinami przedstawiającymi więţniów, które mają straszyć odwiedzających",
+    "reference-capacity": "16 guests",
+    "capacity": "16 gości"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Przejażdżka po nawiedzonym domu",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Wagoniki z napędem jadą po wielopoziomowym torze wśród przerażających dekoracji i efektów specjalnych",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Bela siana"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Drzewo sercowe"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Posadzka niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Sadzawka niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Narożnik sadzawki niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Brzeg sadzawki niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Schody do sadzawki niebiańskich łaţni"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach niebiańskich łaţni"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach niebiańskich łaţni"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach niebiańskich łaţni"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Dach niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Okno niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arkada niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arkada niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arkada niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektura niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektura niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektura niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Architektura niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontanna niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontanna niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Schody niebiańskich łaţni"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Schody niebiańskich łaţni"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Żywopłot"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Żywopłot"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Lądowisko"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Herkules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hibiskus"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hipopotam 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hipopotam 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Przejażdżka hipopotamem",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Pasażerowie podróżują podwodnym torem, usadowieni w łodzi podwodnej",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 pasażerów na wagonik"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Iglicznia"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Styl horror"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Koń"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Posąg konia"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Posąg jeţdţca"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Bieg z przeszkodami",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Pasażerowie jadą pojazdami w kształcie koni, poruszającymi się po jednoszynowym torze kolejki",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 pasażerów na konia"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Stragan z grzaną czekoladą",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Stragan z czekoladą do picia."
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Kiosk z hotdogami",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Stoisko sprzedające parówki w bułeczkach"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Podrasowany wóz"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Podrasowany wóz"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Podrasowane samochody",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Po ekscytującym starcie z pneumatycznej wyrzutni pociąg rozpędza się pod górę pionowego toru, pokonuje szczyt i spada pionowo z drugiej strony, by powrócić na stację",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Dom"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Latające motocykle",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Pasażerowie podróżują na futurystycznych pojazdach w kształcie motocykli, jadących po jednoszynowym torze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasażerów na pojazd"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Latające samochody",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Technologia kolei magnetycznej umożliwiła stworzenie złudzenia futurystycznych latających samochodów",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Latający motocykl"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Latający motocykl"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Latający motocykl na podeście"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Latający motocykl na podeście"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Latająca deska",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Pasażerowie podróżują na futurystycznej latającej desce, wychylającej się swobodnie na zakrętach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Latający samochód"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Latający samochód"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Latający samochód na podeście"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Latający samochód na podeście"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Psi zaprzęg",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Pojazdy w kształcie sanek zaprzężonych w psy jadące po torze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Pociąg hiperzwijka",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Przestronne wagoniki z prostymi zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hiperzwijka (szerokie wagoniki)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Szerokie na 4 miejsca wagoniki z podniesionymi fotelami i prostymi zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hiperjazda",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Wysoka, nieobrotowa szybka kolejka górska z dużymi zjazdami i wygodnymi wagonikami, wyposażonymi w zabezpieczenia obejmujące pasażerów jedynie w pasie",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Lód"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Lód"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Kiosk z rożkami",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Stoisko sprzedające lodowe rożki"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Kostka lodu"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Formacja lodowa"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Formacja lodowa"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Lodowy pałac"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Wejście do parku lodowego"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Podstawa rury lodowej"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Segment rury lodowej"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Wylot rury lodowej"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Lodowy dach"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ściana lodowa"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Styl lodowy"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Oblodzone beczułki"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Oblodzone beczułki"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Oblodzone beczułki"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Kiosk z mrożoną herbatą",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Stoisko sprzedające mrożoną herbatę"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Dach igloo"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Ściana igloo"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Kolejka zwrotna",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Wagoniki tego typu kolejki są wciągane ze stacji na pionowy odcinek toru, po czym zjeżdżają z niego, przejeżdżają z powrotem przez stację i wjeżdżają siłą rozpędu tyłem na drugi pionowy odcinek",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Cedr wonny"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indiańska jedwabna flaga"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indiańska jedwabna flaga"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indiańska jedwabna flaga"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indiańska jedwabna flaga"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indiańska jedwabna flaga"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Narożnik dachu przemysłowego"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Narożnik dachu przemysłowego"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Segment dachu przemysłowego"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Narożnik muru przemysłowego"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Narożnik muru przemysłowego"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Element muru przemysłowego"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Element muru przemysłowego"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Element muru przemysłowego"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Element muru przemysłowego"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Mur przemysłowy z drzwiami"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Mur przemysłowy z oknem"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Kiosk informacyjny",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Tutaj goście mogą otrzymać mapy parku i zakupić parasole"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Eskimos"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Eskimos"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Żelazo"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Włoski cyprys"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Karuzela karabinierów",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Pasażerowie jadą w parach siedzisk wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Niewielka kolejka górska z oddzielnymi wagonikami i gładkimi zakręconymi spadkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japońska kwitnąca wiśnia"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japońskie drzewo wiśniowe"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Wejście do parku japońskiego"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japońska sosna"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Dach japoński"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Dach japoński"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Dach japoński"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japońska jedwabna flaga"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japońskie ośnieżone drzewo"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Muzyk jazzbandu"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Muzyk jazzbandu"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Muzyk jazzbandu"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Muzyk jazzbandu"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Gumiś"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Żelka"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Płot żelkowy"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Odrzutowiec"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Odrzutowiec"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Odrzutowiec"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Lot z plecakiem rakietowym",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Pasażerowie podróżują w pojeţdzie wystrzeliwanym na pionowy odcinek toru",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasażerów na pojazd"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Lot odrzutowcem",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Zwarta przestrzennie kolejka górska z oddzielnymi wagonikami i gładkimi, krętymi zjazdami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Skutery wodne",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Jednomiejscowe skutery, którymi pasażerowie mogą sami kierować",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 osoba na pojazd"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Turniej rycerski",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Pasażerowie podróżują wagonikami w kształcie koni, jadącymi po jednoszynowym torze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasażerów na pojazd"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Skaczące fontanny"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Skaczące śnieżki"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Dżungla"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Płot tropikalny"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Drogowskaz z dżungli"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Wystrój tropikalny"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Drzewo z dżungli 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Drzewo z dżungli 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Drzewo z dżungli z panterami"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Drzewo z dżungli z lianami"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Styl bębnów dżungli"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Śmieci"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Drogowskaz jurajski"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Wystrój jurajski"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Styl jurajski"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangur"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Zabójczy wieloryb",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Pasażerowie podróżują podwodnym torem, usadowieni w łodzi podwodnej",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 pasażerów na wagonik"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Duży wagonik dla kolejki o swobodnym spadku",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasażerów na wagonik"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlowska wieża - podstawa"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlowska wieża - część środkowa"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlowska wieża - szczyt"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Część wieżyczki kremlowskiej 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Część wieżyczki kremlowskiej 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Część wieżyczki kremlowskiej 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Segment dachu kremlowskiego 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Segment dachu kremlowskiego 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlowska wieżyczka - podstawa"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlowska wieżyczka - część środkowa"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlowska wieżyczka - podstawa minaretu"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Wznoszący się segment muru kremlowskiego 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Wznoszący się segment muru kremlowskiego 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Segment muru kremlowskiego 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Segment muru kremlowskiego 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Segment muru kremlowskiego 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Segment muru kremlowskiego 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Segment muru kremlowskiego 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Segment muru kremlowskiego 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Segment muru kremlowskiego 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Segment muru kremlowskiego 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Kolejka z napędem liniowym",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Wagoniki są rozpędzane za pomocą magnetycznego silnika liniowego i podróżują tam i z powrotem po zakręconym torze",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Jazda na biedronkach",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Kolejka górska z wagonikami w kształcie biedronek",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Wielki zakrzywiony płot mamuci"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Wielki zakrzywiony płot mamuci"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Duży wiąz"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Wielki płot mamuci"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Wielki płot mamuci"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Duży krater po meteorycie"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Wielki dąb"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Wielkie drzewo tropikalne"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Duży czerwony krater po meteorycie"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Wielki dymiący komin"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Duży głośnik"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Wielki totem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Ogrodzenie laserowe"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Narożnik ogrodzenia laserowego"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Wystrzałowa spadajka",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Wagonik jest wystrzeliwany pneumatycznie na szczyt wysokiej wieży, a potem swobodnie opada",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawsonia"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Podwieszana minikolejka",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Pasażerowie podróżują w pozycji leżącej, twarzą w dół, w specjalnych wagonikach podwieszonych pod pojedynczym torem, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasażer na wagonik"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Leżąca kolejka",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Pasażerowie wiszą w specjalnych uprzężach twarzą w dół, podróżując przez zakręcony tor albo na plecach, albo twarzą ku ziemi",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Stragan z lemoniadą",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Stylizowane stoisko sprzedające staroświecką świeżą lemoniadę."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Kiosk z lemoniadą",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Stoisko sprzedające orzeţwiającą lemoniadę"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Winda",
+    "reference-description": "Steel lift cabin",
+    "description": "Pasażerowie jeżdżą w dół lub w górę windą w wieży, aby przejść z jednego poziomu na drugi",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lilia"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Kolejka-limuzyna",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Kolejka górska z wagonikami w kształcie limuzyn",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lew"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lwia przejażdżka",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Niewielka kolejka górska z pojedynczymi wagonikami i łagodnie zakręconymi spadkami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Kosz na śmieci"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Kosz na śmieci"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Kosz na śmieci"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Kosz na śmieci"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Chata z bali"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Hata z bali"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Chata z bali - segment dachu"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Chata z bali - segment dachu"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Chata z bali - segment dachu"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Boczny komin chaty z bali"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Chata z bali - segment ściany"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Pociąg drwali",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Kolejka górska z wagonikami w kształcie pni drzew",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Pnie"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Jazda flisacka",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Łódki w kształcie pni płyną wodnym kanałem, spadając z pluskiem ze stromych spadków, aby zamoczyć pasażerów",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasażerów na łódkę"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lizak"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Topola lombardzka"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Kolejka górska",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Wagoniki kolejki górskiej z zabezpieczeniami obejmującymi pasażerów w pasie, mogące pokonywać pionowe pętle",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Zaginione miasto - część kolumny"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Zaginione miasto - część kolumny"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Zaginione miasto - segment płaskiego dachu"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Zaginione miasto - segment płaskiego dachu"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Zaginione miasto - segment płaskiego dachu"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Zaginione miasto - segment schodów"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Zaginione miasto - segment schodów"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Zaginione miasto - segment schodów"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Zaginione miasto - segment schodów"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Zaginione miasto - segment schodów"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Zaginione miasto - narożnik ściany"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Zaginione miasto - narożnik ściany"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Zaginione miasto - narożnik ściany"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Zaginione miasto - narożnik ściany"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Zaginione miasto - segment ściany"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Niski krzak"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Dziób luksusowego liniowca"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Segment środkowy luksusowego liniowca"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Rufa luksusowego liniowca"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Jazda na maczudze",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Pasażerowie siedzą w stylizowanym wagoniku, przymocowanym do napędzanego obrotowego ramienia",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 osoba na wagonik"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Latający dywan",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Wagony w kształcie latającego dywanu poruszające się na przemian w górę i w dół na końcach czterech ramion",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasażerów"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Czarodziejska zbroja"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Czarodziejski hełm"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Czarodziejska tarcza"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Czarodziejski miecz"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Pałac maharadży łuk 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Pałac maharadży łuk 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Pałac maharadży - kopuła"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Element pałacu maharadży"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Element pałacu maharadży"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Element pałacu maharadży"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Pałac maharadży - podstawa wieży"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Pałac maharadży - korpus wieży"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Pałac maharadży - szczyt wieży"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Pociąg maharadży",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniaturowe pociągi składające się z lokomotywy parowej i tendra, ciągnących zadaszone drewniane wagoniki",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasażerów na wagon"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Kaczki-mandarynki",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Łódki w kształcie łabędzi napędzane przez pedałujących pasażerów z przednich miejsc",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasażerów na łódkę"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrowiec"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Wielka płaszczka",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Duże łódki płynące szerokim kanałem wodnym, wciągane na wzniesienia przez taśmę i zjeżdżające z nich z wielkim pluskiem, aby zamoczyć pasażerów",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasażerów na łódkę"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Dach marmurowy"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Dach marmurowy"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Dach marmurowy"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Dach marmurowy"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Tancerka karnawałowa"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Tancerka karnawałowa"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Namiot"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Słoninka"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Słoninka"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Mars"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Budynek Marsjan"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Artefakt Marsjan"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Artefakt Marsjan"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Artefakt Marsjan"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Artefakt Marsjan"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Artefakt Marsjan"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Wystrój marsjański"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Ściana marsjańska"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Styl marsjański"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labirynt",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Goście wędrują po labiryncie zbudowanym z dwumetrowych żywopłotów lub ścian"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Kiosk z zupą klopsikową",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Stoisko sprzedające chińską zupę z klopsikami"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Wystrój mechaniczny"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Styl mechaniczny"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Wystrój średniowieczny"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Styl średniowieczny"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Człowiek zamieniony w kamień"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Człowiek zamieniony w kamień"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Człowiek zamieniony w kamień"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Człowiek zamieniony w kamień"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Karuzela obrotowa",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Tradycyjna karuzela z drewnianymi konikami",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Płot z siatki"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Płot z siatki"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Narożnik krateru po meteorycie"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Narożnik krateru po meteorycie"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Odwrócony narożnik krateru po meteorycie"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Ściana krateru po meteorycie"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Ściana krateru po meteorycie z kryształami"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Ściana krateru po meteorycie z kryształami"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Błękitny jałowiec"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Przejażdżka mikrobusem",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Symulator ruchu, wewnątrz którego wyświetlany jest film, zaś pojazd jest wstrząsany i przechylany zgodnie z obrazem za pomocą siłownika hydraulicznego",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Mikrobus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Zwariowana kopalnia",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Małe wózki kopalniane jadące po zygzakowatym drewnianym torze, przechylające się na ostrych zakrętach i zdradliwych zjazdach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Wózki kopalniane",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Pojedyncze samochodziki w kształcie drewnianych wózków kopalnianych",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Wagoniki kopalniane",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Drewniane wagoniki z wyściełanymi siedzeniami i zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Chatka górnicza"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Chatka górnicza"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Winda kopalniana",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Pasażerowie jeżdżą w dół lub w górę windą w wieży, aby przejść z jednego poziomu na drugi",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Szyb kopalniany"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Wystrój górniczy"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Kolejka kopalniana",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Kolejka górska w stylu górniczym, poruszająca się po stalowych szynach stylizowanych na stary tor kolejowy",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 lub 4 pasażerów na wagonik"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Minigolf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Spokojna gra w miniaturowego golfa",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Minihelikoptery",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Wagoniki w kształcie helikopterów jadące po stalowym torze, sterowane przez pedałujących pasażerów",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Posąg minotaura"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Miętówka"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Styl nowoczesny"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Araukaria"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Potworne pikapy",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Samochody na olbrzymich kołach z napędem 4 x 4, które mogą wjeżdżać na strome zbocza",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 pasażerów na samochód"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Cyprys amerykański"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Sosna Montezumy"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumentalny uszkodzony segment ściany"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumentalna fontanna"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentalny segment schodów"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentalny segment schodów"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentalny segment schodów"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumentalny segment schodów"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalny narożnik ściany"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalny narożnik ściany"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalny narożnik ściany"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumentalny narożnik ściany"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumentalny segment ściany"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Sok z Księżyca",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Stoisko sprzedające najnowsze napoje bezalkoholowe"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Chodnik mozaikowy"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Symulator ruchu",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Pasażerowie oglądają film, siedząc w specjalnej kabinie, poruszanej i wstrząsanej przez siłowniki hydrauliczne",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Wyścigi motocyklowe",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Pasażerowie jadą wagonikami w kształcie motocykli po jednoszynowym torze",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 pasażerów na motocykl"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motocykl"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motocykl"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Myszochody",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Pojedyncze samochodziki w kształcie myszy",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Drewniana szalona mysz",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Wagoniki w kształcie myszy jadące po zygzakowatym drewnianym torze, przechylające się na ostrych zakrętach i zdradliwych zjazdach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Gliniany segment dachu"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Segment glinianej ściany"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Kolejka wielowymiarowa",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Wagoniki z fotelami, które mogą obracać się do góry nogami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Wejście mitologiczne"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Wystrój mitologiczny"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Indianin"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Naturalna woda"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Narożnik poręczy dachu żeglarskiego"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Żeglarski segment dachu"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Żeglarski segment dachu"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Żeglarski segment dachu"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Żeglarski segment dachu"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Żeglarski segment dachu"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Poręcz dachu żeglarskiego"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Segment ściany żeglarskiej"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon baru"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon baru"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon baru"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon baru"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Przejażdżka z Neptunem",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Pasażerowie podróżują parami w stylizowanych siedziskach obracających się wokół ruchomego posągu Neptuna.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Morskie jadło Neptuna",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Stoisko sprzedające słone smakołyki Neptuna"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Wypełnienie narożnika nowojorskiego"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Wejście nowojorskie"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Odwrócony narożnik nowojorski"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Odwrócony narożnik nowojorski"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Odwrócony narożnik nowojorski"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Odwrócony narożnik nowojorski"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Odwrócony narożnik dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Segment dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Segment dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Segment dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Segment dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Segment dachu nowojorskiego"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Segment ściany nowojorskiej"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Ściana nowojorska z liną"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Ściana nowojorska z liną"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Ściana nowojorska z linią mycia"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Ściana nowojorska z linią mycia"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Brak wejścia"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Brak wejścia, brak platformy"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Wejście do parku północnoamerykańskiego"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Wystrój północnoamerykański"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Świerk norweski"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Przejażdżka w dębowej beczce",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Dębowe beczki lawirują po szerokim kanale, spadając z pluskiem przez wodospady i śmigając przez spienione bystrzyny",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 pasażerów na łódkę"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Wieżowiec z obsydianu - segment drzwi"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Wieżowiec z obsydianu - segment dachu"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Wieżowiec z obsydianu - lekko nachylony narożnik"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Wieżowiec z obsydianu - lekko nachylony narożnik"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Wieżowiec z obsydianu - lekko nachylona ściana"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Wieżowiec z obsydianu - mocno nachylony narożnik"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Wieżowiec z obsydianu - mocno nachylona ściana"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Wieżowiec z obsydianu - mocno nachylona ściana"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Wieżowiec z obsydianu - mocno nachylona ściana"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Wieżowiec z obsydianu - ściana"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Wieżowiec z obsydianu - ściana z oknem"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Biurowiec"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Baryłka ropy"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Pompa naftowa"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Stare przerośnięte drzewo"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Pomarańczowa woda"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Styl organowy"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Styl orientalny"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Obiekt dekoracyjny"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Obiekt dekoracyjny"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Obiekt dekoracyjny"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Drzewo ozdobne"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Drzewo ozdobne"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Drzewo ozdobne"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Drzewo ozdobne"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Drzewo ozdobne"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ozdobna ściana marmurowa"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrygowa jazda",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Kolejka górska, w której pasażerowie pokonują pętle, stojąc",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Wiosła w dłoń",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Długie kanoe, w których pasażerowie sami wiosłują",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 pasażerów na kanoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Drogowskaz dalekowschodni"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Wystrój japoński"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Dach pagody"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palma"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Kosz w kształcie pandy"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Wystrój pandowy"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Pandzie Pociągi",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Kolejka górska z puchatymi pandzimi wagonikami",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasażer na wagonik"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Wejście - budynek"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Wejście - brama"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Chałupa"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Przejażdżka na Pegazie",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Po torze jadą napędzane wagoniki w kształcie Pegaza ciągnącego wózek",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Bobsleje-pingwiny",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Pasażerowie zjeżdżają krętą trasą w wagonikach o kształcie pingwinów, prowadzonych jedynie przez krzywizny i wychylenia półkolistego toru",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Samochód z epoki"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Samochód z epoki"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Stylowy bar"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Flaga z epoki"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Jacht z epoki"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Stylowe lampy uliczne"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Ciężarówka z epoki"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Ciężarówka z epoki"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Stacja benzynowa"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Furgonetki",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Pojazdy z napędem mające kształt półciężarówek",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 pasażer na samochód"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Różowa woda"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Rura"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Segment rury"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Segment rury"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Segment rury"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Piracka bandera"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Okręt piracki",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Wielka huśtawka w kształcie statku",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Okręt piracki"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Wystrój piracki"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Styl piracki"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Kiosk z pizzą",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Stoisko sprzedające porcje pizzy"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Prosty"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Zwykła ściana marmurowa"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Roślina"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Roślina"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Ściana z kart do gry"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Ściana z kart do gry"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Cokół"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Pług"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Niedţwiedţ polarny",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Pasażerowie siedzą naprzeciwko siebie, pokonując pętle i ostre zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Słup"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Słup"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Słupy"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Policyjny pościg",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Kolejka górska z pętlami, w której pasażerowie jadą na siedząco",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Gonitwa radiowozów",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Radiowozy w stylu lat 60. jadą po drewnianym torze, zawracając na specjalnych obrotowych odcinkach trasy",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Kiosk z popcornem",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Stoisko sprzedające wielkie pudełka popcornu"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Krata"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Krata"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Słupek"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Przejażdżka kopalniana",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Napędzane wagoniki kopalniane jadą po gładkim i zakręconym torze",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 lub 4 pasażerów na wagonik"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Wejście do parku prehistorycznego"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Wystrój prehistoryczny"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Kiosk z preclami",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Stoisko sprzedające chrupiące precle"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Bulion pierwotny"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Drzwi więzienne"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Więzienne ogrodzenie"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Odwrócony segment więzienny"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Narożnik muru więziennego"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Narożnik muru więziennego"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Segment muru więziennego"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Dach muru więziennego"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Strażnica więzienna"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Schody na strażnicę więzienną"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Schody na strażnicę więzienną"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Więzienna wieża ciśnień"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodaktylot",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Pasażerowie podróżują w wygodnych siedziskach zawieszonych pod torem, pokonując zawiły tor w odjazdowym locie prehistorycznym",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Dynia"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Dom dyniowy"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Piramida"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Telewizor kolejkowy"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Wyścigówki",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Pojazdy z napędem mające kształt samochodów wyścigowych",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 pasażer na wagonik"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Wyścigi raptorów",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Pasażerowie siedzą na grzbietach wagoników w kształcie raptorów, jadących po jednoszynowym torze",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 pasażerów na pojazd"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Głośnik wyścigowy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Antena radarowa"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Tratwy rzeczne",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Tratwy manewrujące zręcznie po wodnym torze",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 pasażerów na tratwę"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Styl ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Płot z prętów"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Płot z prętów"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Płot z prętów"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Płot z prętów"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Płot"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Płot"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Płot"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Tęczowy chodnik"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Czerwona cegła - narożny segment dachu"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Czerwona cegła - płaski narożnik dachu"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Czerwona cegła - płaski skrajny segment dachu"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Czerwona cegła - odwrócony segment dachu"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Czerwona cegła - segment dachu 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Czerwona cegła - segment dachu 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Czerwona cegła - segment dachu 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Czerwona cegła - segment ściany 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Czerwona cegła - segment ściany 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Czerwona cegła - segment ściany 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Czerwona cegła - segment ściany 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Czerwona cegła - segment ściany 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Czerwona cegła - segment ściany 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Czerwona cegła - segment ściany 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Czerwona cegła - segment ściany 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Czerwona cegła - segment ściany 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Daglezja"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Daglezja"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Narożnik czerwonego krateru po meteorycie"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Narożnik czerwonego krateru po meteorycie"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Odwrócony narożnik czerwonego krateru po meteorycie"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Ściana czerwonego krateru po meteorycie"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Czerwona i Brązowa Mozaikowa Ścieżka"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Sekwoja"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retrokolejka jednoszynowa",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Otwarte wagoniki jednoszynowe",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Wagonik",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Duży wagonik dla kolejki o swobodnym spadku",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Zawracajka",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Wózki kopalniane jeżdżące po drewnianych torach, zawracające na specjalnych obrotowych sekcjach",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Nosorożec"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Nosorożcowa jazda",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Kolejka górska ze spiralnym wjazdem na wzniesienie i pasażerami siedzącymi jeden za drugim",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Olinowanie"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Przełomy Dunajca",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Okrągłe łódki pokonujące szeroki kanał wodny, spadające z wodospadów i przepływające przez spienione bystrzyny",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 pasażerów na łódkę"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Rzeka Styks",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Łódki w kształcie tratw płyną spokojnie krętym torem rzecznym",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 pasażerów na tratwę"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Droga"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Wejście do parku \"Ryczące dwudziestki\""
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Wystrój Ryczących Dwudziestek"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Zestawy ścian dla Ryczących Dwudziestek"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Kiosk z pieczonymi kiełbaskami",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Stoisko sprzedające chińskie pieczone kiełbaski"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Obóz Robin Hooda"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Chatka Robin Hooda"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Chatka Robin Hooda"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Kamień"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Kamień"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Wejście do parku rockandrollowego"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Wystrój rockandrollowy"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Autobus zespołu rockowego"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Ściana skalna"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Styl rockowy"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Styl rockowy 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Styl rockowy 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Samochody rakietowe",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Wagoniki w kształcie rakiet",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Kamienista dróżka"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Pomnik nagrody kolejki górskiej"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Kelnerka na wrotkach"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Koloseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Rzymska kolumna"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Ściana z rzymskich kolumn"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Narożnik rzymskiego pałacu"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Narożnik rzymskiego pałacu"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Narożnik rzymskiego pałacu"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Narożnik rzymskiego pałacu"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skrzyżowanie rzymskiego pałacu"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skrzyżowanie rzymskiego pałacu"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skrzyżowanie rzymskiego pałacu"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skrzyżowanie rzymskiego pałacu"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Segment końcowy rzymskiego pałacu"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Segment końcowy rzymskiego pałacu"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Prosty segment rzymskiego pałacu"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Prosty segment rzymskiego pałacu"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Prosty segment rzymskiego pałacu"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Prosty segment rzymskiego pałacu"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Rzymski posąg"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Rzymski posąg"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Rzymska świątynia"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Ściana rzymska"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Ściana rzymska"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Styl rzymskich fanfarów"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Dach"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Dach (Szary)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Dach (Czerwony)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Obrotospad",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Pierścień z zamocowanymi fotelami jest wciągany na szczyt wysokiej wieży, obracając się powoli. Następnie spada swobodnie, wyhamowując delikatnie u dołu z użyciem hamulców magnetycznych",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Znak drogi 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Londyński piętrus",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Wagoniki są replikami londyńskich autobusów",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasażerów na wagonik"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Łodzie wiosłowe",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Łodzie wiosłowe napędzane przez samych pasażerów",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasażerów na łódkę"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Zniszczony posąg"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Narożnik bieżni"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Skraj bieżni"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Odwrócony narożnik bieżni"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Segment bieżni"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Segment bieżni"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Segment bieżni"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rdza"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Tramwaj z San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replika tramwaju",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasażerów na wagonik"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Piasek"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Piasek (Brązowy)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Piasek (Czerwony)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Piaskowiec (Brązowy)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Piaskowiec (Szary)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Wieżowiec z piaskowca - dolny narożnik"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Wieżowiec z piaskowca - dolny narożnik"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Wieżowiec z piaskowca - pochyła zakrzywiona podstawa"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Wieżowiec z piaskowca - dolny odwrócony narożnik"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Wieżowiec z piaskowca - pochyła podstawa"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Wieżowiec z piaskowca - górny narożnik"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Wieżowiec z piaskowca - górna pochyła krzywizna"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Wieżowiec z piaskowca - górna pochyła krzywizna"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Wieżowiec z piaskowca - podjazd"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Wieżowiec z piaskowca - wejście"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Wieżowiec z piaskowca - wypełnienie"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Wieżowiec z piaskowca - wypełnienie"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Wieżowiec z piaskowca - górny odwrócony narożnik"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Wieżowiec z piaskowca - środkowy narożnik"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Wieżowiec z piaskowca - środkowy narożnik"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Wieżowiec z piaskowca - środkowa pochyła krzywizna"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Wieżowiec z piaskowca - środkowa pochyła krzywizna"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Wieżowiec z piaskowca - środkowy pochyły narożnik"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Wieżowiec z piaskowca - środkowy segment ściany"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Wieżowiec z piaskowca - środkowy segment ściany"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Wieżowiec z piaskowca - środkowy segment ściany"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Wieżowiec z piaskowca - środkowy segment ściany"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Wieżowiec z piaskowca - środkowy segment ściany"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Wieżowiec z piaskowca - dach"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Wieżowiec z piaskowca - iglica dachowa"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Wieżowiec z piaskowca - iglica dachowa"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Wieżowiec z piaskowca - chodnik"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Wieżowiec z piaskowca - chodnik"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Narożnik chodnika z piaskowca"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Chodnik z piaskowca - skrzyżowanie"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Chodnik z piaskowca - zakończenie"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Chodnik z piaskowca - skrzyżowanie T"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satelita"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Antena satelitarna"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Gimbus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Przejażdżka gimbusem",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Wagoniki w kształcie żółtych autobusów szkolnych",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasażerów na wagonik"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Sosna"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Znak przewijany"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Napis przewijany"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Rzeţba"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Rzeţba"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Kiosk z owocami morza",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Stoisko sprzedające smażone macki"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Hydroplan"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Focza kolejka",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Kolejka ze stalowymi torami układającymi się w korkociągi i pętle",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Przystań hydroplanu"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Przystań hydroplanu"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Reflektor"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Siedzenia"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Sziwa"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Gąszcz"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Gąszcz"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Krzewy i dekoracje"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Lotka"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Lotka"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Ściana japońska"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Chodnik uliczny"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Drogowskaz"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Znaki i elementy dróżek"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Brzoza"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Piosenkarz"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Wieża obserwacyjna",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Obrotowa kabina obserwacyjna wjeżdżająca na wysoką wieżę",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 pasażerów"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Wystrój Sześciu Flag"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Pionospadajka",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Bardzo szerokie wagoniki zjeżdżają po całkowicie pionowym torze, zapewniając pasażerom jedyne w swoim rodzaju wrażenie swobodnego spadania",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Szkielet"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Podniebne krzesełka",
+    "reference-description": "Open cars for chairlift",
+    "description": "Kolejka krzesełkowa z otwartymi siedziskami",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Ślizgowe unikajki",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Samochodziki z napędem elektrycznym",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 osoba na samochód"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Czaszka"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Czaszka"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Drapacz chmur - segment dachu"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Drapacz chmur - segment dachu"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Drapacz chmur - segment dachu"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Drapacz chmur - segment dachu"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Drapacz chmur - segment dachu"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Drapacz chmur - segment ściany"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Drapacz chmur - segment ściany"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Drapacz chmur - segment ściany"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Podniebna dróżka"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Wieżowiec (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Wieżowiec (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Drapacz chmur - segment wklęsły"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Drapacz chmur - dach wklęsły"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Drapacz chmur - segment wypukły"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Drapacz chmur - dach wypukły"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Drapacz chmur - segment windy"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Drapacz chmur - segment windy"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Drapacz chmur - segment windy"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Drapacz chmur - segment windy"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Drapacz chmur - segment windy"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Drapacz chmur - zestaw metalowy 1 segment wklęsły"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Drapacz chmur - zestaw metalowy 1 segment wypukły"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Drapacz chmur - zestaw metalowy 1 segment ściany"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Drapacz chmur - zestaw metalowy 2 segment wklęsły"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Drapacz chmur - zestaw metalowy 2 segment wklęsły"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Drapacz chmur - zestaw metalowy 2 segment wypukły"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Drapacz chmur - zestaw metalowy 2 segment ściany"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Drapacz chmur - zestaw metalowy 2 segment ściany"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Segment dachu drapacza chmur"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Koniuszek drapacza chmur"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Leniwa przejażdżka",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi wagonikami w kształcie leniwców, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Mały zakrzywiony płot mamuci"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Mały zakrzywiony płot mamuci"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kółko zębate"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kółko zębate"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kółko zębate"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Kółko zębate"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Mała bryła"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Mały krater po meteorycie"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Wagoniki jednoszynowe",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Wagoniki jednoszynowe z otwartymi bokami",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Drzewko tropikalne 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Drzewko tropikalne 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Mały czerwony krater po meteorycie"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Mały głośnik"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Podstawa komina"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Środkowa część komina"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Ślimak"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Śnieg / Lód"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Drogowskaz ośnieżony"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Śnieżne filiżanki",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Pasażerowie jadą w parach foteli obracających się wokół centralnego bałwanka",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Wystrój zimowy"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Styl śnieżny"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Ośnieżona kaukaska jodła"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Ośnieżony świerk norweski"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Ośnieżona daglezja"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Ośnieżona daglezja"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Śnieżka"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Bałwanek"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Wyścigi mydelniczek",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Pasażerowie jadą wagonikami w kształcie mydelniczek po jednoszynowym torze kolejki",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Kiosk z przytulankami",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Stoisko sprzedające mięciutkie dinozaury"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Wystrój południowoamerykański"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Wejście do parku południowoamerykańskiego"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Kiosk z pamiątkami",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Stoisko sprzedające pamiątki, przytulanki i parasole"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Kiosk z mlekiem sojowym",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Stoisko sprzedające kartoniki z mlekiem sojowym"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Kosmos"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Kosmiczna kapsuła"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Kosmiczna kapsuła"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Kosmiczne kule"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Kosmiczne pierścienie",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Koncentryczne obrotowe obręcze, umożliwiające swobodne kręcenie się we wszystkich kierunkach",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 osoba"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Rakieta kosmiczna"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Statek kosmiczny - sekcja ładowni"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Statek kosmiczny - sekcja łączności"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Statek kosmiczny - sterownia"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Statek kosmiczny - skrzyżowanie"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Statek kosmiczny - sekcja dokowania"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Statek kosmiczny - sekcja silnikowa"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Statek kosmiczny - sekcja paliwowa"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Statek kosmiczny - sekcja grawitacji"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Statek kosmiczny - sekcja mieszkalna"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Statek kosmiczny - sekcja naukowa"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Statek kosmiczny - baterie słoneczne"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Statek kosmiczny - sekcja baterii"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Dróżka kosmiczna"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Drogowskaz kosmiczny"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Wystrój kosmiczny"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Styl kosmiczny"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Drzewo pikowe"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sfinks"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Pająk"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Kolczaste ogrodzenie"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Wirująca szalona mysz",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Wagoniki w kształcie myszy pokonujące ostre zakręty i krótkie zjazdy, wirujące łagodnie w celu zdezorientowania pasażerów",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Pajęcza jazda",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Kolejka ze stalowym torem, spiralnym podjazdem i siedzeniami jedno za drugim",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiralny zjazd",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Drewniany budynek ze schodami wewnątrz i spiralną zjeżdżalnią na zewnątrz. Goście zjeżdżają na matach"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Pluskołódki",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Pojemne łodzie płynące szerokim kanałem, wciągane po nachyleniu przez pasy napędowe, zjeżdżające ze wzniesień i w wielkim plusku moczące pasażerów",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 pasażerów na łódkę"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Wystrój straszliwy"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Wyścigówki",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Pojazdy z napędem w kształcie samochodów wyścigowych",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Wystrój sportowy"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Kolejka sputnikowa",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Pasażerowie podróżują w pozycji leżącej, twarzą w dół, w specjalnych wagonikach podwieszonych pod pojedynczym torem, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Drzewo wiewiórkowe"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Wędrówka pionierów",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Drewniana kolejka górska z wyściełanymi siedzeniami i zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Rozszalałe stado",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Kolejka górska z pętlami i wagonikami w kształcie rozszalałego stada dinozaurów.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stojąca kolejka",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Zapętlona kolejka, w której pasażerowie jadą w pozycji stojącej",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Kolejka stojąca",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Pasażerowie jadą w pozycji stojącej w szerokich wagonikach ze specjalnie zaprojektowanymi zabezpieczeniami, pokonując gładkie spadki i liczne ostre zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Kiosk z gwiezdnymi napojami",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Stoisko sprzedające gwiezdne napoje owocowe"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statua"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statua"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Posąg"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statua Wolności"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Pociągi parowe",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniaturowe pociągi składające się z lokomotywy parowej i tendra, ciągnących otwarte drewniane wagoniki",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasażerów na wagon"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Pociągi parowe z krytymi wagonami",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniaturowe pociągi składające się z lokomotywy parowej i tendra, ciągnących drewniane wagoniki z płóciennymi daszkami",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 pasażerów na wagon"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Parujący kanał"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Stalowy blok"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Stalowy blok"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Stalowy płot"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Kratownica stalowa"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Stalowa ściana"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Świątynia z epoki kamiennej"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Kamienna ławka"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Blok kamienny"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Kamienny wieżowiec - dół schodów"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamienny wieżowiec - segment ściany"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamienny wieżowiec - segment ściany"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamienny wieżowiec - segment ściany"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamienny wieżowiec - segment ściany"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Kamienny wieżowiec - segment ściany"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Ściana kamienna"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Ściana kamienna"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Ściana kamienna"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Ściana kamienna"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stołek"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stołki"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Opływowa kolejka jednoszynowa",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Pojemne wagony jednoszynowe, opływowe na obu końcach",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 lub 10 pasażerów na wagonik"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stiuk (Zielony)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stiuk (Szary)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stiuk (Fioletowy)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stiuk (Czerwony)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stiuk (Żółty)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Kiosk z kanapkami",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Stoisko sprzedające świeże kanapki"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Podwodna podróż",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Pasażerowie usadowieni w łodzi podwodnej podróżują podwodnym torem",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 pasażerów na łódţ podwodną"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Kiosk Sujeonggwa",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Stoisko sprzedające koreańskie napoje Sujeonggwa"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Styl letni"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Kiosk z okularami",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Stoisko sprzedające okulary słoneczne"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Zatopiony statek"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Olbrzymi procesor superkomputera"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor superkomputera"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Mały procesor superkomputera"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Podpora"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Podpora"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Podpora"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfingowe szaleństwo",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Pasażerowie jadą w pozycji stojącej w szerokich wagonikach ze specjalnie zaprojektowanymi zabezpieczeniami, pokonując gładkie zjazdy i liczne ostre zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Podwieszane wagoniki jednoszynowe",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Pojemne wagoniki jednoszynowe",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 pasażerów na wagonik"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Lot hydroplanem",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Podwieszana kolejka, której wagoniki mogą się swobodnie przechylać na zakrętach",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Swobodnie podwieszone wagoniki samolotowe",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi wagonikami w kształcie samolotów, które mogą się swobodnie kołysać podczas pokonywania zakrętów",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Swobodnie podwieszone wagoniki",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi wagonikami, które mogą się swobodnie kołysać podczas pokonywania zakrętów",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Most wiszący segment podstawy"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Most wiszący segment odstępnika"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Most wiszący - część lin"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Most wiszący segment środkowy"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Most wiszący - początek strona 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Most wiszący - początek strona 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Most wiszący - wieża strona 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Most wiszący - wieża strona 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Paproć bagienna"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Muł bagienny"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Roślina bagienna"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Roślina bagienna"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Roślina bagienna"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Łabędzie",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Łodzie w kształcie łabędzi napędzane przez pedałujących pasażerów z przednich miejsc",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 pasażerów na łódkę"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Dyndające wagoniki",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Wagoniki podwieszone na górnej szynie",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Dyndające krzesełka",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Kolejka górska z podwieszanymi fotelikami typu wyciągu krzesełkowego, które bujają się swobodnie na zakrętach",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Morska huśtawka",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Statek przymocowany do ramienia z przeciwwagą wykonuje pełne obroty",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 pasażerów"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Miecz w kamieniu"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Kiosk z koszulkami",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Stoisko sprzedające pamiątkowe koszulki"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "Pociąg TGV",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Wagoniki są rozpędzane za pomocą magnetycznego silnika liniowego i podróżują po zakręconym torze",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Beczułki z dynamitem"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Skrzynie z dynamitem"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Stosik dynamitu"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Wysoka latarnia"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Wysoka latarnia"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Wysoki drewniany płot"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Tarcza"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Dróżka tłuczniowa"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Karczma"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Styl techno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tipi"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Goście są transportowani między poziomami w górę lub w dół",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 pasażerów"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Uszkodzony segment ściany świątynnej z głową"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Segment dachu świątyni"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Segment schodów świątynnych"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Segment schodów świątynnych"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Narożny segment ściany świątyni"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Narożny segment ściany świątyni"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Narożny segment ściany świątyni"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Narożny segment ściany świątyni"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Segment ściany świątyni"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Segment ściany świątynnej z głową"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Czynszówka"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Piłka tenisowa"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Ściana z siatki tenisowej"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Ściana z siatki tenisowej"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Namiot"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tipi"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Kopiec termitów"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Dom z tarasem"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Wojska z terakoty"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Wehikuł czasu",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Pasażer zasiada w specjalnej kuli, zapewniającej mu złudzenie podróżowania w czasie",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "Jednomiejscowe"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Muchomor"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Na saneczki",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Kolejka górska z wagonikami w kształcie sanek, w których pasażerowie siedzą jeden za drugim",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Stragan z jabłkami toffee",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Stylizowane stoisko sprzedające lepkie słodkie jabłka."
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Kiosk z jabłkami w polewie",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Stoisko w kształcie jabłka, sprzedające jabłka oblane polewą toffi"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Podstawowe toalety w budynku z prefabrykowanego betonu"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toalety umieszczone w budynku typu chata z drewnianych bali"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toalety",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Podstawowe toalety w budynku z prefabrykowanego betonu"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Wystrzałowa przejażdżka",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Pasażerowie podróżują parami w stylizowanych siedziskach, okrążających wielką replikę pistoletu maszynowego.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Wirówka",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Pasażerowie podróżują w gondoli zawieszonej na wielkich obrotowych ramionach, która może huśtać się w przód i w tył, a także do góry nogami",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Ratusz"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Styl krainy zabawek"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Rosyjskie samochody",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Wagoniki kolejki górskiej w kształcie dawnych samochodów",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Zakręt toru"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Zerwany tor"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Koniec toru"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Rozwidlenie toru"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Prosty tor"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Ciągnik"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Tradycyjne wejście do parku"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Tramwaje",
+    "reference-description": "Old-timer replica trams",
+    "description": "Repliki staroświeckich tramwajów",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 pasażerów na wagonik"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Furgonetka mieszkalna"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Skrzynia ze skarbem"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Skrzynia ze skarbem"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Skrzynia ze skarbem"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuszowa jazda",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Pasażerowie jadą w wózku zawieszonym na dwóch wielkich ramionach. Atrakcja w stylu średniowiecznej broni oblężniczej",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 pasażerów"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Drzewo"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Drzewa"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Dinozaurowe samochodziki",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Pasażerowie jeżdżą samochodzikami w kształcie triceratopsów i atakują się ich rogami",
+    "reference-capacity": "1 person per car",
+    "capacity": "Jednomiejscowe"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trylobitowe łódki",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Wagoniki w kształcie trylobitów jadą po torze, pokonując ostre zakręty i strome zjazdy, i wpadając od czasu do czasu w odcinki rzeczne",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 pasażerów na łódkę"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Elżbietański segment ściany z balkonem"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Elżbietański segment ściany parteru 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Elżbietański segment ściany parteru 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Elżbietański segment ściany parteru 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Elżbietański segment ściany parteru 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Elżbietański segment ściany parteru 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Elżbietański segment ściany parteru 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Elżbietański segment ściany parteru 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Elżbietański segment ściany parteru 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Elżbietański segment ściany parteru 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Elżbietański segment ściany parteru 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Elżbietański segment ściany parteru 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Elżbietański segment ściany parteru 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Elżbietański segment ściany parteru 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Elżbietański segment dachu 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Elżbietański segment dachu 1 przedłużenie"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Elżbietański segment dachu 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Elżbietański segment dachu 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Elżbietański segment dachu 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Elżbietański segment ściany 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Elżbietański segment ściany 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Elżbietański segment ściany 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Elżbietański segment ściany 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Wyścigi żółwi",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Małe okrągłe pontony napędzane silnikiem zamontowanym centralnie i sterowanym przez pasażerów",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 pasażerów na łódkę"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Pasażerowie jadą w parach siedzeń wirujących na końcach trzech obracających się ramion",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 pasażerów"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Wagoniki zwijki",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Wagoniki kolejki górskiej wykonującej zabójcze zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Wagoniki zwijki (ruszające tyłem)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Wagoniki kolejki górskiej wykonującej zabójcze zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Zwijka",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Szerokie wagoniki suną po gładkim stalowym torze, pokonując liczne ostre zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Miejsce katastrofy UFO"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Posąg jednorożca"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Wystrój miejski"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Styl uliczny"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Walkiria"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Walkiria"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Jazda z Walkiriami",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Bardzo szerokie wagoniki zjeżdżają z całkowicie pionowego toru, zapewniając pasażerom niesamowite wrażenie swobodnego spadku",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Pionowy znak 3D"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Odwrócony pionozjazd",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Pasażerowie siedzą w wagonikach podwieszonych pod torem, wciąganych tyłem na pionowy odcinek, a następnie pokonujących rozpędem pętle i ciasne zakręty",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Drzewo z lianami"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Klasyczne wagoniki",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Pojazdy z napędem mające kształt klasycznych wagoników jadących po szynowym torze",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "W koło Macieju",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Okrągłe wagoniki wirują, jadąc po zygzakowatym drewnianym torze",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Pustka"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Wulkan"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Wulkan z drzewkami"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Złotokap"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wóz"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wóz"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Koło wozu"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Ściana"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Ściana łuk"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Ściana z przejściem"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Ściany i dachy"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Orzech włoski"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Pomnik Waszyngtona"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Osa"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Wystrój wodny"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Armatka wodna"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "×ródełko"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Rowery wodne",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Wodne pojazdy napędzane pedałami, z dużymi kołami-pływakami",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 pasażerów na rower"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Styl wodny"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Wodospad"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Dach z tynkowanej plecionki"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Dach z tynkowanej plecionki"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Dach z tynkowanej plecionki"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Ściana lepianki"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Zestaw broni"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Wierzba płacząca"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Koła"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Baryłka whisky"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Baryłki whisky"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Biały goniec"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Biały król"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Biały skoczek"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Biały pionek"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Topola biała"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Biała królowa"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Biała wieża"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wystrój Dzikiego Zachodu"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Styl dziki zachód"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Zerodowany narożnik wklęsłego dachu"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Zerodowany narożnik wklęsłej ściany"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Zerodowany narożnik wklęsłej ściany"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Zerodowany narożnik wypukłego dachu"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Zerodowany narożnik wypukłej ściany"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Zerodowany narożnik wypukłej ściany"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Zerodowany segment podstawy"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Zerodowany segment podstawy"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Zerodowana podstawa formacji skalnej"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Zerodowana podstawa formacji skalnej"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Zerodowana środkowa część formacji skalnej"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Zerodowana środkowa część formacji skalnej"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Zerodowana środkowa część formacji skalnej"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Zerodowana środkowa część formacji skalnej"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Zerodowany szczyt formacji skalnej"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Zerodowany szczyt formacji skalnej"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Zerodowany segment płaskiego szczytu"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Zerodowany segment płaskiego szczytu"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Zerodowany segment płaskiego szczytu"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Zerodowany segment ściany"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Wiatrak"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Okno"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Kocioł czarownic",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Stoisko sprzedające gęsty bulion"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Czarownicy przy kotle"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Jazda na larwach",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Kolejka górska z małymi wagonikami w kształcie larw",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 pasażerów na wagonik"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wystrój Krainy Czarów"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Kiosk z zupą wonton",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Stoisko sprzedające zupę z uszkami wonton"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Drewno"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Drewno (czarne)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Drewno (czerwone)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Drewniany płot z pnączami"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Drewniany płot z pnączami"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Drewniany płot z uschłymi pnączami"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Drewniany płot z uschłymi pnączami"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Drewniany płot z uschłymi pnączami"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Drewniany płot z ludożerczą rośliną"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Drewno"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Blok drewniany"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wóz drewniany"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Drewniany płot"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Drewniany płot"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Płot drewniany"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Drewniany płot"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Drewniany płot"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Drewniany płot"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Ściana z desek"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Drewniany chodnik"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Płotek drewniany"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Ściana z drewnianych słupków"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Ściana z drewnianych słupków"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Ściana z drewnianych słupków"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Drewniana kolejka górska",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Drewniana kolejka górska z wyściełanymi siedzeniami i zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Drewniana kolejka górska (6 miejsc)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Drewniana kolejka górska z wyściełanymi siedzeniami i zabezpieczeniami obejmującymi pasażerów w pasie",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Drewniana kolejka górska (6 miejsc, odwrócona)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Drewniana kolejka górska z wyściełanymi siedzeniami i zabezpieczeniami obejmującymi pasażerów w pasie, z fotelami ustawionymi tyłem do kierunku jazdy",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 pasażerów na wagonik"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Drewniane wagoniki \"Tarcie Boczne\"",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Podstawowe wagoniki dla kolejki \"Tarcie Boczne\"",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Drogowskaz drewniany"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Ściana drewniana"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Ściana drewniana"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Ściana drewniana"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Ściana drewniana"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrak hydroplanu"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Żółte taksówki",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Wielka stalowa kolejka górska jeżdżąca po łagodnych spadkach i wzniesieniach o wysokości 100 m",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 pasażerów na wagonik"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Cis"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Posąg Zeusa"
+  }
+}

--- a/objects/pt-BR.json
+++ b/objects/pt-BR.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "Placa 'Golias'"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Placa 'Medusa'"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Placa 'Nitro'"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Placa 'Texas Gigante'"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Carros de Corrida dos Anos 20",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Karts com temática dos anos 20",
+    "reference-capacity": "Single-seater",
+    "capacity": "Assento único"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Carro de 1950"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Carro de 1950"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "Foguete de 1950"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Foguetes de 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Trens de montanha-russa suspensos em formato de foguete onde os carros podem balançar livremene ao fazer curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passsageiros por vagão"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "Cinema 3D",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema mostrando filmes em 3D dentro de uma construção em forma de esfera geodésica",
+    "reference-capacity": "20 guests",
+    "capacity": "20 visitantes"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "Placa 3D"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "Placa 3D"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Trens Montanha-Russa Invertida (4 assentos)",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Trens suspensos onde os passageiros se sentam em fileiras",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Trens Bobsleigh (6 assentos)",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs com assentos de 3 fileiras, com espaço para duas pessoas em cada",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por Vagão"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Peça de Conjunto de Arte Aborígene"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Azulejo Liso Aborígene"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Arte Aborígene de Serpente"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Arte Aborígene de Espírito"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstrata"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Temática Abstrata"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Água Verde-Ácido"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Boca de Vulcão Ativo"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Elefante Indiano Adulto"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Panda Adulto"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Entrada do Parque Africano"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Temática Africana"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Trens Montanha Vertical de Propulsão Hidráulica",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Vagões para montanhas-russas com propulsão a ar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Trens de Monotrilho Estilo Zepelim",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Trens de monotrilho temáticos de grande capacidade com vagões frontais e traseiros aerodinâmicos",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passageiros por vagão"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Árvore Pinheiro-de-Aleppo"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Estruturas Históricas Alienígenas"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Estruturas Históricas Alienígenas"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Planta Alienígena"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Planta Alienígena"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Clarabóia Alienígena Grande"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Clarabóia Alienígena Pequena"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estrutura Alienígena Grande"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estrutura Alienígena Grande"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Estrutura Alienígena Grande"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estrutura Alienígena Pequena"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estrutura Alienígena Pequena"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Estrutura Alienígena Pequena"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Base de Torre Alienígena"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Meio de Torre Alienígena"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Topo de Torre Alienígena"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Árvore Alienígena"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Árvore Alienígena"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Árvore em Forma de Jacaré"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Bola de Futebol Americano"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Bola de Futebol Americano"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Capacete de Futebol Americano"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Trens a Vapor Americanos",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trens a vapor em miniatura consistindo de uma réplica de locomotiva e vagão de carga, puxando vagões de madeira com tetos de tecido",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Trens Anaconda",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Trens espaçosos com simples barras de colo",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cozinhando no espeto"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Balões Animados"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Fogueira de Acampamento Animada"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Olho-Que-Tudo-Vê Animatrônico"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonauta Animatrônico"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonauta Animatrônico"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonauta Animatrônico"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Astronauta Animatrônico"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Homem das Cavernas Animatrônico Acendendo Fogueira"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Donzela Acorrentada Animatrônica"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Membro de Tribo Animatrônico"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Cavaleiro Negro Animatrônico"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Cavaleiro Negro Animatrônico"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Libélulas Animatrônicas"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Águia em Gaiola Animatrônica"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Alienígena Maligno Animatrônico"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Alienígena Maligno Animatrônico"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Alienígena Maligno Animatrônico"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Bombeiro Animatrônico"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Canhão Animatrônico"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Gângster Animatrônico"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Alienígena Bondoso Animatrônico"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Alienígena Bondoso Animatrônico"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Alienígena Bondoso Animatrônico"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Cavaleiro Animatrônico"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Cavaleiro Animatrônico"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Medusa Animatrônica"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Oficial de Polícia Animatrônico"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Robin Hood Animatrônico"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Exército de Esqueletos Animatrônico"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Exército de Esqueletos Animatrônico"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Exército de Esqueletos Animatrônico"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Policial do Espaço Animatrônico"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Estegossauro Animatrônico"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "T-Rex Animatrônico"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Triceratops Animatrônico"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Rei Animatrônico Acenando"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Escorpião Animatrônico em Ataque"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Escorpião Animatrônico em Ataque"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Pterodáctilo Animatrônico Batendo as Asas"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Temática Antártica"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antílope Fêmea"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antílope Macho"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Par de Antílopes"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Quadro de Avisos de Cristal Líquido Antigravidade"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Quadro de Avisos de Cristal Líquido Antigravidade"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Alvo de Flechas"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Árvore Cipreste-do-Arizona"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Seção de Canto de Art Déco"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Canto de Art Déco com Grades"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Canto de Art Déco com Grades"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Canto de Art Déco com Janelas"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Canto de Art Déco com Janelas"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Canto de Art Déco com Janelas"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Quiosque de Art Déco de Comida",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Um quiosque vendendo Macarrão e Limonada Fresca"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Seção de Canto Invertido de Art Déco"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Seção de Canto Invertido de Art Déco"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Seção de Telhado de Art Déco"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Seção de Topo de Canto de Art Déco"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Seção de Topo de Canto de Art Déco"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Seção de Topo de Canto de Art Déco"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Seção de Topo de Art Déco"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Seção de Topo de Art Déco"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Seção de Parede de Art Déco"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Parede de Art Déco com Porta"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Parede de Art Déco com Grades"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Parede de Art Déco com Grades"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Parede de Art Déco com Grades"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Parede de Art Déco com Grades"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Parede de Art Déco com Janelas"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Parede de Art Déco com Janelas"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Trens de Montanha-russa Articulados",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Trens de montanha-russa com carros curtos de fila única e frente aberta",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Caminho de Cascalho"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Árvore de Freixo com Ninfas"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Temática Asiática"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Gongo Asiático"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Árvore Aspen"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Estátua de Atlas"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Entrada do Parque Australiano"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Temática Australiana"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Conjunto de Fontes Australianas 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Conjunto de Fontes Australianas 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Vagões de Automóveis",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Vagões de montanha-russa na forma de automóveis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Polvo Gigante de Filme B"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Aranha Gigante de Filme B"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Brinquedo de Aranha Gigante de Filme B",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Os visitantes andam em pares de assentos temáticos que giram ao redor de uma enorme Aranha de Filme B",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Elefante Indiano Filhote"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Panda Filhote"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Raquete de Badminton"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Raquete de Badminton"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterna Chinesa"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Lanterna Chinesa"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Barraca de Balões",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Uma barraca de souvenires vendendo balões de hélio"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Arbusto de Bambu"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Plinto de Bambu"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Telhado de Bambu"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Telhado de Bambu"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Telhado de Bambu"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Ramos de Bambu"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Parede de Bambu"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Membro de Banda"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Membro de Banda"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Membro de Banda"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Membro de Banda"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Banco"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Carros Avião Barnstorming",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Trens de montanha russa invertida para a montanha russa impulsionada, em formas de aviões de dois andares",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barril"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barril"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barril"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barril"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Bloco de Base"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Bloco de Base"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Bloco de Base"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Bloco de Base"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Trens Aríete",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Uma montanha-russa compacta de aço com uma subida em espiral e vagões com assentos em linha",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Barraca de Macarrão com Carne",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Uma barraca vendendo macarrão chinês com carne"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Banco"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Bancos"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Carros Tigre-de-Bengala",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Carros de montanha-russa capazes de viradas emocionantes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicicletas",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Bicicletas especiais que correm numa pista  de monotrilho, propulsionadas pelas pedaladas dos passageiros",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 passageiro por bicicleta"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben e as Casas do Parlamento"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Grande Geosfera"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motoqueiro"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Bispo Preto"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Taxis Pretos",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Veículos funcionais no formato de táxis londrinos",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Trens Peste Negra",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trens em forma de rato com vagões de dois assentos, onde os passageiros sentam uns atrás dos outros",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Rei Preto"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Cavalo Preto"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Peão Preto"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Árvore Álamo-preto"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Rainha Preta"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Torre Preta"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Bolha do Espaço Sideral",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Uma cabine de observação rotatória e temática com formato de gosma de filmes de ficção científica",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passageiros"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Bloco"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Bloco"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Trens Bobsleigh",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trens com carros de 2 assentos onde os passageiros sentam um atrás do outro",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Caçarola"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Osso"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Cerca de Ossos"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Ossos"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerangue"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Trens Bumerangue",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Trens de montanha russa com propulsão a ar em formato de bumerangues",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Tijolo"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Parede de Tijolo"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Parede de Tijolo"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Parede de Tijolo"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Caixa Postal Inglesa"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Cabine Telefônica Inglesa"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Estátua Quebrada"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Roda Quebrada"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Caminho de Asfalto Marrom"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Calçada de Azulejos Marrons"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Poço de Piche Borbulhante"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Balde"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Edifício"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Edifício"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Montanha Bala",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Montanha-russa com vagões temáticos inspirados no trem bala japonês",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Junco"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Barcos de Batida",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Pequenos barcos circulares com um motor central controlado pelos passageiros",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passageiros por barco"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Bóia"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Bóia"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Lanchonete",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Uma construção em forma de hambúrguer, vendendo hambúrgueres"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Arbusto"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Borboleta"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Varanda de Cabana"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Varanda de Cabana"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Peça de Telhado de Cabana"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Peça de Telhado de Cabana"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Peça de Telhado de Cabana"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Topo de Cabana"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede de Cabana"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede de Cabana"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede de Cabana"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede da Cabana"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede da Cabana"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede da Cabana"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede da Cabana"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Peça de Parede da Cabana"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cacto"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cacto"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cacto"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cacto"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cacto"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Árvore Olmo-de-Camperdown"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Árvore Palmeira-das-Canárias"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Doce"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Doce"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Doce"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Barra de Doce"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Árvore de Doces"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Árvore de Doces"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Árvore de Doces"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Estilo Doce"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Barraca de Algodão-doce",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Uma construção em forma de algodão-doce, vendendo algodão-doce rosado"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Canhão"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Canhão"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Balas de Canhão"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoas",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Longas nas quais os passageiros remam",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passageiros por canoa"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Teto de Lona"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Tenda de Tecido"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carros Borboleta do Carnaval",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Carros de montanha-russa em forma de borboleta",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carros Sapo do Carnaval",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Carros de montanha-russa em forma de sapos",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carros Lagarto do Carnaval",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Carros de montanha-russa em forma de lagarto",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Entrada de Galeria"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Caixa Eletrônico",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Um posto bancário eletrônico para os visitantes usarem se ficarem com pouco dinheiro"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castelo (marrom)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castelo (cinza)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Peça de Canto de Castelo"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Peça de Canto de Castelo"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Entrada de Castelo"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Canto Invertido de Castelo"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Porta Corrediça de Castelo"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Baluartes de Castelo"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Canto de Baluartes de Castelo"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Canto de Baluartes de Castelo"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Canto de Baluartes de Castelo"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Canto Invertido de Baluartes de Castelo"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Torre de Castelo"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Peça de Canto de Torre de Castelo"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Peça de Canto de Torre de Castelo"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Seção Transversal de Torre de Castelo"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Peça Reta de Torre de Castelo"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Peça em T de Torre de Castelo"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Peça em T de Torre de Castelo"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Muro de Castelo"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Crânio de Gado"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Árvore Abeto-Caucasiano"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Caldeirão"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Entrada de Caverna"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Carros de Homens das Cavernas",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Karts pilotáveis em temática da Idade da Pedra",
+    "reference-capacity": "Single-seater",
+    "capacity": "Assento único"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Árvore Cedro-do-Líbano"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Trens Cérbero",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Trens confortáveis com proteção de colo simples e vagões com formato dos cães de várias cabeças do submundo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Carros de Teleférico",
+    "reference-description": "Open cars for chairlift",
+    "description": "Carros abertos para teleférico",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Bloco Quadriculado"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Tabuleiro de xadrez"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Gatos Risonhos",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Veículos motorizados em forma de gatos",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passageiros por gato"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Barraca de Nuggets de Frango",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Uma barraca vendendo nuggets fritos de frango"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Árvore Cedro-Chinês"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Dragão Chinês"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Cabeça de Dragão Chinês",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Passageiros lutam uns com os outros em carros bate-bate elétricos pilotáveis em formato de cabeça de dragão",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por carro"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Barco à Vela Chinês",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "O barco é preso a um braço com um contrapeso na extremidade oposta e faz um giro completo de 360 graus",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passageiros"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Loja de Fritas",
+    "reference-description": "A hut selling chips",
+    "description": "Uma cabana vendendo batatas fritas"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Barraca de Fritas",
+    "reference-description": "A stall selling chips",
+    "description": "Uma barraca vendendo batatas fritas"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Barra de Chocolate"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Trilha de Circuito"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circo",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Show circense de animais dentro de uma enorme barraca",
+    "reference-capacity": "30 guests",
+    "capacity": "30 visitantes"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circo"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Clássica / Romana"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Placa Estilo Clássico"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Temática Clássica/Romana"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Obelisco de Cleópatra"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Trepadeira"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Relógio"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Árvore em Forma de Clava"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Barcos Costeiros",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Vagões de montanha-russa em forma de barcos",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passageiros por barco"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Xícaras Giratórias",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Os passageiros sentam-se aos pares e giram em torno das extremidades de três longos braços rotativos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Loja de Café",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Uma loja em estilo art déco vendendo xícaras de café"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Roda Dentada"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Roda Dentada"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Roda Dentada"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Roda Dentada"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Doce de Cola"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colunata"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Árvore Zimbro Comum"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Árvore Carvalho Comum"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Árvore Yew Comum"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Trens Montanha Invertida Compacta",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Os passageiros sentam em pares de assentos suspensos entre a pista",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Montando em travas especiais sob a pista, os passageiros experimentarão a sensação de voar em trens com formato de Condor",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Montanha-Russa Enguia Conger",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Uma montanha russa de aço compacta onde trens com formato de enguia viajam por parafusos e loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Sebe de Conífera"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Sebe de Conífera"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Canto de Correia Transportadora"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Canto de Inversão da Correia Transportadora"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Final de Correia Transportadora"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Subida de Correia Transportadora"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Reta de Correia Transportadora"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Loja de Biscoito",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Uma barraca vendendo biscoitos grandes"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cara Maneiro"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Trens Montanha-Russa Saca Rolhas",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Trens de montanha-russa com travas de ombro",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Peça de Telhado Ondulado"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Base de Aço Ondulado"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Teto de Aço Ondulado"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Parede de Aço Ondulado"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Peça de Parede Ondulada"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Árvore Pinheiro-Corso"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Vaqueiro 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Vaqueiro 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Caminho de Pavimento Doido"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Temática Assustadora"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Barcos Crocodilo",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Barcos com formato de crocodilo feitos para percorrer canais d'água",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passageiros por barco"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Casa Maluca",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Construção contendo salas tortas e corredores angulados para desorientar as pessoas que andarem por eles",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitantes"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Chafarizes de Cupido"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Bloco Curvo"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Bloco Curvo"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Peça de Parede Curvada de Barro"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Peça de Parede Curvada de Barro"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Peça de Parede Curvada de Barro"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Teto Curvo"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Teto Curvo"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Muro Curvo"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Muro Curvo"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Música Personalizada 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Música Personalizada 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Brinquedo do Ciclope",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Os visitantes dirigem o Olho de um Ciclope Gigante",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por vagão"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Estátua de Ciclope"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Luminária Margarida"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Torre da Represa"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Entrada da Idade Média"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Temática da Idade Média"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Peça de Canto de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Peça de Canto de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Peça de Telhado Invertido de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Peça de Telhado Invertido de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Peça Inferior de Canto de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Peça Inferior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Peça de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Peça de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Peça de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Peça de Telhado de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Telhado com Chaminé de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Peça Superior de Canto de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Peça Superior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Peça Superior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Peça Superior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Peça Superior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Peça Superior de Parede de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Topo de Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Topo de Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Topo de Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Topo de Jardineira de Vila da Idade Média"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Taverna da Idade Média"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Árvore Morta"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Árvore Morta"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Árvore Morta"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Barcos Veleiros",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Barcos de pesca decorativos, que os próprios passageiros podem remar",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passageiros por bote"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Carroça de Diamante"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamante",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Os passageiros sentam-se aos pares e giram em torno das extremidades de três longos braços rotativos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Galeria de Diamante"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Árvore em Forma de Diamante"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Didjeridu"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Botes",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Barcos infláveis que se torcem por uma pista sinuosa semicircular ou de tubo fechado",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passageiros por barco"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinossauro"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinossauro"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinossauro"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinossauro"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinossauro"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Brinquedo do Ovo de Dinossauro",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Os visitantes andam em pares, em assentos temáticos que giram ao redor de uma mãe Dinossauro animada.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Sujeira"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Caminho de Terra"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Bate-bate",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Passageiros batem uns nos outros carros bate-bate elétricos pilotáveis",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por carro"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Estilo Carrinho de Bate-Bate"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Barcos Golfinho",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Veículos individuais com formato de golfinho que os passageiros podem dirigir",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passageiro por vagão"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Chafariz de Golfinho"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Estátua de Golfinhos"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Portal"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Carrossel de Dois Andares",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Carrossel tradicional de dois andares com cavalos em madeira esculpida",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passageiros"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Cabine Plataforma dupla",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Cabine giratória de observação de dois andares",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passageiros"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Loja de Rosquinhas",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Uma barraca vendendo rosquinhas"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Base de Grande Torre Gris"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Base Quebrada de Grande Torre Gris"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Seção Intermediária de Grande Torre Gris"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Topo de Grande Torre Gris"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Peça de Minarete Gris 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Peça de Minarete Gris 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Peça de Minarete Gris 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Peça de Telhado Gris 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Peça de Telhado Gris 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Peça de Telhado Gris 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Peça de Telhado Gris 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Base de Pequena Torre Gris"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Base de Pequena Torre de Minarete Gris"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Seção Intermediária ou Topo de Pequena Torre Gris"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Peça de Subida Gris 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Peça de Subida Gris 9"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Peça de Parede Gris 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Peça de Parede Gris 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Peça de Parede Gris 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Peça de Parede Gris 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Peça de Parede Gris 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Peça de Parede Gris 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Peça de Parede Gris 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Peça de Parede Gris 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Peça de Parede Gris 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Peça de Parede Gris 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Peça de Parede Gris 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragão Atacando"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Montanha do Dragão",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Montanha-russa com carros com tema de dragão",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Carros Libélula",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Vagões em formato de libélula que pendem do trilho acima",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Barraca de Bebidas",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Uma barraca em forma de latinha vendendo bebidas com gás"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Estátua da Ilha de Páscoa"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Coluna Egípcia"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Estátua Egípcia"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Placa Estilo Egípcio"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Temática Egípcia"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Muro Egípcio"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Estilo Egípcio"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Torre Eiffel"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Cerca Elétrica"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Cerca Elétrica Quebrada"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Peça de Canto de Cerca Elétrica"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Peça de Canto Invertido de Cerca Elétrica"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Cerca Elétrica com Luz"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Chafariz de Elefante"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Carroça Vazia"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Ema"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Empresa",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Roda-gigante com módulos suspensos para os passageiros, que primeiro começa a rodar e depois é inclinada por um braço de suporte",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Árvore de Eucalipto"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Temática Europeia"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Árvore Larício-Europeu"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Entrada do Parque Europeu"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Samurai Malvado"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Ovo Fabergé",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Os passageiros sentam-se aos pares e giram em torno das extremidades de três longos braços rotativos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Carros Enfrentamento",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Os passageiros sentam em pares, em assentos para frente ou para trás e passam por loops, curvas sinuosas e inversões fechadas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Estilo Órgão de Parque de Diversões"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Estilo Fantasia"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Ferramentas de Fazenda"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Buda Gordo"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Mesa de Banquete"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Cerca"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Cerca"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Cerca"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Cercas e Muros"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Roda-Gigante",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Grande roda-gigante com cadeiras abertas",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passageiros"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Farol Brilhante"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Batalha de Pipas",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Os passageiros sentam-se aos pares e giram em torno das extremidades de três longos braços rotativos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Carrinhos bate-bate de Cavaleiros de Justa",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Os passageiros participam de uma justa em carros com formato de cavalo",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por vagão"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fogos de Artifício Giratórios",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Roda giratória com cápsulas suspensas com passageiros, que primeiro começa a girar e é então inclinada para cima por um braço de apoio",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Hidrante"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Sala de Primeiros Socorros",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Um local para visitantes enjoados ou doentes se recuperarem"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Buraco de Peixe"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Estátua Consertada"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Chamas"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Comendo"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Observando"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Limpando as Penas"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Trens Tornado sem chão",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Um trem espaçoso com travas de ombro e sem chão, deixando o passeio mais emocionante",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flor"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Brinquedo Paz e Amor",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Passageiros passeiam em barcos em formato de flores que eles mesmos podem controlar",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passageiro por vagão"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Camisetas Paz e Amor",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Quiosque vendendo camisetas com temas floridos"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Barcos voadores",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Vagões em formato de hidroaviões",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passageiros por barco"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Trens Montanha-Russa Voadora",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Os passageiros são colocados em assentos confortáveis abaixo da pista para uma experiência aérea definitiva",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Discos Voadores",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Passageiros andam em veículos aéreos pilotáveis em formato de nave alienígenas",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por carro"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Bola de Futebol"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Trens Bola de Futebol",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Trens de montanha russa suspensa que consiste em um vagão com formato de bola de futebol americano capaz de balançar livremente conforme o trem faz curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Árvore do Fruto Proibido"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Árvores de Floresta"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Chafariz"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Chafariz"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Carros com 4 assentos",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Vagões individuais construídos para pistas de zigue-zague com curvas fechadas e quedas íngremes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Barraca de Frango Frito",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Uma barraca vendendo baldes de frango frito"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Barraca de Macarrão com Arroz Frito",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Uma barraca vendendo macarrão chinês com arroz frito"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Gota de Frutas"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Gota de Frutas"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Árvore Frutífera"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Árvore Frutífera"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Barraca de Sorvetes de Frutas",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Uma barraca temática vendendo sorvetes de frutas"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Casa Maluca",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Prédio contendo pisos e paredes móveis para desorientar as pessoas andando dentro dela",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitantes"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Loja de Bolos",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Uma barraca vendendo pedaços de bolo"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Temática Futurista"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Entrada de Parque Futurista"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Forca"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Carros Gangster",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Vagões temáticos de gângsteres dos anos 20 saem da estação acelerados por motores de indução linear para correr por inversões sinuosas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Jardins"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Gueixa"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Loja de Departamentos"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Estilo Suave/Calmo"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Chafariz Geométrico"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura Geométrica"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura Geométrica"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura Geométrica"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura Geométrica"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Escultura Geométrica"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Canto de Telhado Georgiano Plano"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Borda de Telhado Georgiano 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Borda de Telhado Georgiano 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Peça de Parede Georgiana do Andar Térreo 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Peça de Parede Georgiana do Andar Térreo 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Peça de Parede Georgiana do Andar Térreo 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Peça de Parede Georgiana do Andar Térreo 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Peça de Parede Georgiana do Andar Térreo 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Peça de Parede Georgiana do Andar Térreo 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Peça de Parede Georgiana do Andar Térreo 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Peça Final de Telhado Georgiano 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Peça Final de Telhado Georgiano 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Peça de Telhado Georgiano 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Peça de Telhado Georgiano 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Peça de Telhado Georgiano 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Peça de Telhado Georgiano 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Peça de Telhado Georgiano 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Peça de Telhado Georgiano 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Peça de Parede Georgiana 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Peça de Parede Georgiana 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Peça de Parede Georgiana 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Peça de Parede Georgiana 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Peça de Parede Georgiana 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Peça de Parede Georgiana 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Gêiseres"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Carros Trem Fantasma",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Carros motorizados em forma de monstros viajam numa pista fantasma",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Baixo Gigante"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pé de Feijão Gigante"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Pé de Feijão Gigante"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Temática de Terra dos Doces"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Cenoura Gigante"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Pegada Gigante de Dinossauro"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Bateria Gigante"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Samambaia Gigante"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Temática de Jardim Gigante"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Grama Gigante"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Guitarra Gigante"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Árvore de Pântano Gigante"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Panda Gigante"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Abóbora Gigante"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Floco de Neve Gigante"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Floco de Neve Gigante"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Floco de Neve Gigante"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Trens Giga-Montanha",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Uma montanha-russa gigante de aço com quedas diretas e morros de mais de 100 m",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Girafa 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Girafa 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Estátua de Girafa"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Teto de Vidro"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Teto de Vidro"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Parede de Vidro"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Parede de Vidro"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Parede de Vidro"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Parede de Vidro"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Karts pilotáveis movidos a gasolina",
+    "reference-capacity": "single-seater",
+    "capacity": "1 assento"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Lhama Dourada"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Estátua Dourada 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Estátua Dourada 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Buda Dourado"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Velo de Ouro"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Árvore Cipreste Hinoki Dourado"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gongo"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Samurai Bondoso"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Trens Gorila",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Trens de montanha-russa suspensa que consistem em vagões com formato de gorilas capazes de balançar livremente conforme o trem faz curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grama"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Moitas de grama"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Lápide"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Lápide"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Lápide"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Lápide"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de Cemitério"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de Cemitério"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Monumento de Cemitério"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Seção Frontal da Parede da Grande Muralha da China"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Seção Traseira da Parede da Grande Muralha da China"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Seção de Subida da Parede da Grande Muralha da China"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Canto de Torre da Grande Muralha da China"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Reta de torre da Grande Muralha da China"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Trens Grande Tubarão Branco",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trens com travas de ombro, moldados como um Grande Tubarão Branco",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Caminho de Asfalto Verde"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Água Verde"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Calçada de Azulejo Verde e Marrom"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Calçada de Azulejo Cinza"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Malha (verde)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Malha (roxa)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Malha (vermelha)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Malha (amarela)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Dançarino(a) Maneiro"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "Navio HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Estátua de Hades"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Sala dos Espelhos",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Prédio contendo espelhos retorcidos que distorcem o reflexo de quem os vê",
+    "reference-capacity": "5 guests",
+    "capacity": "5 visitantes"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Doca de Porto"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Parede de Porto"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Peça de Canto de Parede de Porto"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Peça de Canto de Parede de Porto"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Parede de Porto com Doca"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Parede de Porto com Equipamento de Pescaria"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Parede de Porto com Amarre"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Parede de Porto com Amarre"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Parede de Porto com Amarre"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Parede de Porto com Amarre"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Trens Harpias",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Trens de montanha russa com formato de criaturas mitológicas que se assemelham a pássaros. Os visitantes são mantidos em arreios especiais numa posição deitada, para cima ou para baixo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Barraca de Chapéus",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Uma barraca de souvenires vendendo grandes chapéus de espuma"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Casa Mal-assombrada",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Grande construção temática contendo corredores e salas assustadores",
+    "reference-capacity": "15 guests",
+    "capacity": "15 visitantes"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Cadeia Assombrada",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Prédio contendo calabouços e manequins de pessoas encarceradas, para assustar os visitantes",
+    "reference-capacity": "16 guests",
+    "capacity": "16 Visitantes"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Carros Mansão Assombrada",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Pequenos carros motorizados que viajam numa pista fantasma",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Fardo de Feno"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Árvore em Forma de Coração"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Piso de Banho Celestial"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Piscina de Banho Celestial"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Canto de Piscina de Banho Celestial"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Borda de Piscina de Banho Celestial"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Degraus de Piscina de Banho Celestial"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Teto de Banho Celestial"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Teto de Banho Celestial"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Teto de Banho Celestial"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Teto de Banho Celestial"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Janela de Banho Celestial"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de Banho Celestial"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de Banho Celestial"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Arco de Banho Celestial"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitetura de Banho Celestial"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitetura de Banho Celestial"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitetura de Banho Celestial"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arquitetura de Banho Celestial"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Chafariz de Banho Celestial"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Chafariz de Banho Celestial"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escadaria de Banho Celestial"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Escadaria de Banho Celestial"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Sebe"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Sebe"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Heliponto"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hércules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Árvore Hiba"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hipopótamo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hipopótamo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Submarinos Hipopótamo",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Passageiros vão em um submarino com formato de hipopótamo em um percurso submerso",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passageiros por carro"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Árvore Alfarrobeira-de-Mel"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Estilo Horror"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Cavalo"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Estátua de Cavalo"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Estátua de Cavaleiro"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Cavalos",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Carros únicos moldados como um cavalo",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 passageiros por cavalo"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Barraca de Chocolate Quente",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Uma barraca vendendo copos de chocolate quente"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Barraca de Cachorro-quente",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Uma barraca vendendo cachorros-quentes"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Carrão"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Carrão"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Carros Hot Rod",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Vagões em formato de hot rod das montanhas russas com lançamento de propulsão a ar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Casa"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Motos Flutuantes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Veículos individuais com formato de motos futuristas",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 visitantes por veículo"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Carros Flutuantes",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "A tecnologia de levitação magnética foi implementada para criar a ilusão de carros flutuantes futuristas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto Flutuante Voando"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Moto Flutuante Voando"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto Flutuante Parada"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Moto Flutuante Parada"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Os visitantes andam num veículo futurista flutuante, balançando livremente para os lados nas curvas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Carro Flutuante Voando"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Carro Flutuante Voando"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Carro Flutuante Parado"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Carro Flutuante Parado"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Carro Huskie Siberiano",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Veículos elétricos em formato de trenós puxados por cães huskies siberianos",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Trens do Hiper-Tornado",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Trens espaçosos com proteções de colo simples",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Trens de Hiper-Tornado (carros largos)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "4 grandes carros com assentos erguidos e proteções de colo simples",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Trens Hiper-montanha",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Trens confortáveis apenas com travas de colo",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por carro"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Gelo"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Gelo"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Barraca de Casquinhas",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Uma barraca vendendo sorvetes de casquinha"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Cubo de Gelo"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Formação de Gelo"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Formação de Gelo"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Palácio de Gelo"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Entrada do Parque de Gelo"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Base de Tubo de Gelo"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Seção de Tubos de Gelo"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Saída de Tubo de Gelo"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Teto de Gelo"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Parede de Gelo"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Estilo Gelo"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Barris Congelados"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Barris Congelados"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Barris Congelados"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Barraca de Chá Gelado",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Uma barraca vendendo bebidas à base de chá gelado"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Iglu"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Teto de Iglu"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Parede de Iglu"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Trens Impulso",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Trens de montanha-russa invertida para a montanha-russa invertida de impulsão",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Árvore Cedro-de-Incenso"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandeira de Seda Indiana"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandeira de Seda Indiana"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandeira de Seda Indiana"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandeira de Seda Indiana"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Bandeira de Seda Indiana"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Peça de Canto de Telhado Industrial"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Peça de Canto de Telhado Industrial"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Peça de Telhado Industrial"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Peça de Canto de Parede Industrial"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Peça de Canto de Parede Industrial"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de Parede Industrial"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de Parede Industrial"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de Parede Industrial"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Conjunto de Parede Industrial"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Parede Industrial com Vão de Porta"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Parede Industrial com Janela"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Quiosque de Informações",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Uma barraca onde os visitantes podem obter mapas do parque e comprar guarda-chuvas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Esquimó"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Esquimó"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Ferro"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Árvore Cipreste-Italiano"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Polícia Italiana",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Os passageiros sentam-se aos pares e giram em torno das extremidades de três longos braços rotativos",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Carros de montanha-russa em forma de jaguar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Árvore Cerejeira Florida"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Árvore Cerejeira"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Entrada do Parque Japonês"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Árvore Pinheiro japonês"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Telhado Shōji"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Telhado Shōji"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Telhado Shōji"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Bandeira de Seda Japonesa"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Árvore Bola-de-neve Japonesa"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Músico de Jazz"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Músico de Jazz"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Músico de Jazz"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Músico de Jazz"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Bala de Goma"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Bala de Mascar"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Parede de Bala de Mascar"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avião a Jato"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avião a Jato"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Avião a Jato"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Nave a Jato",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Vagões grandes com formatos de jetpack para a montanha russa de queda livre invertida",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passageiros por vagão"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Carros Avião a Jato",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Uma montanha-russa compacta com vagões individuais e quedas sinuosas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Motos aquáticas",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Jet skis com um assento, dirigível pelos próprios visitantes",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passageiro por veículo"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Cavaleiros de Justa",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Veículos separados em formato de cavalos",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 visitantes por veículo"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Chafarizes"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Lança-bolas de Neve"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Selva"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Cerca da Selva"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Placa Estilo Selva"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Temática de Selva"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Árvore Selvagem 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Árvore Selvagem 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Árvore Selvagem com Leopardo"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Árvore Selvagem com Videira"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Estilo Bateria da Selva"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Lixo"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Placa Estilo Jurássico"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Temática Jurássica"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Estilo Jurássico"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Canguru"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Submarinos Baleia Assassina",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Passageiros vão em um submarino em formato de orca por um percurso submerso",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passageiros por carro"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Carro Coala",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Grande vagão de montanha russa para a Montanha Reversa de Queda Livre",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passageiros por vagão"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Base de Grande Torre do Kremlin"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Seção Intermediária de Grande Torre do Kremlin"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Topo de Grande Torre do Kremlin"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Peça de Minarete do Kremlin 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Peça de Minarete do Kremlin 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Peça de Minarete do Kremlin 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Peça de Telhado do Kremlin 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Peça de Telhado do Kremlin 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Base de Torre Pequena do Kremlin"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Seção Intermediária de Torre Pequena do Kremlin"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Base de Domo da Torre Pequena do Kremlin"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Peça de Parede de Subida do Kremlim 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Peça de Parede de Subida do Kremlim 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Peça de Parede do Kremlim 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Peça de Parede do Kremlim 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Peça de Parede do Kremlim 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Peça de Parede do Kremlim 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Peça de Parede do Kremlin 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Peça de Parede do Kremlin 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Peça de Parede do Kremlin 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Peça de Parede do Kremlin 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Trens Montanh-Russa de Indução Linear",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Trens de montanha-russa que são impulsionados por motores de indução linear",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Trens de Joaninha",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Trens de montanha-russa com pequenos vagões em forma de joaninha",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Poste de Luz"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Poste de Luz"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Poste de Luz"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Poste de Luz"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Poste de Luz"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Cerca de Mamute Inclinada Grande"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Cerca de Mamute Inclinada Grande"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Olmeiro Grande"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Cerca de Mamute Grande"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Cerca de Mamute Grande"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Cratera de Meteoro Grande"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Carvalho Grande"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Grande Árvore Tropical"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Cratera de Meteoro Vermelho Grande"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Chaminé Fumacenta Grande"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Alto-Falante Grande"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Grande Totem"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Cerca a Laser"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Canto de Cerca a Laser"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Carro Queda Livre Lançada",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "O carro de queda livre é lançado pneumaticamente numa torre alta de aço e então desce em queda livre",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Árvore Cipreste-de-Lawson"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Carros Deitados",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Pequenos vagões suspensos onde os passageiros ficam de rosto para baixo na posição horizontal, balançando livremente de um lado para o outro",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passageiro por carro"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Trens Montanha-Russa Deitada",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Os passageiros são colocados em assentos especiais na posição horizontal, deitados para cima ou para baixo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Quiosque de Limonada",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Um quiosque temático vendendo a velha e boa limonada fresca"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Barraca de Limonada",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Uma barraca vendendo refrescantes bebidas de limão"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Cabine do Elevador",
+    "reference-description": "Steel lift cabin",
+    "description": "Cabine de aço do elevador",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lírio"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Montanha-russa Limusine",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Montanha-russa com carros inspirados nas limusines",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Leão"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Carros Leão",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Carros de montanha-russa temáticos para se assemelhar a um leão",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Lixeira"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Lixeira"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Lixeira"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Lixeira"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Cabana de Madeira"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Cabine de madeira"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Peça de Telhado de Cabana de Troncos"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Peça de Telhado de Cabana de Troncos"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Peça de Telhado de Cabana de Troncos"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Chaminé Lateral de Cabana de Troncos"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Peça de Parede de Cabana de Troncos"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Trens de Tronco",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Trens de montanha-russa com pequenos vagões em forma de tronco",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Troncos"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Troncos",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Barcos em forma de tronco construídos para flutuar por canais d'água",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passageiros por barco"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Pirulito"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Árvore Choupo-da-Lombardia"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Trens de Montanha-russa",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Trens de montanha-russa com protetores de colo capazes de passar por loops verticais",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Peça de Coluna da Cidade Perdida"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Peça de Coluna da Cidade Perdida"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Peça de Parede Plana da Cidade Perdida"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Peça de Telhado da Cidade Perdida"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Peça de Telhado da Cidade Perdida"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Peça de Escadaria da Cidade Perdida"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Peça de Escadaria da Cidade Perdida"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Peça de Escadaria da Cidade Perdida"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Peça de Escadaria da Cidade Perdida"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Peça de Escadaria da Cidade Perdida"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Peça de Canto da Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Peça de Canto da Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Peça de Canto da Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Peça de Canto da Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Peça de Parede da Cidade Perdida"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Arbusto Baixo"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Proa de Navio de Luxo"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Meio de Navio de Luxo"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Popa de Navio de Luxo"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Brinquedo de Maça",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Os visitantes sentam numa cadeira temática que é presa a um braço giratório motorizado",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 visitante por cadeira"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Tapete Mágico",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Um enorme vagão com tema de tapete voador que se move para cima e para baixo, ciclicamente, na ponta de 4 braços",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passageiros"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Armadura Mágica"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Capacete Mágico"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Escudo Mágico"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Espada Mágica"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Árvore Magnólia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Arco do Palácio do Marajá 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Arco do Palácio do Marajá 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Domo de Palácio do Marajá"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Peça de Palácio do Marajá"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Peça de Palácio do Marajá"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Peça de Palácio do Marajá"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Base de Torre do Palácio do Marajá"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Coluna de Torre do Palácio do Marajá"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Topo de Torre do Palácio do Marajá"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Trem a Vapor do Marajá",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Trens a vapor em miniatura consistindo de uma réplica da locomotiva que puxa vagões",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Barcos Pato-mandarim",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Barcos em forma de pato, movidos pelo pedalar dos passageiros da frente",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passageiros por barco"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Árvore Manguezal"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Barcos Arraia Manta",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Barcos de montanha-russa em formato de uma Arraia Manta",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passageiros por barco"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Teto de Mármore"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Teto de Mármore"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Teto de Mármore"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Teto de Mármore"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Dançarina de Carnaval"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Dançarina de Carnaval"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquise"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Marciana"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Construção Marciana"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Objeto Marciano"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Objeto Marciano"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Objeto Marciano"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Objeto Marciano"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Objeto Marciano"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Temática Marciana"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Parede Marciana"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Estilo Marciano"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labirinto",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "O labirinto é construído por paredes de 1,80 m, e os visitantes andam por ele até encontrar a saída"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Barraca de Sopa de Carne",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Uma barraca vendendo sopa de carne à moda chinesa"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Temática Mecânica"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Estilo Mecânico"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Temática Medieval"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Estilo Medieval"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Homem Transformado em Pedra"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Homem Transformado em Pedra"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Homem Transformado em Pedra"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Homem Transformado em Pedra"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Carrossel",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Tradicional carrossel giratório com cavalos esculpidos em madeira",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Cerca de Tela"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Cerca de Tela"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Canto de Cratera de Meteoro"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Canto de Cratera de Meteoro"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Canto Invertido de Cratera de Meteoro"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Parede de Cratera de Meteoro"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Parede de Cratera de Meteoro com Cristais"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Parede de Cratera de Meteoro com Cristais"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Árvore Zimbro-Azul-de-Meyer"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Brinquedo Microônibus",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Os visitantes vêem um filme dentro do simulador de movimento enquanto ele é mexido e agitado por um braço hidráulico",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microônibus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Carros de Mina",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Carros moldados como um carro antigo de mina",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Vagões de Mina",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Vagões individuais em forma de carrinhos de mina de madeira",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Trens Carro de Mina",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Trens de montanha-russa de madeira com assentos acolchoados e barra fixadora no colo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Cabana de Mina"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Cabana de Mina"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Cabine de Elevador de Mina",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Um elevador com cabine de aço comumente usado em minas",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Fosso de Mina"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Temática de Mina"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Trens de Mina",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Montanha-russa com trens de mina",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ou 4 passageiros por carro"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Minigolfe",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Um agradável jogo de golfe em miniatura",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini-Helicópteros",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Vagões em forma de helicópteros, controlados pelas pedaladas dos passageiros",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Estátua do Minotauro"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Menta"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Estilo Moderno"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Árvore Enigma-do-Macaco"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Caminhões Monstros",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Enormes caminhões motorizados 4 x 4 que podem subir ladeiras íngremes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passageiros por caminhão"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Árvore Cipreste-de-Monterey"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Pinheiro-de-Montezuma"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Peça de Parede Quebrada Monumental"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Fonte Monumental"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Peça de Escadaria Monumental"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Peça de Escadaria Monumental"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Peça de Escadaria Monumental"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Peça de Escadaria Monumental"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Peça de Canto de Parede Monumental"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Peça de Canto de Parede Monumental"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Peça de Canto de Parede Monumental"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Peça de Canto de Parede Monumental"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Peça de Parede Monumental"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Suco da Lua",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Um quiosque vendendo as novidades em refrigerantes"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Trilha de Mosaico"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Simulador de Movimento",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Os passageiros vêem um filme dentro do simulador de movimento, enquanto ele é balançado e movido por um braço hidráulico",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motos",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Carros únicos moldados como motos",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 passageiros por moto"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicleta"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motocicleta"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Carros de Rato",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Carros individuais na forma de ratos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Carros de Rato",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Carros individuais moldados como um rato",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Peça de Telhado de Barro"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Peça de Parede de Barro"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Trem de Montanha Multidimensional",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Vagões com assentos capazes de levantar os passageiros de ponta-cabeça",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Entrada Mitológica"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Temática Mitológica"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Índio Nativo Americano"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Água Natural"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Peça de Canto do Telhado Náutico"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Peça de Telhado Náutico"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Peça de Telhado Náutico"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Peça de Telhado Náutico"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Peça de Telhado Náutico"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Peça de Telhado Náutico"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Gradeamento de Telhado Náutico"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Peça de Parede Náutica"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Placa de Lanchonete em Néon"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Placa de Lanchonete em Néon"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Placa de Lanchonete em Néon"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Placa de Lanchonete em Néon"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Brinquedo de Netuno",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Os visitantes andam em pares, em assentos temáticos que giram ao redor de uma estátua animada de Netuno",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Quiosque de Frutos do Mar de Netuno",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Um quiosque vendendo os quitutes salgados de Netuno"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Preenchimento de Canto de Nova York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Entrada de Nova York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Peça Invertida de Canto de Nova York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Peça Invertida de Canto de Nova York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Peça Invertida de Canto de Nova York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Peça Invertida de Canto de Nova York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Canto Invertido de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Peça de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Peça de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Peça de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Peça de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Peça de Telhado de Nova York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Peça de Parede de Nova York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Parede de Nova York com Varal"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Parede de Nova York com Varal"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Varal de Nova York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Varal de Nova York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Sem entrada"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "Sem entrada, sem plataforma"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Entrada do Parque Norte-americano"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Temática Norte-americana"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Abeto-Norueguês"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Barris de Carvalho",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Barris de carvalho que giram e respingam conforme vagam pelas corredeiras",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passageiros por barco"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Peça de Porta de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Peça de Telhado de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Canto de Inclinação Rasa de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Canto de Inclinação Rasa de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Parede Inclinada Rasa de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Canto de Inclinação Profunda de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parede Inclinada Profunda de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parede Inclinada Profunda de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Parede Inclinada Profunda de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Parede de Arranha-Céu Obsidiana"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Parede de Arranha-Céu Obsidiana com Janela"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Bloco de Escritório"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Barril de Óleo"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Bomba de Petróleo"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Velha Árvore Coberta de Vegetação"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Água Laranja"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Estilo Órgão"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Estilo Oriental"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estrutura Ornamental"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estrutura Ornamental"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Estrutura Ornamental"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árvore Ornamental"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árvore Ornamental"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árvore Ornamental"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árvore Ornamental"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Árvore Ornamental"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Parede de Mármore Ornamentada"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Trens Avestruz",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Uma montanha-russa de loops onde os passageiros vão de pé",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Canoas Polinésias",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Canoas longas em que os próprios passageiros podem remar",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passageiros por canoa"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagode"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Placa Estilo Pagode"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Temática Oriental"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Torre Pagode"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Árvore Palmeira"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Lixeira de Panda"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Temática Panda"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Trens Panda",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Trens de montanha-russa com vagões em forma de panda",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passageiro por vagão"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Prédio de Entrada de Parque"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Portões de Entrada de Parque"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Cabana de Camponês"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Carros Pégasos",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Veículos motorizados na forma de Pégaso puxando uma carruagem",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Trens Penguim",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trens com formato de pinguim com vagões de 2 assentos em que os passageiros sentam um atrás do outro",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Automóvel de Época"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Automóvel de Época"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Lanchonete de Época"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Bandeira de Época"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Iate de Época"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Postes de Luz de Época"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Caminhão de Época"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Caminhão de Época"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Posto de Gasolina"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Picapes",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Veículos motorizados na forma de picapes",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passageiro por picape"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Água Rosa"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Tubo"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Seção de Cano"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Seção de Cano"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Seção de Cano"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Bandeira Pirata"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Navio Pirata",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Grande navio pirata de balanço",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Navio Pirata"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Temática Pirata"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Estilo Piratas"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Barraca de Pizza",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Uma barraca vendendo pedaços de pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Padrão"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Parede de Mármore Simples"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Parede de Cartas"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Parede de Cartas"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Base"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Arado"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Trens Urso Polar",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Trens de montanha russa suspensa em formato de urso polar onde os passageiros se sentam em pares virados ou para frente ou para trás ",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Poste"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Poste"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Postes"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Trens Carro de Polícia",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Uma montanha-russa com loop onde os visitantes viajam sentados",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Carros de Polícia",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Vagões temáticos de polícia dos anos 20 correm em pista de madeira, virando em seções especiais de reversão",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Barraca de Pipoca",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Uma barraca vendendo baldes gigantes de pipoca"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Porta Corrediça"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Porta Corrediça"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Estaca"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Trens de Mina Motorizados",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Montanha russa com trens de temática de mina que se auto impulsionam",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 ou 4 passageiros por vagão"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Entrada Pré-Histórica"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Temática Pré-Histórica"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Barraca de Pretzels",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Uma barraca vendendo pretzels crocantes"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Sopa Primordial"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Porta de Prisão"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Cerca de Prisão"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Peça Invertida de Prisão"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Canto de Parede de Prisão"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Canto de Parede de Prisão"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Peça de Parede de Prisão"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Topo de Parede de Prisão"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Torre de Vigia de Prisão"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escadas de Torre de Vigia de Prisão"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Escadas de Torre de Vigia de Prisão"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Torre de Água de Prisão"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Trens Pterodáctilo",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Os visitantes são mantidos em assentos confortáveis abaixo do trilho, numa experiência definitiva de vôo pré-histórico",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Abóbora"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Casa de Abóbora"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pirâmide"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Área de Fila com TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Carros de Corrida",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Veículos motorizados na forma de carros de corrida",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passageiro por carro"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Montanha-Russa de Corrida de Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Vagões separados em formato de Raptor",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 visitantes por veículo"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Alto-Falantes de Corrida"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Antena de Radar"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Jangadas",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Barcos em forma de balsa construídos para leitos de rios planos",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passageiros por balsa"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Estilo Ragtime"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Grades"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Trilha Arco-Íris"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Peça de Canto de Telhado de Tijolo Vermelho"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Canto de Telhado de Tijolo Vermelho"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Peça de Borda de Telhado de Tijolo Vermelho"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Peça Invertida de Telhado de Tijolo Vermelho"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Peça de Telhado de Tijolo Vermelho 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Peça de Telhado de Tijolo Vermelho 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Peça de Telhado de Tijolo Vermelho 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Peça de Parede de Tijolo Vermelho 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Peça de Parede de Tijolo Vermelho 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Peça de Parede de Tijolo Vermelho 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Peça de Parede de Tijolo Vermelho 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Peça de Parede de Tijolo Vermelho 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Peça de Parede de Tijolo Vermelho 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Peça de Parede de Tijolo Vermelho 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Peça de Parede de Tijolo Vermelho 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Peça de Parede de Tijolo Vermelho 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abeto Vermelho"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Abeto Vermelho"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Canto de Cratera de Meteoro Vermelho"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Canto de Cratera de Meteoro Vermelho"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Canto Invertido de Cratera de Meteoro Vermelho"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Parede de Cratera de Meteoro Vermelho"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Calçada de Azulejo Vermelho e Marrom"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Árvore Pau-brasil"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Trens de Monotrilho Estilo Retrô",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Trens de monotrilho com cabines abertas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Carro de Queda Livre Reversa",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Grande carro de montanha-russa para a Queda Livre Reversa",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Carros Reversos",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Carros Truque capaz de virar em torno de si em seções de reversão especiais",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rinoceronte"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Trens Rinocerontes",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Uma compacta montanha-russa de aço como uma subida em espiral e vagões com assentos sequenciais",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Cordame"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Correnteza Veloz",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Barcos circulares que giram e espirram água ao viajar por corredeiras velozes",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passageiros por barco"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Barcos Rio Styx",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Barcos com temática do submundo, construídos para leitos de rios planos",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passageiros por balsa"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Estrada"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Entrada de Parque dos Anos 20"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Temática Anos 20"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Conjuntos de Paredes Anos 20"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Barraca de Salsicha Assada",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Uma barraca vendendo salsicha assada à moda chinesa"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Acampamento de Robin Hood"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Cabana de Robin Hood"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Cabana de Robin Hood"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robô"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robô"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Pedra"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Pedra"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Entrada de Parque Rock & Roll"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Temática Rock & Roll"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Ônibus de Turnê de Banda de Rock"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Muro de Rocha"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Estilo Rock"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Estilo Rock 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Estilo Rock 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Carros-foguete",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Carros de montanha-russa que se parecem com foguetes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Trilha Rochosa"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Estátua de Prêmio de Montanha-russa"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Garçonete de Patins"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Coliseu Romano"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Coluna Romana"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Muro de Colunas Romanas"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Peça de Canto de Palácio Romano"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Peça de Canto de Palácio Romano"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Peça de Canto de Palácio Romano"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Peça de Canto de Palácio Romano"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Seção Transversal de Palácio Romano"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Seção Transversal de Palácio Romano"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Seção Transversal de Palácio Romano"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Seção Transversal de Palácio Romano"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Peça de Ponta de Palácio Romano"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Peça de Ponta de Palácio Romano"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Peça Reta de Palácio Romano"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Peça Reta de Palácio Romano"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Peça Reta de Palácio Romano"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Peça Reta de Palácio Romano"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Estátua Romana"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Estátua Romana"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Templo Romano"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Parede Romana"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Muro Romano"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Estilo Fanfarra Romana"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Teto"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Telhado (cinza)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Telhado (vermelho)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Queda Giratória",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Um anel de assentos é erguido até o alto de uma torre alta enquanto gira lentamente, e então cai em queda livre, parando suavemente usando freios magnéticos",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Sinal da Rota 66"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Ônibus Routemaster",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas do famoso ônibus Routemaster de Londres",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passageiros por carro"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Barco a Remo",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Barcos a remo nos quais os próprios passageiros remam",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passageiros por barco"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Estátua em Ruínas"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Peça de Canto de Pista de Decolagem"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Peça de Borda de Pista de Decolagem"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Peça de Canto Invertido de Pista de Decolagem"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Peça de Pista de Decolagem"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Peça de Pista de Decolagem"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Peça de Pista de Decolagem"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Ferrugem"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Bonde São Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Bondes réplica",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passageiros por bonde"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Areia"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Areia (marrom)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Areia (vermelha)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Arenito (marrom)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Arenito (cinza)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Canto Inferior de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Canto Inferior de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Inclinação Curvada Inferior de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Inferior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Base Inferior de Inclinação de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Topo de Canto de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Topo de Inclinação Curvada de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Topo de Inclinação Curvada de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Baia de Doca de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Entrada de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Preenchimento de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Preenchimento de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Superior de Canto Invertido de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Canto Mediano de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Canto Mediano de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Inclinação Curvada Mediana de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Inclinação Curvada Mediana de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Canto de Inclinação Mediana de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Seção Mediana de Parede de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Seção Mediana de Parede de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Seção Mediana de Parede de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Seção Mediana de Parede de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Seção Mediana de Parede de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Telhado de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Torre de Telhado de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Torre de Telhado de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Passadiço de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Passadiço de Arranha-Céu de Arenito"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Canto de Passadiço de Arenito"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Seção Transversal de Passadiço de Arenito"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Seção de Ponta de Passadiço de Arenito"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Junção em T de Passadiço de Arenito"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satélite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Antena Parabólica"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Ônibus Escolar"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Brinquedo de Ônibus Escolar",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Bondes temáticos, réplicas de ônibus escolares",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passageiros por vagão"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Pinheiro-Escocês"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Placa Giratória"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Placa Giratória"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Escultura"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Escultura"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Barraca de Frutos do Mar",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Uma barraca vendendo lula frita"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Hidroavião"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Montanha-Russa de Foca",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Uma compacta montanha-russa de aço onde os carros circulam por loops e saca-rolhas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hangar de Hidroavião"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Hangar de Hidroavião"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Luz de Sinalização"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Assentos"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Arbusto"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Arbustos e Ornamentos"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Peteca"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Peteca"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Parede Shōji"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Trilha de Calçada"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Placa"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Placas e Itens para Caminhos"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Árvore Vidoeiro-de-Prata"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Cantor com Qwiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Cabine Plataforma única",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Cabine giratória de observação de um andar",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passageiros"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Temática Six Flags"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Trens Tornado (6 assentos)",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Trens de montanha-russa extralargos feitos para queda livre",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por carro"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Esqueleto"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Teleférico",
+    "reference-description": "Open cars for chairlift",
+    "description": "Carros abertos para teleférico",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Carro Esquimó",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Passageiros deslizam por aí em motos de neve pilotáveis",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por carro"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Caveira"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Caveira"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Peça de Telhado do Arranha-céu"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Peça de Telhado do Arranha-céu"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Peça de Telhado do Arranha-céu"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Peça de Telhado do Arranha-céu"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Peça de Telhado do Arranha-céu"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Peça da Parede do Arranha-céu"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Peça da Parede do Arranha-céu"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Peça da Parede do Arranha-céu"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Trilha Suspensa"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Arranha-céus (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Arranha-céus (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Peça Côncava do Arranha-céu"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Telhado Côncavo do Arranha-céu"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Peça Convexa do Arranha-céu"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Telhado Convexo do Arranha-céu"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Peça de Elevador do Arranha-céu"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Peça de Elevador do Arranha-céu"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Peça da Seção do Elevador do Arranha-céu"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Peça da Seção do Elevador do Arranha-céu"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Peça da Seção do Elevador do Arranha-céu"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Peça Côncava de Conjunto de Metal 1 do Arranha-céu"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Peça Convexa de Conjunto de Metal 1 do Arranha-céu"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Peça do Conjunto de Metal 1 da Parede do Arranha-céu"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Peça Côncava de Conjunto de Metal 2 do Arranha-céu"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Peça Côncava de Conjunto de Metal 2 do Arranha-céu"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Peça Convexa de Conjunto de Metal 2 do Arranha-céu"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Peça do Conjunto de Metal 2 da Parede do Arranha-céu"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Peça do Conjunto de Metal 2 da Parede do Arranha-céu"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Peça de Telhado de Arranha-céu"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Topo de Arranha-céu"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Preguiça",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Trem de montanha-russa suspenso composto de carros em forma de preguiça capazes de balançar livremente enquanto o trem passa pelas curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Cerca de Mamute Inclinada Pequena"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Cerca de Mamute Inclinada Pequena"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Roda Dentada Pequena"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Roda Dentada Pequena"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Roda Dentada Pequena"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Roda Dentada Pequena"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Pequena Geosfera"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Cratera de Meteoro Pequena"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Carros de Monotrilho Pequenos",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Pequenos carros de monotrilho com lados abertos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Pequena Árvore Tropical 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Pequena Árvore Tropical 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Cratera de Meteoro Vermelho Pequena"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Alto-Falante Pequeno"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Base de Chaminé de Fumaça"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Meio de Chaminé de Fumaça"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Lesma"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Neve / Gelo"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Placa Coberta de Neve"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Girando pela Neve",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Os passageiros andam em pares de assentos girando ao redor de um homem de neve",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Temática de Neve e Gelo"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Estilo Neve"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Árvore Abeto-Caucasiano coberta de Neve"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Abeto-Norueguês Coberto de Neve"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abeto Vermelho Coberto de Neve"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Abeto Vermelho Coberto de Neve"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Bola de Neve"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Homem de Neve"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Caixas de Sabão",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Carros únicos moldados como caixas de sabão",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Quiosque de Brinquedo Fofo",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Um quiosque vendendo um Dinossauro de pelúcia fofinho"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Temática Sul-americana"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Entrada do Parque Sul-americano"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Barraca de Lembrancinhas",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Uma barraca vendendo brinquedos de pelúcia e guarda-chuvas de lembrança"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Barraca de Leite de Soja",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Uma barraca vendendo caixinhas de leite de soja"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Espacial"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Cápsula Espacial"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Cápsula Espacial"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Orbes Espaciais"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Anéis Espaciais",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Anéis concêntricos giratórios permitem que o visitante gire livremente em todas as direções",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 visitante"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Foguete Espacial"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Seção de Carga de Nave Espacial"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Seção de Comunicação de Nave Espacial"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Convés de Controle de Nave Espacial"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Seção Transversal de Nave Espacial"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Seção de Atracagem de Nave Espacial"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Seção de Motor de Nave Espacial"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Seção de Combustível de Nave Espacial"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Seção de Gravidade de Nave Espacial"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Seção de Convivência de Nave Espacial"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Seção de Ciência de Nave Espacial"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Painéis Solares de Nave Espacial"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Seção Solar de Nave Espacial"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Caminho Estilo Espacial"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Placa Estilo Espacial"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Temática Espacial"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Estilo Espaço"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Árvore em Forma de Espada"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Esfinge"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Aranha"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Cerca de Esporões"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Carros Rato Giratório",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Carros em forma de rato que girm suavemente para desorientar os passageiros",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Trens Montanha-Russa Espiral",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Uma montanha-russa de aço compacta com subida em espiral e vagões com assentos em linha",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Escorregador Espiral",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Construção de madeira com uma escada interna e um escorregador em espiral externo, no qual se desce com tapetes"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Barcos Splash",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Barcos de grande capacidade, projetados para percursos com quedas íngremes",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passageiros por barco"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Temática Fantasmagórica"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Carros Esporte",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Veículos motorizados na forma de carros esporte",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Temática Esportiva"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Satélite Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Carros Sputnik",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Vagões no formato de satélites russos que pendem do trilho",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Árvore em Forma de Esquilo"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Diligência",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Trens de madeira com assentos acolchoados e barras de proteção",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Trens Rebanho de Estamparia",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Uma montanha-russa com loop com veículos na forma de hordas de Dinossauros correndo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Trens Montanha-Russa em Pé",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Uma montanha-russa com loops, na qual os passageiros andam em pé",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Trens Tornado em Pé",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Um trem com travas de ombro, onde passageiros passeiam em pé",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Barraca de Sucos de Frutas",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Uma barraca vendendo sucos de frutas"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Estátua"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Estátua"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Estátua"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Estátua da Liberdade"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Trens a Vapor",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Trens a vapor em miniatura, consistindo de uma réplica de uma locomotiva a vapor e vagão de carga, puxando vagões de madeira abertos",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Trens a Vapor com Carros Cobertos",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Trens a vapor em miniatura, consistindo de uma réplica de uma locomotiva a vapor e vagão de carga, puxando vagões de madeira com tetos de tecido",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Canos de Vapor"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Bloco de Aço"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Bloco de Aço"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Cerca de Aço"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Treliça de Aço"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Muro de Aço"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Muro de Aço"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Parede de Aço"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Parede de Aço"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Parede de Aço"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Parede de Aço"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Templo da Idade da Pedra"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Banco de Pedra"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Bloco de Pedra"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Base de Escadaria do Arranha-céu de Pedra"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Peça de Parede de Arranha-céu de Pedra"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Peça de Parede de Arranha-céu de Pedra"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Peça de Parede de Arranha-céu de Pedra"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Peça da Parede do Arranha-céu de Pedra"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Peça de Parede de Arranha-céu de Pedra"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Parede de Pedra"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Parede de Pedra"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Parede de Pedra"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Parede de Pedra"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Tamborete"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Tamboretes"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Trens de Monotrilho",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Trens de Monotrilho de grande capacidade com carros frontais e traseiros alinhados",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 ou 10 passageiros por carro"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Estuque (verde)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Estuque (cinza)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Estuque (roxo)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Estuque (vermelho)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Estuque (amarelo)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Barraca de Supersanduíches",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Uma barraca vendendo sanduíches enormes e fresquinhos"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarinos",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Os passageiros andam num submarino submerso por um percurso subaquático",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passageiros por submarino"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Barraca de Ponche de Caqui",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Uma barraca vendendo ponche de caqui à moda coreana"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Estilo Verão"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Barraca de Óculos de Sol",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Uma barraca vendendo todos os  tipos de óculos"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Navio Afundado"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "CPU Grande de Supercomputador"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor de Supercomputador"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "CPU Pequena de Supercomputador"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Estrutura de Suporte"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Estrutura de Suporte"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Estrutura de Suporte"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Trens Surfing",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Trens com vagões largos onde os passageiros se mantem em pé em pranchas de surfe através de amarras especialmente projetadas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Trens Monotrilho Suspenso",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Vagões de trem de monotrilho de grande capacidade",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passageiros por vagão"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Carros Hidroavião Suspensos",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Trens suspensos de montanha-russa consistindo de vagões com formato de hidroaviões capazes de balançar livremente quando o trem corre por curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Vagões de Avião de Balanço Suspenso",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Trens de montanha-russa suspensa consistindo de vagões em forma de avião, capazes de balançar livremente quando o trem entra em curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por Vagão"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Carros de Balanço Suspensos",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Trens de montanha-russa suspenso consistindo de carros capazes de balançar livremente quando o trem passa pelas curvas",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Peça de Base da Ponte Suspensa"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Peça Espaçadora de Base da Ponte Suspensa"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Seção de Cabo da Ponte Suspensa"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Peça de Seção Intermediária da Ponte Suspensa"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Lado 1 do Início de Ponte Suspensa"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Lado 2 do Início de Ponte Suspensa"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Lado 1 da Torre de Ponte Suspensa"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Lado 2 da Torre de Ponte Suspensa"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Xaxim de Pântano"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Visco do Pântano"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de Pântano"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de Pântano"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Planta de Pântano"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Cisnes",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Barco em forma de cisne, propulsionado pelos pedais dos passageiros da frente",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passageiros por barco"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Vagões de Balanço",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Pequenos vagões que balançam pendurados no trilho acima",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Carros de Balanço Sem-Chão",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Trens de montanha-russa suspensa consistindo de assentos de estilo teleférico, capazes de balançar livremente quando o trem passa por curvas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Navio de Balanço Reverso",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "O navio é preso a um braço com um contrapeso na ponta oposta, e balança em 360 graus completos",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passageiros"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Espada na Pedra"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Barraca de Camisetas",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Uma barraca vendendo camisetas de lembrança"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "Trens TGV",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Trens de montanha-russa no estilo dos trens-bala franceses (TGV) que são acelerados por motores de indução linear",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Barril de TNT"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "Caixa de TNT"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Detonador de TNT"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Pilha de TNT"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterna Alta"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Lanterna Alta"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Cerca Alta de Madeira"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Alvo"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Caminho de Asfalto"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Taverna"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Estilo Techno"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tipi"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Cabine Teletransportadora",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Cabine de elevador futurista que dá impressão de teleporte aos passageiros",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passageiros"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Peça de Parede Quebrada de Templo com Cabeça"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado do Templo"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado de Templo"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado do Templo"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado do Templo"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado do Templo"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado do Templo"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Peça de Telhado de Templo"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Peça de Escadaria do templo"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Peça de Escadaria do Templo"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Peça de Canto de Parede do Templo"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Peça de Canto de Parede do Templo"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Peça de Canto de Parede do Templo"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Peça de Canto de Parede do Templo"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede do Templo"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Peça de Parede de Templo"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Peça de Parede de Templo com Cabeça"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Casa de Cômodos"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Bola de Tênis"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Parede de Rede de Tênis"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Parede de Rede de Tênis"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tenda"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tenda de Índio"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Cupinzeiro"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Casa com Terraço"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Exército de Terracota"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Máquina do Tempo",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Os visitantes sentam numa esfera especialmente projetada, e experimentam a ilusão da viagem no tempo",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 por visitante"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Cogumelo Venenoso"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Vagões de Tobogã",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Vagões de montanha-russa em forma de tobogã com assentos em linha",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Quiosque de Maçã do Amor",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Um quiosque temático vendendo maçã caramelada"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Barraca de Maçã-do-amor",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Uma barraca na forma de maça vendendo maçãs-do-amor"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Banheiros",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Banheiros básicos abrigados numa construção pré-fabricada de concreto"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Banheiros",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Banheiros abrigados numa cabana de madeira"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Banheiros",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Banheiros básicos abrigados numa construção pré-fabricada de concreto"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Brinquedo Tommy Gun",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Os visitantes andam em pares de assentos temáticos que giram ao redor de uma grande réplica de Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passageiros brincam numa gôndola suspensa por grandes braços rotatórios, rodando de pernas para o ar para frente e para trás",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Prefeitura"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Estilo Brinquedolândia"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Carros Russos",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Carros de montanha-russa em forma de automóveis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Curva de Trilho"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Trilho Quebrado"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Fim de Trilho"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Divisão de Trilho"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Reta do Trilho"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Trator"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Entrada de Parque Tradicional"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Bondes Elétricos",
+    "reference-description": "Old-timer replica trams",
+    "description": "Réplicas de bondes antigos",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passageiros por vagão"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Van de Viagem"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Arca do Tesouro"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Arca do Tesouro"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Arca do Tesouro"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Brinquedo Trebuchet",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Os passageiros viajam numa carruagem suspensa por dois grandes braços, baseada numa catapulta da Idade Média",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passageiros"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Árvore"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Árvores"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Bate-bate de Triceratops",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Os visitantes batem os chifres entre si em carrinhos bate-bate de Triceratops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 pessoa por vagão"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Barcos Trilobitas",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Vagões em forma de trilobitas",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passageiros por barco"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Peça de Parede de Baía de Solo Tudor 4"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Peça da Parede do Andar Térreo Tudor 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Peça da Parede do Andar Térreo Tudor 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Peça da Parede do Andar Térreo Tudor 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Peça da Parede do Andar Térreo Tudor 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Peça da Parede do Andar Térreo Tudor 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Peça da Parede do Andar Térreo Tudor 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Peça da Parede do Andar Térreo Tudor 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Peça da Parede do Andar Térreo Tudor 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Peça da Parede do Andar Térreo Tudor 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Peça da Parede do Andar Térreo Tudor 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Peça da Parede do Andar Térreo Tudor 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Peça da Parede do Andar Térreo Tudor 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Peça da Parede do Andar Térreo Tudor 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Peça de Telhado Tudor 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Peça de Telhado Tudor 1 Peça de Extensão"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Peça de Telhado Tudor 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Peça de Telhado Tudor 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Peça de Telhado Tudor 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Peça da Parede Tudor 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Peça da Parede Tudor 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Peça da Parede Tudor 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Peça de Parede Tudor 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Botes Tartaruga",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Pequenos botes circulares de tartaruga movidos por um motor central e controlado pelos passageiros",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passageiros por bote"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Torção",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Os passageiros se acomodam em pares de assentos que giram ao redor das pontas de três longos braços giratórios",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passageiros"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Carros Tornado",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Carros de montanha-russa capazes de girar para cima e para baixo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Carros Tornado (começam invertidos)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Carros de montanha-russa capazes de girar para cima e para baixo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Trens Tornado",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Trens espaçosos com travas de ombro",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Local de Queda de OVNI"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Estátua de Unicórnio"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urbana Temática"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Estilo Urbano"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkiria"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkiria"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Trens Valquírias",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Trens de montanha russa com temática valquíria com vagões extragrandes, feitos para quedas íngremes",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Placa Vertical 3D"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Carros Vai-e-vem Vertical",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Vagões largos de montanha russa onde os passageiros sentam suspensos",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Videira"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Carros Antigos",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Veículos motorizados na forma de carros antigos",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por carro"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Toneis Virginia Reel",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Carros circulares giram enquanto viajam pela pista",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Vazio"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Vulcão"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Vulcão com Pequenas Árvores"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Árvore Voss's Laburnam"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Carroça"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Carroça"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Roda de Carroça"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Muro"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Parede"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Arco de Parede"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Parede com Passagem"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Paredes e Tetos"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Árvore Nogueira"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Estátua de Washington"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Vespa"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Temática Aquática"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Jato d'Água"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Bica de Água"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Triciclos de Água",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedalinhos com grandes rodas flutuantes",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passageiros por triciclo"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Estilo Água"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Cachoeira"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Telhado de Pau a Pique"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Telhado de Pau a Pique"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Telhado de Pau a Pique"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Parede de Pau a Pique"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Conjunto de Armas"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Árvore Salgueiro-Chorão"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Rodas"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Barril de Uísque"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Barris de Uísque"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Bispo Branco"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Rei Branco"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Cavalo Branco"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Peão Branco"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Árvore Choupo-Branco"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Rainha Branca"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Torre Branca"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Temática do Velho Oeste"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Estilo Oeste Selvagem"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Canto de Telhado Côncavo Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Canto Côncavo de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Canto Côncavo de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Canto Convexo de Telhado Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Canto Convexo de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Canto Convexo de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Peça de Solo Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Peça de Solo Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Base de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Seção Intermediária de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Seção Intermediária de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Seção Intermediária de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Seção Intermediária de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Topo de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Topo de Formação Rochosa Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Peça de Telhado Plano Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Peça de Telhado Plano Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Peça de Telhado Plano Esculpido Pelo Vento"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Base de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Peça de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Peça de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Peça de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Peça de Parede Esculpida Pelo Vento"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Moinho"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Janela"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Janela"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Janela"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Sopa das Bruxas",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Um quiosque vendendo uma sopa espessa de carne"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Bruxas ao Redor de Caldeirão"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Trens Larvas Comestíveis",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Trens de montanha russa com pequenos vagões em forma de larvas",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passageiros por vagão"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Temática de Fantasia"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Barraca de Comida Chinesa",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Uma barraca vendendo Sopa Wonton"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Madeira"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Madeira (preta)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Madeira (vermelha)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Cerca de Madeira com Trepadeiras"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Cerca de Madeira com Trepadeiras"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Cerca de Madeira com Videiras"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Cerca de Madeira com Videiras"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Cerca de Madeira com Videiras"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Cerca de Madeira com Planta Carnívora"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Madeira"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Bloco de Madeira"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Carroça de Madeira"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Cerca de Madeira"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Trilha de Madeira"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Cerca de Poste de Madeira"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Parede de Poste de Madeira"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Parede de Poste de Madeira"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Parede de Poste de Madeira"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Trens de Montanha-russa de Madeira",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Trens de montanha-russa de madeira com assentos acolchoados e protetores de colo",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Trens de Montanha-russa de Madeira (6 assentos)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Trens de montanha-russa de madeira com assentos acolchoados e proteções de colo",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por carro"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Trens de montanha-russa de Madeira (6 assentos, Reverso)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Trens de montanha-russa de madeira com assentos acolchoados e proteções de colo, correndo com os assentos virados de costas",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passageiros por vagão"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Carros de Madeira de Fricção Lateral",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Carros básicos para a Montanha-russa de Fricção Lateral",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por carro"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Placa de Madeira"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Parede de Madeira"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Parede de Madeira"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Parede de Madeira"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Parede de Madeira"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Hidroavião Naufragado"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Trens Taxi Amarelo",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Uma gigante montanha-russa de aço capaz de quedas suaves e subidas de mais de 90m",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passageiros por vagão"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Teixo"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Estátua de Zeus"
+  }
+}

--- a/objects/ru-RU.json
+++ b/objects/ru-RU.json
@@ -1,0 +1,9582 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' знак"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "Знак 'Medusa'"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "Знак 'Нитро'"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "Знак 'Техас'"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "Машинки 1920гг",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Люди гоняются друг с другом на машинках в стиле 20х",
+    "reference-capacity": "Single-seater",
+    "capacity": "Одиночные"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "Авто 1950"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "Машина"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950 Ракета"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "Ракета 1950",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Обратные горки поднимают вертикально вверх и бросают вниз на станцию.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира в вагон"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Кино",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Кинотеатр с 3D фильмами в сферическом здании",
+    "reference-capacity": "20 guests",
+    "capacity": "20 чел."
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Знак"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Знак"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Перевёрнутые горки",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Пассажиры сидят под треком и несутся по огромным кольцам с переворотами и падениями.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Кружилки",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Пассажиры едут в больших бобах, несущихся по полукруглому треку.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Местный сувенир"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Деталь аборигенов"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Змей аборигенов"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Сувенир от аборигенов"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Абстракция"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Яд.-зелёная вода"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Вулкан"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Индийский слон"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Панда"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Африканский вход"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Тема Африки"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Воздушные горки",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "После воздушного запуска поезд устремляется на вертикальный трек и затем падает с другой стороны и возвращается на станцию.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Монорельсовый поезд",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Вместительный монорельсовый поезд с вагончиками.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 чел. в вагоне"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Сосна"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Инопланетные конструкции"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Инопланетные конструкции"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Растение"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Растение"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Инопланетная крыша"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Инопланетная крыша"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Космическая структура"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Основание башни"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Середина башни"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Верх башни"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Дерево"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Дерево"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Куст в форме крокодила"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Мяч"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Футбольный мяч"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Футбольный шлем"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Американский паровоз",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Анаконда",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Анаконда",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Вертел"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Шарики"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Костёр"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Всевидящее Око"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Аргонавт"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Аргонавт"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Аргонавт"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Астронавт"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Человек, зажигающий огонь"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Девушка"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Человек"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Рыцарь"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Рыцарь"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Стрекоза"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Орёл на клетке"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Пожарный"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Пушка"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Гангстер"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Инопланетянин"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Рыцарь"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Рыцарь"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Медуза"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Полицейский"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Робин Гуд"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Скелет"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Скелет"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Скелет"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Космический рейнджер"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Стегозавр"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Т-Рекс"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Трицераптор"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Король"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Скорпион"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Скорпион"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Птеродактиль"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Тема Антарктики"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Антилопа"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Антилопа"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Пара антилоп"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "LCD-табло"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "LCD-табло"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Мишень"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Аризонский Кипарис"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Угловая секция Арт-Деко"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Угол Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Угол Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Угол Арт-Деко с окнами"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Угол Арт-Деко с окнами"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Угол Арт-Деко с окнами"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Палатка Арт-Деко",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Палатка с лапшой и свежим лимонадом."
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Угловая секция Арт-Деко"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Угловая секция Арт-Деко"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Крыша Арт-Деко"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Верхний угол Арт-Деко"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Верхний угол Арт-Деко"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Верхний угол Арт-Деко"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Секция Арт-Деко"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Секция Арт-Деко"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Стена Арт-Деко"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Стена Арт-Деко с дверью"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Стена Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Стена Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Стена Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Стена Арт-Деко с оградой"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Стена Арт-Деко с окнами"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Стена Арт-Деко с окнами"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Сочленённые поезда",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Поезда для горок с короткими вагончиками",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Гравий"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Дерево с нимфами"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Тема Азии"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Гонг"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Тополь"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Глобус"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Атомиум"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Австралийский вход в парк"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Тема Австралазии"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Австралийский фонтан"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Австралийский фонтан"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Автомобили",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Вагончики в виде автомобилей",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Осьминог"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Паук"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "Паук",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Люди катаются парами вокруг большого паука.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 человек"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Индийский слонёнок"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Панда"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Ракетка"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Ракетка"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Лампа"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Лампа"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Шары",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Сувенирный ларек с шариками, надутыми гелием."
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Бамбук"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Цоколь"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Крыша"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Крыша"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Банк"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Гастрольные горки",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Кабинки подвешены, горки допускают вращение и резкие падения.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 человека в вагоне"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Бочка"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Бочка"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Бочка"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Бочка"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "База"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "База"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "База"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "База"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Таранные горки",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Небольшие горки на стальном рельсе со спиральным подъёмом и вагончиками с сидениями в ряд.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 человек в вагоне"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Палатка с лапшой",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Палатка, где продают лапшу."
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Лавка"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Лавка"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Лавка"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Скамьи"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Бенгальский тигр",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Горки с вращением",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Моноциклы",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Особые велосипеды с педальной тягой едут по стальным рельсам.",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 человек"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Биг-Бен и здание парламента"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Геосфера"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Мачо"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Чёрный слон"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Лондонское такси",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Лондонское такси",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Чёрная Смерть",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Кабинки в виде крыс едут по извилистому треку без рельсов и колес.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 человека в кабинке"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Король"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Чёрный конь"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Пешка"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Чёрный тополь"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Ферзь"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Ладья"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Падение из космоса",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "Вращающаяся наблюдательная кабина, поднимающаяся вверх по башне.",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 пассажиров"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Блок"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Блок"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Бобслей-поезд",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Поезд состоящий из двухместных вагонов, где пассажиры сидят друг за другом",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Котёл"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Прах"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Забор"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Кости"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Бумеранг"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Бумеранг",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Поезд едет вертикально до вершины и затем вниз на станцию",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Стена"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Стена"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Стенка"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Почтовый ящик"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Телефонная будка"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Статуэтка"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Стена"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Дорожка"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Ловушка"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Сосуд"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Здание"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Здание"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Пулевые горки",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Горки в виде восточного поезда.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Камыш"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Лодочки",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Маленькие круглые лодочки с моторами управляются пассажирами.",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Буй"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Буй"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Бургер-бар",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "Бар, где продаются гамбургеры."
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Куст"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Бабочка"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Крыльцо"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Крыльцо"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Верх"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Дерево"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Кактус"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Кактус"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Кактус"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Кактус"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Кактус"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Ильм"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Канарская пальма"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Пирог"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Пирог"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Пирог"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Конфета"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Дерево"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Дерево"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Дерево"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Конфетный стиль"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Кондитерская",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "Палатка с конфетами"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Пушка"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Пушка"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Пушечные ядра"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Каноэ",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Длинные каноэ, где пассажиры гребут сами",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 чел. на лодку"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Брез. крыша"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Карнавал - Бабочки",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Вагончики в виде бабочек",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Карнавал - Лягушки",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Вагончики в форме лягушек",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Карнавал - Вараны",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Вагончики в форме варана",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Карт"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Банкомат",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "Банкомат"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Деталь замка"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Деталь замка"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Вход в замок"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Деталь замка"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Решётка замка"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Бастион замка"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Угол бастиона замка"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Угол бастиона замка"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Угол бастиона замка"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Угол бастиона замка"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Башня замка"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Деталь башни замка"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Деталь башни замка"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Деталь башни замка"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Прямая деталь башни замка"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Деталь башни замка"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Деталь башни замка"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Стена замка"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Череп"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Кавказская ель"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Котёл"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Вход в пещеру"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Пещ. машины",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Люди гоняются на стильных машинках",
+    "reference-capacity": "Single-seater",
+    "capacity": "Одиночные"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Ливанский кедр"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Горки Цербер",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Сидя в удобном поезде, люди наслаждаются плавными спусками и парением над горами.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 человека в вагоне"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Кресло-лифт",
+    "reference-description": "Open cars for chairlift",
+    "description": "Открытые вагончики",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Шахматы"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Чешир",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Машинки в виде котов едут по рельсам",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 пассажира"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Куры-гриль",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Палатка, где продают куры-гриль."
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Китайский кедр"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Дракон"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Китайский дракон",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Самодвижущиеся машинки",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 чел в машинке"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Китайская джонка",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Кораблик прикреплён к маятнику и вращается на 360 градусов.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 пассажиров"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Картошка",
+    "reference-description": "A hut selling chips",
+    "description": "Ларек с картошкой"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Картошка",
+    "reference-description": "A stall selling chips",
+    "description": "Продажа картошки"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Шоколадница"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Тропа"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Цирк",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Цирковое выступление со зверями",
+    "reference-capacity": "30 guests",
+    "capacity": "30 чел"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Цирк"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Знак 'Классика'"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Рим"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Игла Клеопатры"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Хищное дерево"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Часы"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Дерево"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Лодки-горки",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Вагончки в виде лодок",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Чашечка кофе",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Людей катают попарно с вращением",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Кофе",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "Здесь продают кофе"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Кола"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Колоннада"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Можжевельник"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "яДуб"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Обычный Тис"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Компактные горки",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Люди сидят парами в подвешенных вагончиках.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Кондор",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Люди едут лицом вперед лежа, в вагончиках в форме кондора",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Угрь-Конга",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Компактные горки с вагончиками в виде рыбы",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Изгородь"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Изгородь"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Транспортёр"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Транспортёр"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Транспортёр"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Транспортёр"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Транспортёр"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Печенье",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Ларек с печеньем"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Пижон"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Штопорные горки",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Небольшие железные горки, где поезда едут по спиралям и кольцам",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Рифлёная база"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Рифлёная крыша"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Рифлёная стена"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Сосна"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Ковбой 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Ковбой 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Дорожка"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Страшилки"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Крокодил",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Лодки в форме крокодилов плывут по каналу.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 человека в лодке"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Кривой дом",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Здание с кривыми комнатами и коридорами",
+    "reference-capacity": "5 guests",
+    "capacity": "5 чел"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Купидон"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Кривой блок"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Кривой блок"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Крыша"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Крыша"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Стена"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Стена"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Своя музыка 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Своя музыка 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Циклоп",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Люди управляют машинками в форме глаз.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 чел. в машине"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Циклоп"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Лампа"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Плотина"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Средневек. вход"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Средневековье"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Деталь нижней стены"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Средневековая деталь крыши"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Средневековая крыша с трубой"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Угловая секция"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Деталь верхней стены"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Деталь верхней стены"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Деталь верхней стены"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Деталь верхней стены"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Средневековое окно"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Средневековое окно"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Средневековая крыша с окном"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Средневековая крыша с окном"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Средневековая крыша с окном"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Средневековая крыша с окном"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Таверна"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Дерево"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Дерево"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Дерево"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Кораблик",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Рыбацкий кораблик, пассажиры гребут сами",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 человека в лодке"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Вагонетка"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Алмаз",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Люди сидят попарно и катаются в свободно раскачивающихся вагончиках",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Ствол"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Ромбовое дерево"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Дигериду"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Шлюпки",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Люди катаются в шлюпках.",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Динозавр"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Динозавр"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Динозавр"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Динозавр"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Динозавр"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Динозавр",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Люди крутятся вокруг двигающегося динозавра.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 человек"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Дорожка"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Кар",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Электромобильчики",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 чел."
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Электро стиль"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Дельфин",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Одиночные машинки в форме дельфина",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 человек в машинке"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Дельфин"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Дельфины"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Дверь"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Дверь"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Дверь"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Двойная Карусель",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Классическая карусель с деревянными лошадками",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 человека"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Наблюдательная башня",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Вращающаяся кабинка поднимается на высокую башню.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 пассажира"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Бублики",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Палатка с бубликами"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Деталь Минарета"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Деталь Минарета"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Деталь Минарета"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Деталь башни"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Деталь"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Деталь"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Дракон"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Дракон-Коастер",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Горки с вагончиками-драконами",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в вагончике"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Стрекоза",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Люди едут по рельсу в подвешенных, раскачивающихся кабинках.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 чел. в кабинке"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Напитки",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Палатка с напитками"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Статуя о. Пасхи"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Колонна"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Статуя"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Знак 'Египет'"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Египет"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Стена"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Египетский стиль"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Башня"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Сломанный забор"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Деталь ограды"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Деталь ограды"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Деталь ограды"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Фонтан"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Вагонетка"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Эму"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Энтерпрайз",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Колесо с подвешенными капсулами вращается с большой скоростью",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Эвкалипт"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Тема Европы"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Лиственница"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Европейский вход"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Злой самурай"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Фаберже",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Людей катают попарно с вращением",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Инвертные Горки",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Люди сидят парами друг напротив друга.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Ярмарочный стиль"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Фэнтези стиль"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Орудия"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Будда"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Стол"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Забор"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Забор"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Забор"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Ограды и стены"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Колесо",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Большое колесо обозрения",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 пассажира"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Маяк"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Боевой змей",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Гости катаются парами с вращением.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Рыцари",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Люди катаются в машинках в виде лошадей",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 чел."
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Огненные гонки",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Вращ. колесо с подвешенными платформами",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Гидрант"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Медпункт",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "Комната для заболевших"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Рыбалка"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Статуэтка"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Огонь"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Фламинго"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Фламинго"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Фламинго"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Горки без пола",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Широкие поезда без пола дают пассажирам чувство свободы, когда они едут по извивающейся трассе.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Цветок"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Цветок",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Небольшие цветочные шлюпки с моторчиками управляются пассажирами",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 человек"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Рубашки с цветами",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Палатка, в которой продаются рубашки."
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Парящая лодка",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Кабинка в виде летающей лодки катится по стремительному треку, иногда падая в воду",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 пасс. в лодке"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Летающие горки",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Люди сидят в удобных креслах и едут по очень сложной трассе, испытывая чувство полёта.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Тарелочки",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Самодвижущиеся машины",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 человек"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Мяч"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Футбол",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Подвешенные горки на футбольную тему",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 человека на вагон"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Запретный плод"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Деревья"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Фонтан"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Фонтан"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Обратные поворот. горки",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Отдельные вагончики едут по зигзагообразному треку с разворотами и падениями",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Куры-гриль",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Палатка, где продают куры-гриль."
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Жареный рис",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Палатка с жареным рисом"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Фрукт"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Фрукт"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Дерево"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Дерево"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Мороженое",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Палатка с фруктовым мороженым"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Домик",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Здание с анимированными стенами и полом дезориентирует людей",
+    "reference-capacity": "5 guests",
+    "capacity": "5 чел."
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Пирожки",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Палатка с пирожками"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Будущее"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Футуристический вход"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Эшафот"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Горки гангстеров",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "Машинки в стиле 1920х проезжают по головокружительной трассе.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в кабине"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Клумба"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Гейша"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Лавка"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Нежный стиль"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Фигурный фонтан"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Скульптура"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Скульптура"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Скульптура"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Скульптура"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Скульптура"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Гейзеры"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Призрак",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Машинки в виде монстров едут по страшным лабиринтам",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Бас-гитара"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Стебель"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Стебель"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Конфета"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Морковь"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "След динозавра"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Барабан"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Куст"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Гигантский Сад"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Трава"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Гитара"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Манговое дерево"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Тыква"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Снежинка"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Снежинка"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Снежинка"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Гига-Горки",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Гигантские горки с крутыми падениями до 100м.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Жираф 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Жираф 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Жираф"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Крыша"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Крыша"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Стена"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Стена"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Стена"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Стена"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Картинг",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Карты с бенз. движками",
+    "reference-capacity": "single-seater",
+    "capacity": "одиночные"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Лама"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Статуэтка 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Статуэтка 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Золотой Будда"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Золотое руно"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Золотой кипарис"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Гонг"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Самурай"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Горилла",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Подвешенные вагончики в форме горилл, свободно качает в поворотах",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 человека в вагоне"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Надгробье"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Надгробье"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Надгробье"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Надгробье"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Памятник"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Памятник"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Памятник"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Деталь китайской стены"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Деталь китайской стены"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Деталь китайской стены"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Фрагмент Великой Стены"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Фрагмент Великой Стены"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Белая акула",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Просторные поезда с ремнем безопасности",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 человек на вагон"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Зелёный асфальт"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Зелёная вода"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Танцор"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "Эндевор"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Гадес"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Холл зеркал",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Здание с кривыми зеркалами, искажающими изображение",
+    "reference-capacity": "5 guests",
+    "capacity": "5 чел."
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Док"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Деталь"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Деталь гавани"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Гарпии",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Люди едут в лежачем положении по извилистой трассе с переворотами.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел в кабинке"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Шляпы",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Сувенирная палатка со шляпами"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Дом ужасов",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Большое здание со страшными коридорами и комнатами.",
+    "reference-capacity": "15 guests",
+    "capacity": "15 чел."
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Тюрьма",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Здание с опасными преступниками, которые пугают добропорядочных прохожих.",
+    "reference-capacity": "16 guests",
+    "capacity": "16 чел."
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Гонки с призраками",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Машинки ездят по многоуровневым трекам в особой обстановке.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Тюк"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Дерево"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Лестница"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Деталь крыши"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Арка"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Арка"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Фонтан"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Деталь бассейна"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Деталь бассейна"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Забор"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Забор"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Площадь"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Геркулес"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Хиба"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Бегемот"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Бегемот"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Гиппопотам",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Путешествие на субмарине по подводной трассе.",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 человек в вагоне"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Медовое дерево"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Страшный стиль"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Конь"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Лошадка"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Всадник"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Стиплчез",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Люди едут на машинках в виде лошадей.",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 пассажира"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Горячий шоколад",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Палатка с горячим шоколадом"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Хот-доги",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Палатка с хот-догами."
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Машина"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Машина"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Горки-Хотрод",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "После ускоряющего толчка поезд разгоняется по вертикальному треку и опускается вниз на станцию.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 чел. в кабинке"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Дом"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Ховербайки",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Люди сидят в футуристических байках и едут по монорельсу",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 чел. в машине"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Ховеркары",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "С помощью мощных магнитов создаётся иллюзия парящих машин",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 чел. в машине"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Ховербайк"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Ховербайк"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Ховербайк"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Ховербайк"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Ховерборд",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Люди едут на фантастических раскачивающихся досках",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 чел. в кабинке"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Ховеркар"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Ховеркар"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Ховеркар"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Ховеркар"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Хаски",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Машинки в форме эскимосских санок едут по рельсам.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 человека в машинке"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Гипер-твистер",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Большие поезда с простыми ремнями",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Гипер-твистер (широкий)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Гипергорки",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Высокие прямые горки с глубокими падениями и большой скоростью, ремни только на колени.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Мороженое",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Палатка с мороженым"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Лёд"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Конструкция"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Конструкция"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Дворец"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ледяной вход"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Труба"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Труба"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Труба"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Стена"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Ледяной стиль"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Бочки"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Бочки"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Бочки"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Холодный чай",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Палатка с холодным чаем."
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Иглу"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Крыша иглу"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Стена иглу"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Обратно-импульсные горки",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Развернутые поезда разгоняются от станции по вертикальному треку, спускаются вниз и забираются на новый подъём.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Ладанный кедр"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Индийский флаг"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Индийский флаг"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Индийский флаг"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Индийский флаг"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Индийский флаг"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Угол индустриальной крыши"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Угол индустриальной крыши"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Индустриальная крыша"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Угловая стена"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Угловая стена"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Стена"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Стена"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Стена"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Стена"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Стена с дверью"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Стена с окном"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Справка",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Киоск, где гости берут карты и зонтики."
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Инуит"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Инуит"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Итальянский кипарис"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Полицейский",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Итальянский полицейский",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Пантера",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Компактные горки с отдельными вагончиками",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Сакура в цвету"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Сакура"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Стена"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Восточный вход в парк"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Сосна"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Шёлковый флаг"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Снежное дерево"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Музыкант"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Желе"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Желе"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Самолёт"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Самолёт"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Самолёт"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Бустер",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Люди сидят в машине, запускаемой по вертикальному треку",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 человек"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Горки-Самолет",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Небольшие горки с отдельными кабинками и плавными перепадами.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в вагоне"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Скутеры",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Водные скутеры на одного человека.",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 чел"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Рыцарские горки",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Люди сидят на лошадях и едут по монорельсу.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 чел. на лошадь"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Фонтаны"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Снежки"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Забор"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Знак 'Джунгли'"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Джунгли"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Дерево"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Дерево"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Дерево с леопардами"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Дерево"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Африканский стиль"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Блок"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Знак 'Юрский п-д'"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Юрский Парк"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Юрский стиль"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Кенгуру"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Кит-Убийца",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Люди плывут в субмарине по подводной трассе",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 пассажиров"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Коала Райд",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Крупные машины реверсивного паден.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Кремль"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Кремль"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Стена Кремля"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Стена Кремля"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Горки на LIM",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Поезда, разгоняемые от станции линейным индукционным мотором.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Божья Коровка",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Поезд с маленькими божьими коровками",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Фонарь"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Фонарь"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Фонарь"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Фонарь"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Фонарь"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Большой Вяз"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Кратер"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Дуб"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Большое дерево"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Большой кратер"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Дымящая труба"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Динамик"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Большой Тотем"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Лазерный забор"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Падение",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Кабинки запускаются на высокую башню и затем падают вниз",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Лоусонский кипарис"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Мини-летающие горки",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Пассажиры едут лежа в вагончиках по одиночному рельсу, свободно качаясь на поворотах.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 пассажир"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Лежачие горки",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Люди лежат на специальных ремнях и несутся по крутому треку",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Палатка с Лимонадом",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Палатка, продающая лимонад."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Лимонад",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Палатка с лимонадом"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Лифт",
+    "reference-description": "Steel lift cabin",
+    "description": "Гости переезжают с уровня на уровень",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Лилия"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Лимузинные горки",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Горки с вагончиками в виде лимузинов.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Лев"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Лев",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Компактные горки с отдельными вагончиками и легкими перепадами.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Урна"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Урна"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Урна"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Урна"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Изба"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Труба от хижины"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Бревна",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Поезда с небольшими вагончиками.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Лага"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Ущелье",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Лодки в виде бревен плывут по каналу, периодически плюхаясь со склонов.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 пассажира"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Леденец"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Тополь"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Американские горки",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Поезда, способные ездить по вертикальным кольцам.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пасс на вагон"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Деталь Колонны"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Деталь колонны"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Куст"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Нос лайнера"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Середина лайнера"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Корма лайнера"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Булавы",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Люди сидят в кресле, вращающемся вокруг шеста.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 чел. в кресле"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Ковёр",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "Большой летающий ковер, двигающийся вверх-вниз.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 пассажиров"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Волшебные латы"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Волшебный шлем"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Волшебный щит"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Волшебный меч"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Магнолия"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Арка дворца магараджей"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Арка дворца магараджей"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Купол дворца"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Деталь башни дворца"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Колонна дворца"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Крыша дворца"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Паровоз Магараджей",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Миниатюрный паровозик тянет деревянные вагончики.",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 пассажиров в вагоне"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Мандариновая утка",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Лодки в виде уток с педалями.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 пассажира в лодке"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Дерево манго"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Манта Рей",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Путешествие на лодке по широкому каналу на транспортере",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 пассажиров в лодке"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Танцор Марди Грас"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Танцор Марди Грас"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Шатёр"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Мальва"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Мальва"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Марсианское здание"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Предмет с Марса"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Предмет с Марса"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Предмет с Марса"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Предмет с Марса"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Предмет с Марса"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Марс"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Стена"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Марсианский стиль"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Лабиринт",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Лабиринт со стенами трёхметровой высоты, где посетители пытаются найти выход.",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Фрикадельки",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Палатка с фрикадельным супом"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Техника"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Механический стиль"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Средневековье"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Средневековье"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Каменный человек"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Каменный человек"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Каменный человек"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Каменный человек"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Карусель",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Обычная Карусель с деревянными лошадками",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Изгородь"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Изгородь"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Деталь кратера"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Деталь кратера"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Деталь кратера"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Деталь кратера"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Кратер с Кристаллами"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Кратер с Кристаллами"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Голубой можжевельник"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Микробус",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Люди смотрят кино внутри подвижной кабины, крутящейся на гидравл. рычаге",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 человек"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Микробус"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Деревянная Шахта",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Маленькие вагонетки едут по зигзагообразному деревянному треку.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Тележки",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Отдельные вагончики в виде тележек",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Вагонетки",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Деревянные горки со скамейками.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира в вагоне"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Хибара"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Хибара"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Шахта",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Люди едут на лифте вверх и вниз по вертикальной шахте",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Шахта"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Рудник"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Шахтёрские горки",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Горный поезд несется по стальным рельсам, похожим на старинную железную дорогу.",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 или 4 пассажира"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Минигольф",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Спокойная игра в минигольф",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Вертолётики",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Машинки в виде вертолетиков.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Минотавр"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Мята"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Современный стиль"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Обезьянье дерево"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Грузовики",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Люди катаются на огромных внедорожниках.",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Горный кипарис"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Горная сосна"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Фонтан"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Лунный Сок",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Палатка с напитками"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Дорожка"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Симулятор",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Люди смотрят фильм внутри симулятора на движущейся основе.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Мотоциклы",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Пассажиры едут в вагончиках в виде мотоциклов по треку",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Мотоцикл"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Мотоцикл"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Мышки",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Машинки в виде мышек",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Деревянные мышки",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Маленькие машинки в виде мышек едут по деревянному треку.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Многомерный поезд",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Вагончики для необыкновенного поезда.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Мифология"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Индеец"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Простая вода"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Перила крыши"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Перила крыши"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Вывеска"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Вывеска"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Вывеска"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Вывеска"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Нептун",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Люди катаются парами вокруг статуи Нептуна.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 человек"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Палатка Нептуна",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Палатка с угощениями от Нептуна"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Вход Нью-Йорка"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Угловая деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Угловая деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Угловая деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Угловая деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Угол крыши Нью-Йорка"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Крыша Нью-Йорка"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Крыша Нью-Йорка"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Крыша Нью-Йорка"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Крыша Нью-Йорка"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Крыша Нью-Йорка"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Стена"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Деталь Нью-Йорка"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Деталь Нью-Йорка"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "No entrance"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Североамериканский вход"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Тема Северной Америки"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Норвежская ель"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Дубовая Бочка",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Дубовые Бочки плывут по широкому каналу, попадая в водопады и стремнины",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 чел. в лодке"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Деталь крыши небоскрёба"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Угол небоскрёба"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Угол небоскрёба"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Деталь стены небоскрёба"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Угол небоскрёба"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Деталь стены небоскрёба"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Деталь стены небоскрёба"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Деталь стены небоскрёба"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Стена небоскрёба"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Стена небоскрёба с окном"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Офис"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Бочка"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Насос"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Старое дерево"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Рыжая вода"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Органный стиль"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Восточный стиль"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Конструкция"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Конструкция"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Конструкция"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Фигурное дерево"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Дерево"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Фигурное дерево"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Дерево"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Фигурное дерево"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Австрийцы",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Круговые горки, люди катаются стоя.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Каноэ",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Длинные каноэ, люди гребут сами.",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 пассажира в каноэ"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Пагода"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Пагода"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Пагода"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Пагода"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Знак 'Пагода'"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Пагода"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Пагода"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Пальма"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Пальма"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Пальма"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Пальма"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Пальма"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Вход в парк"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Ворота парка"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Хижина"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Пегас",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Машинки в форме Пегасов едут по треку",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 чел. в кабине"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Пингвин-Бобслей",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Люди едут вниз по треку в бобах в виде пингвинов.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Автомобиль"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Автомобиль"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Закусочная"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Флаг"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Яхта"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Уличные фонари"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Грузовик"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Грузовик"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Заправка"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Грузовики",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 пассажир"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Труба"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Труба"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Труба"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Труба"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Флаг"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Корабль",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Большой пиратский корабль",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 чел"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Корабль"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Пираты"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Пиратский стиль"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Пицца",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Палатка с пиццей"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Мраморная стена"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Куст"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Куст"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Карточная стена"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Карточная стена"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Пост"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Плуг"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Белый медведь",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Люди сидят парами и вращаются вперед-назад",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Шест"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Шест"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Столб"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Горки-Погоня",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Круговые горки. Люди едут сидя.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в кабине"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Полиция",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "Полицейские машины 1960х едут по деревянному треку",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 чел в машине"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Попкорн",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Палатка с Попкорном"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Дверь"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Дверь"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Пост"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Рудник",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Шахтёрские поезда несутся по сложному треку.",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 или 4 пассажира"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Доисторический вход"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Доисторический Мир"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Крендели",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Палатка с кренделями"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Субстанция"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Дверь"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Забор"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Деталь тюрьмы"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Угловая стена"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Тюремная стена"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Тюремная крыша"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Смотровая башня"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Ступени башни"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Ступени башни"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Водяная башня"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Птеродактиль",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Люди сидят в удобных креслах под треком и несутся по головокружительной трассе",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел в кабинке"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Тыква"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Тыквенный дом"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Башня"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "ТВ Вывеска"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Машинки",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Гоночные Машинки",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 пассажир"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Раптор Рейсерс",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Люди сидят на машинках-Рапторах и едут по монорельсу",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 чел. в машине"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Репродуктор"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Радар"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Рафтинг",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Люди плывут по каналу на деревянных плотах.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 пассажира"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Стиль Регги"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Перила"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Перила"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Перила"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Перила"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Ограда"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Ограда"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Ограда"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Дорожка"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Деталь стены"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Красная ель"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Красная ель"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Часть кратера"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Часть кратера"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Деталь метеорита"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Часть кратера"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Секвойя"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Старинный монорельс",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Монорельсовые поезда",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Обратный вагончик",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Большой вагончик для реверсивных горок",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Горки с 4м измерением",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Вагончики на деревянных рельсах, меняющие направление на середине трека.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Рино"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Носорог",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Компактные горки со спиральным лифтом",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Снасти"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Перекаты",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Круглые лодки плывут по широкому каналу, попадая на водопады и стремительные перекаты",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Стикс",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Лодки, спокойно плывущие по речке.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 чел. в рафте"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Путь"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Вход в парк двадцатых годов"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Двадцатые Годы"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Детали стен 20х годов"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Сосисочная",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Лавка с сосисками."
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Лагерь Робина"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Хижина Робина"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Хижина Робина"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Робот"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Робот"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Вход рок-н-ролл"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Рок-н-Ролл"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Автобус рок-группы"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Стена"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Рок"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Рок 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Рок 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Ракеты",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Вагончики для горок в виде ракет",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Дорожка"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Статуэтка Роллеркоастер"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Официантка"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Колизей"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Колонна"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Римская стена"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Деталь дворца"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Статуя"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Статуя"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Римский храм"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Стена"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Стена"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Стиль римских фанфар"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Блок"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Рото-дроп",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Ряд кресел загоняют на верх высокой башни и вращают, затем они падают вниз, остановившись внизу на магнитных тормозах.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 пассажиро"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "'Трасса 66'"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Автобус",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Автобус",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 пассажиров в вагон"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Лодочки",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Гребные лодки, где пассажиры гребут сами",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Статуя"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Деталь"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Деталь"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Деталь"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Деталь"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Деталь"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Деталь"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Салун"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Трамвай Сан-Франц.",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Трамвайчики",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 пассажиров"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Деталь крыши небоскрёба"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Угол небоскрёба"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Крыша небоскрёба"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Спутник"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Тарелка"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Автобус"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Автобус",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Старый жёлтый автобус",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 человек"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Сосна"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Знак"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Знак"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Статуя"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Статуя"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Морская еда",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Палатка с морской пищей"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Акваплан"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Акваплан"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Акваплан"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Самолёт"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Акваплан"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Акваплан"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Тюлени",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Компактные горки с виражами и петлями.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Ангар"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Ангар"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Прожектор"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Лавка"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Шива"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Куст"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Куст"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Кусты и Орнаменты"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Волан"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Волан"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Тротуар"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Знак"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Знаки для дорожек"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Берёза"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Певец"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Смотровая башня",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Вращающаяся кабинка поднимается на башню.",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 пассажиров"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Шесть Флагов"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Вертикальные горки",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Широкие вагончики падают по вертикальному треку.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Скелет"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Лыжные кресла",
+    "reference-description": "Open cars for chairlift",
+    "description": "Открытые вагончики",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Скидо-машинки",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Электрические машинки",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 человек"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Череп"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Череп"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Небесная тропа"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Деталь крыши небоскрёба"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Лифт небоскрёба"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Лифт небоскрёба"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Деталь секции лифта"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Деталь секции лифта"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Деталь секции лифта"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Крыша небоскрёба"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Верхушка"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Ленивец",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Подвесные горки с вагончиками, свободно качаются на виражах.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Ограда"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Шестерёнка"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Геосфера"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Кратер"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Моно-вагончики",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Мал. монорельсовые вагончики",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Маленькое дерево"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Маленькое дерево"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Маленький кратер"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Динамик"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Деталь"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Деталь"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Мидия"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Знак 'Снег'"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Снеговик",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Люди едут парами вокруг снеговика",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Снег и Лед"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Снежный стиль"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Заснеженная Кавказская Ель"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Снежная норвежская ель"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Снежная красная ель"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Снежная красная ель"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Снежный ком"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Снеговик"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Мыльные Гонки",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Гонки на машинках в виде мыльниц по американским горкам.",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 чел."
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Игрушки",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Палатка с динозавриками"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Тема Северной Америки"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Южноамериканский вход в парк"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Сувениры",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Палатка с игрушками и зонтиками"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Молочный киоск",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Палатка с молоком"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Капсула"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Капсула"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Телескоп"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Космокольца",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Концентрические кольца позволяют вращаться во всех направлениях",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 чел."
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Ракета"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Секция корабля"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Секция корабля"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Дорожка"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Знак 'Космос'"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Космос"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Космический стиль"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Дерево"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Сфинкс"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Паук"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Забор"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Вращающаяся мышка",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Машинки в виде мышек едут по трассе, слегка вращаясь.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Спиральные горки",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Компактные горки со спиральным лифтом и сиденьями в ряд.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Спираль",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Деревянное здание с лестницей и спиральной горкой.",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Лодки",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Вместительные лодки плывут по широкому каналу при помощи ременного привода.",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 пассажиров"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Страшилки"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Спорткары",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Машинки в форме спорткаров",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Спорт"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Спутник"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Спутник",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Пассажиры едут, лёжа лицом вниз, по треку, свободно кач. по сторонам",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Беличье дерево"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Дилижанс",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Деревянные горки со скамейками",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Стадные горки",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Круговые горки с вагончиками в виде динозавров.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в вагоне"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Стоячие горки",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Кольцевые горки, где люди катаются стоя.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Стоячие горки",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Посетители едут стоя в широких поездах в специальных креплениях.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Фруктовые напитки",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Палатка фруктовых напитков"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Статуя"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Статуя"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Статуя"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Статуя Свободы"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Паровозы",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Паровозики с вагончиками",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Фонтанчик"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Блок"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Блок"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Забор"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Фигурная решётка"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Древний храм"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Скамейка"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Блок"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Деталь небоскрёба"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Деталь небесной стены"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Стена"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Стена"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Стена"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Лавка"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Скамья"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Моно-паровозики",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Вместимые монорельсовые поезда с паровозами",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 или 10 пассажиров"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Сэндвичи",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Палатка с сэндвичами."
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Подлодки",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Люди плавают на подводных лодках",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 Пассажира"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Рюмочная",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Палатка, где разливают сухое вино."
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Летний стиль"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Очки",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Палатка с очками"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Корабль"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "ЦПУ Компьютера"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Монитор компьютера"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "ЦПУ Компьютера"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Поддержка"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Поддержка"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Поддержка"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Серфинг Коастер",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Пассажир стоит в широком вагончике со спец системой безопасности.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Подвесные поезда",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Большие монорельсовые поезда",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Акваплан",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Подвесные раскачивающиеся вагончики",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 чел. в кабинке"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Аэропланы",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster train consisting of airplane shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажираpa"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Подвесные вагоны",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster train consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Подвесной Мостик"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Подвесной Мостик"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Подвесной мост"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Подвесной Мостик"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Подвесной мост"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Подвесной мост"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Подвесной мост"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Подвесной мост"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Папоротник"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Липучка"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Растение"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Растение"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Растение"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Лебеди",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Люди катаются в лодках, имеющих форму лебедей.",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 пассажира"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Свинг-вагоны.",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Вагончики, качающиеся на рельсе.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Вагончики",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Подвесные вагончики, раскачивающиеся во всех направлениях.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Качающийся корабль",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Корабль, прикрепленный к балке с противовесом на другом конце, крутится на 360 градусов.",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 пассажиров"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Меч в камне"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "Футболки",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Палатка с футболками"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "Поезд TGV",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Поезд с линейным индукционным мотором с крутыми виражами",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "Бочки ТНТ"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "ТНТ"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "Детонатор ТНТ"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "Куча ТНТ"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Лампа"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Лампа"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Высокий забор"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Мишень"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Асфальт"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Кабак"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Техно стиль"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Вигвам"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Лифт",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Люди переезжают вверх-вниз с уровня на уровень.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 человек"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Кусок стены с головой"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Деталь Ступеней"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Деталь стены храма"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Деталь стены храма"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Кусок стены с головой"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Дом"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Мяч"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Теннисная сетка"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Теннисная сетка"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Тент"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Вигвам"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Термитник"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Особняк"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Солдаты"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Время",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Люди сидят в специальной сфере и путешествуют во времени.",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 человек"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Мухомор"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Мухомор"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Мухомор"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Поганка"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Мухомор"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Мухомор"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Сани",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Вагончики в виде саней для горок",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Палатка с конфетами",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Палатка, где продают ириски."
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Конфеты",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Палатка с яблочными конфетами."
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Туалет",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Уборная для посетителей парка"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Туалет",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Туалет в деревянном доме"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Туалет",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Уборная для посетителей парка"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Томми-Ган",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Люди сидят попарно и вращаются вокруг большого автомата.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 человек"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Топ Спин",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Пассажиры едут в гондоле, подвешенной на большом рычаге, раскачивающемся вперед-назад.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 пассажиров"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Тотем"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Ратуша"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Игрушечный стиль"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Трабант",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Горки в форме автомобилей",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира в машине"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Трек"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Трек"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Трек"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Трек"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Трек"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Трактор"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Традиционный вход"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Трамвай",
+    "reference-description": "Old-timer replica trams",
+    "description": "Старый трамвай",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 пасс. на вагон"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Фургон"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Сундук"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Сундук"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Сундук"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Катапульта",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Люди качаются в подвешенных вагончиках в стиле осадных орудий.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 человек"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Дерево"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Деревья"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Трицерапторы",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Люди катаются в маленьких электромобильчиках.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 чел. в машине"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Трилобиты",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Лодки в форме трилобитов несутся по головокружительному треку с падениями в воду.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 чел в лодке"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Черепаха",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Маленькие круглые шлюпки с моторчиком",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 пассажира"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Твист",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Люди катаются попарно, сидя в креслах.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 пассажиров"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Твистер-Кар",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Вагончики, способные вращаться",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Твистер-Кар (реверс.)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Горки с головокружительным вращением.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Твистер-коастер",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Широкие поезда скользят по гладким рельсам со множеством поворотов",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Упавший НЛО"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Единорог"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Город"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Город"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Валькирия"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Валькирия"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Валькирии",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Широкие вагончики спускаются по отвесному треку с участками свободного падения",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 человек"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "3D вывеска"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Вертикальный челнок",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Люди сидят в вагончиках, подвешенных под треком, поднимаются вверх и спускаются по головокружительной трассе.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Дерево"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Ретрокары",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Люди катаются на старинных автомобильчиках.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Вирджиния",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Круглые вагончики едут по трассе и одновременно крутятся.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Вулкан"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Вулкан с деревьями"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Ракита"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Фургон"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Фургон"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Колесо"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Блок"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Арка"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Стены и крыши"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Орешник"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Статуя Вашингтона"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Оса"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Водная Тема"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Водомёт"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Фонтан"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Водные трициклы",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Педальные трициклы",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Водный стиль"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Водопад"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Крыша"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Оружие"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Плакучая Ива"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Колеса"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Бочка виски"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Бочки с виски"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Белый слон"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Король"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Белый конь"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Пешка"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Белый тополь"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Ферзь"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Ладья"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Дикий Запад"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Стиль Дикого Запада"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Деталь Пола"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Деталь Пола"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Деталь"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Деталь крыши"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Деталь стены"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Мельница"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Окно"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Окно"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Окно"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Супчик",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Палатка, где продают суп."
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Ведьмы у котла"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Колдовство",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Горки с маленькими вагончиками.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 пассажира"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Чудесная Тема"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Супная",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Лоток, где разливают суп."
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Деревянная ограда"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Блок"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Тележка"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Забор"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Деревянный забор"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Дорожка"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Забор"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Деревянная стена"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Деревянная стена"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Деревянная стена"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Деревянные поезда",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Деревянные поезда для горок с ремнями на колени",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Деревянные поезда (6 мест)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Деревянные поезда для Горок с ремнями на колени",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Деревянные поезда (6 мест, реверс)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Деревянные поезда с сидениями и ремнями для ног.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 пассажиров"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Дерев. вагончики",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Вагончики для боковых горок.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Знак из дерева"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Стена"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Стена"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Стена"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Стена"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Акваплан"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 пассажира"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Тис"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Зебра"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Зевс"
+  }
+}

--- a/objects/sv-SE.json
+++ b/objects/sv-SE.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' skylt"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' skylt"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' skylt"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant'-skylt"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "20-tals-racing",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "Förarna tävlar mot varandra i gokarts som ser ut som racerbilar från 20-talet.",
+    "reference-capacity": "Single-seater",
+    "capacity": "Ensitsig"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "50-talsbil"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "50-talsbil"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "50-talsraket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "50-talsraket",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Berg- och dalbanevagnar accelererar först ut från stationen och färdas snabbt uppför en vertikal bana för att sedan snabbt backa genom stationen och färdas uppför en ny vertikal bana",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D-bio",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Bio som visar 3D filmer inuti en geodetisk sfäriskt formad byggnad",
+    "reference-capacity": "20 guests",
+    "capacity": "20 besökare"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D-skylt"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D-skylt"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "Omvänd berg- och dalbana",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Passagerarna sitter i säten upphängda under spåret medan de rusar genom jätteloopar, skruvar och stora ryckiga stup",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "Flyganfall",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Passagerarna halas nerför ett snott spår i en stor bobsläde som endast styrs av krökningen och påskjutningen av det halvcirkulära spåret",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Del av urinnevånares konstverk"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Urinnevånares tom platta"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Urinnevånares ormkonstverk"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Urinnevånares spirituella kostverk"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstrakt tema"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Mintgrönt vatten"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Aktiv vulkanöppning"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Fullvuxen indisk elefant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Fullvuxen panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Ingång till afrikansk park"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Afrikanskt tema"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Lufttrycksdriven lodrät bana",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Efter en upprymd luftdriven start ökar tåget hastigheten upp för ett lodrätt spår över toppen och lodrätt ner på andra sidan för att återvända till stationen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Monorailtåg med luftskeppstema",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Monorailtåg med strömlinjeformade fram- och bakvagnar och med hög kapacitet.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagerare per vagn"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo-tall"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Historiska utomjordiska strukturer"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Historiska utomjordiska strukturer"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Utomjordisk växt"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Utomjordisk växt"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Stor utomjordisk strålkastare"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Liten utomjordisk strålkastare"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Stor utomjordisk struktur"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Stor utomjordisk struktur"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Stor utomjordisk struktur"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Liten utomjordisk struktur"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Liten utomjordisk struktur"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Liten utomjordisk struktur"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Nedre del, utomjordiskt torn"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Mittdel, utomjordiskt torn"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Övre del, utomjordiskt torn"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Utomjordiskt träd"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Utomjordiskt träd"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligatorformat träd"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "Amerikansk fotboll"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "Amerikansk fotboll"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "Amerikansk fotbollshjälm"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "Amerikanska ånglokomotiv",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniångtåg som består av kopior av ånglokomotiv och drar mjukt trävagnarna med tygtak",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagerare per fordon"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda-bana",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Rymliga vagnar med enkel fastspänning",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Grillat djur på spett"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Ballonger 1"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Lägereld"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Allseende öga (animatroniskt)"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut (animatronisk)"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut (animatronisk)"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Argonaut (animatronisk)"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Astronaut (animatronisk)"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Grottmänniska som gör upp eld (animatronisk)"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Kättrad jungfru (animatronisk)"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Klanmedlem (animatronisk)"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Svarte riddaren (animatronisk)"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Svarte riddaren (animatronisk)"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Trollsländor (animatroniska)"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Örn på bur (animatronisk)"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Ond utomjording (animatronisk)"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Ond utomjording (animatronisk)"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Ond utomjording (animatronisk)"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Brandman (animatronisk)"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Skjutande kanon (animatronisk)"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Gangster (animatronisk)"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "God utomjording (animatronisk)"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "God utomjording (animatronisk)"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "God utomjording (animatronisk)"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Knekt (animatronisk)"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Knekt (animatronisk)"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Medusa (animatronisk)"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Poliskonstapel (animatronisk)"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Robin Hood (animatronisk)"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armé av skelett (animatronisk)"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armé av skelett (animatronisk)"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Armé av skelett (animatronisk)"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Rymdfarare (animatronisk)"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Stegosaurus (animatronisk)"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "T-Rex (animatronisk)"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Triceratops (animatronisk)"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Vinkande kung (animatronisk)"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Attackerande skorpion (animatronisk)"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Attackerande skorpion (animatronisk)"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Flaxande pterodaktyl (animatronisk)"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarktiskt tema"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antilop-hona"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antilop-hanne"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antilop-par"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antigravitations-LCD-skärm"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Antigravitations-LCD-skärm"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Piltavla"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona-cypress"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Hörnsektion, art déco"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Hörn med ledstänger, art déco"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Hörn med ledstänger, art déco"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Hörn med fönster, art déco"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Hörn med fönster, art déco"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Hörn med fönster, art déco"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art déco-matstånd",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "Stånd som säljer nudlar och kyld lemonad"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Omvänd hörnsektion, art déco"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Omvänd hörnsektion, art déco"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Taksektion, art déco"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Övre hörnsektion, art déco"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Övre hörnsektion, art déco"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Övre hörnsektion, art déco"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Toppsektion, art déco"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Toppsektion, art déco"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Väggsektion, art déco"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Vägg med dörr, art déco"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Vägg med ledstänger, art déco"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Vägg med ledstänger, art déco"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Vägg med ledstänger, art déco"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Vägg med ledstänger, art déco"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Vägg med fönster, art déco"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Vägg med fönster, art déco"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Tåg med ledvagnar",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Berg- och dalbanetåg med korta enkelradsvagnar och öppna fronter",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Gångväg av aska"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Askträd med nymfer"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asiatiskt tema"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asiatisk gong-gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Asp"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlasstaty"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Ingång till australiensisk park"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australiensiskt tema"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australiensisk fontän 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australiensisk fontän 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Bilar",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Berg- och dalbanevagnar i form av bilar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "Jättebläckfisk från B-film"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "Jättespindel från B-film"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-filmsspindel",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Passagerarna åker i par i säten som roterar kring en jättespindel som tagen ur en B-film.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Indisk babyelefant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Babypanda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badmintonracket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badmintonracket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Cirkelformad lykta"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Cirkelformad lykta"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Ballongstånd",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "Ett souvenirstånd som säljer heliumfyllda ballonger"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bambubuske"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bambuplint"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bambutak"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bambutak"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bambutak"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bambuskott"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bambumur"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Bandmedlem"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Bandmedlem"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Bandmedlem"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Bandmedlem"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Ladugårdsstorm",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Passagerarna sitter i säten som hänger under spåret och färdas i hög fart genom gigantiska loopar, svängar och höga fall.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Tunna"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Tunna"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Tunna"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Tunna"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Grundblock"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Grundblock"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Grundblock"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Grundblock"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Rusande murbräcka",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "En kompakt berg-och dalbana med stålskena, spiralformad lyftbacke och vagnar med säten i rad.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Biffnudelstånd",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "Ett stånd som säljer kinesiska biffnudlar"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bänk"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bänk"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bänk"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Bänkar"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengalisk tiger",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Berg- och dalbana med tvära svängar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Enspårs-cyklar",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Speciella cyklar kör på en enspårig skena drivna genom passagerarnas pedaler",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 passagerare per cykel"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben och parlamentet"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Stor geosfär"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Motorcyklist"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Svart löpare"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Svart London-taxi",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Eldrivna taxibilar av London-typ",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per bil"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Digerdöden",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagerarna dundrar nerför ett slingrande spår i råttvagnar som styrs enbart av det halvcirkelformade spårets kurvatur och lutning.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Svart kung"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Svart riddare"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Svart schackpjäs"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Svart poppel"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Svart drottning"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Svart torn"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blobb från yttre rymden",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "En roterande observationskabin som färdas upp i ett högt torn.",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagerare"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobslädesbana",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagerarna åker ner för ett skruvat spår i en bobslädeformad vagn som endast styrs av svängarna och böjningen av det halvrunda spåret",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Kokande gryta"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Ben"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Benstaket"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Ben"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Bumerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Bumerangbana",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Efter en luftdriven snabbstart susar vagnarna uppför och nedför en vertikal bana innan de återvänder till stationen",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Tegelmur"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Tegelmur"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Tegelmur"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "Brittisk postlåda"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "Brittisk telefonkiosk"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Trasig staty"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Trasiga hjul"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brun plattformsgång"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Sjudande tjärgrop"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Hink"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Byggnad"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Byggnad"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bulletbana",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Berg- och dalbana med japanska bullet-vagnar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Vass"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Krockbåtar",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Små runda skeppsjollar som drivs av en centralmonterad motor som styrs av passagerarna",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Boj"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Boj"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Hamburgarbar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "En hamburgarformad byggnad där man säljer hamburgare"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Buske"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Fjäril"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda till stuga"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Veranda till stuga"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Takdel till stuga"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Takdel till stuga"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Takdel till stuga"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Tak till koja"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Väggdel till stuga"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Kålträd"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Kaktus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown-alm"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Kanariepalm"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Godis"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Godis"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Godis"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Slickpinne"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Godisträd"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Godisträd"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Godisträd"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Godislandstema"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Sockervaddsstånd",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "En sockervaddsformad byggnad där man säljer rosa sockervadd"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Kanon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Kanon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Kanonkulor"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Kanoter",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Långa kanoter som passagerarna paddlar själva",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagerare per kanot"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvastak"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Karnevalbåtar med fjärilsvagnar",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Karnevalsliknande berg- och dalbanevagnar med fjärilsmotiv",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Karnevalsbåtar med grodvagnar",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Karnevalsliknande berg- och dalbanevagnar med grodmotiv",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Karnevalsbåtar med ödlevagnar",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Karnevalsliknande berg- och dalbanevagnar med ödlemotiv",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Vagnkoppling"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Bankautomat",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "En bankautomat som gästerna kan använda om de använder alla sina pengar"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Hörndel, slott"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Hörndel, slott"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Slottsentré"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Omvänt hörn, slott"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Fällgaller, slott"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Slottsvall"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Vallhörn, slott"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Vallhörn, slott"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Vallhörn, slott"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Omvänt vallhörn, slott"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Slottstorn"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Tornhörn, slott"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Tornhörn, slott"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Tornskarvdel, slott"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Rak torndel, slott"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "T-del till torn, slott"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "T-del till torn, slott"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsmur"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsvägg"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsvägg"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Slottsvägg"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Boskapskranium"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Kaukasisk tall"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Kittel"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Grottentré"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Grottbilar",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Förarna tävlar mot varandra i stenåldersgokarts.",
+    "reference-capacity": "Single-seater",
+    "capacity": "Ensitsig"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Libanesisk ceder"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Kerberos",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Passagerarna sitter i bekväma tåg med enbart enkla knästöd vilket möjliggör långa, mjuka fall, slingrande svängar och dessutom gott om lufttid över krönen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Linbanekorgar",
+    "reference-description": "Open cars for chairlift",
+    "description": "Öppna vagnar för linbana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Chackbrädsblock"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshirekatter",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Motordrivna kattformade fordon som följer en spårbaserad bana",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passagerare per katt"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets-stånd",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "Ett stånd som säljer friterade kycklingbitar"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Kinesisk Ceder"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Kinesisk drake"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Kinesiska drakar",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Elektriskt drivna radiobilar",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagerare per bil"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Kinesisk djonk",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "I ena änden på en lång arm sitter djonken och i den andra änden sitter en motvikt som får djonken att rotera i 360 grader",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagerare"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chipsaffär",
+    "reference-description": "A hut selling chips",
+    "description": "En butik där man säljer chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Pommes frites-bod",
+    "reference-description": "A stall selling chips",
+    "description": "Ett stånd som säljer pommes frites"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chokladkaka"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Kretsgång"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Cirkus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Cirkusdjurföreställning inuti ett stort kupoltält",
+    "reference-capacity": "30 guests",
+    "capacity": "30 besökare"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Cirkus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Klassisk skylt"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Klassiskt/romanskt tema"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatras nål"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Klättrande vinranka"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Klocka"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Klöverformat träd"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Båtattraktion",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Båtformade berg- och dalbanevagnar",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagerare per båt"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Kaffekoppar",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Passagerare åker parvis i säten som roterar kring tre långa, roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Kafé",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "En affär i art-decostil som säljer kaffe i koppar"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Kugghjul"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Kugghjul"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Kugghjul"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Kugghjul"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Kola"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Allé"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Vanlig en"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Vanlig ek"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Vanlig gran"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Kompakt omvänd bana",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Passagerarna sitter i par i säten upphängda under spåret då de åker genom loopar och skruvar med snabba omkastningar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Kondorhjulet",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Åkandes i speciella byglar under spåret känner passagerarna känslan av flygning när de sveper genom luften i kondorformade vagnar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Berg- och ålbana",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Berg- och dalbana av kompakt stål med ålformade vagnar som ringlar sig fram genom korkskruvar och spiraler",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Barrhäck"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Barrhäck"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Transportband, hörn"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Transportband, riktningsomkastare"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Transportband, ände"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Transportband, stigning"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Transportband, rak del"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Kakaffär",
+    "reference-description": "A stall selling giant cookies",
+    "description": "Ett stånd som säljer jättekakor"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool kille"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Korkskruvsberg- och dalbana",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "En solid stålberg- och dalbana där tågen åker längs korkskruvar och loopar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Del av korrugerat tak"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Korrugerad stålgrund"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Korrugerat ståltak"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Korrugerad stålmur"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Del av kurrogerad vägg"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Korsikansk tall"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Rolig stengång"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Kräldjurstema"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Krokodilbana",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Krokodilformade båtar forsar fram i en vattenfylld kanal och stänker ned åskådare vid foten av dödsföraktande stup",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagerare per båt"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Lustiga huset",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Byggnad som innehåller skeva rum och vinklade korridorer för att disorientera personerna som går igenom den",
+    "reference-capacity": "5 guests",
+    "capacity": "5 besökare"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Amorfontäner"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Böjt block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Böjt block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Del av svängd jordvägg"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Del av svängd jordvägg"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Del av svängd jordvägg"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Böjt tak"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Böjt tak"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Krökt mur"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Krökt mur"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Egen musik 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Egen musik 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyklop",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Förarna kör ögat från en jättecyklop.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per bil"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyklopstaty"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Prästkragelampa"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dammtorn"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Medeltida entré"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Medeltidstema"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Takhörndel, medeltida by"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Takhörndel, medeltida by"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Omvänd takdel, medeltida by"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Omvänd takdel, medeltida by"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Nedre hörndel, medeltida by"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Nedre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Takdel, medeltida by"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Takdel, medeltida by"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Takdel, medeltida by"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Takdel, medeltida by"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Tak med skorsten, medeltida by"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Övre hörndel, medeltida by"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Övre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Övre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Övre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Övre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Övre väggdel, medeltida by"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Fönsternisch, medeltida by"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Fönsternisch, medeltida by"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Tak med fönster, medeltida by"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Tak med fönster, medeltida by"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Tak med fönster, medeltida by"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Tak med fönster, medeltida by"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Medeltida värdshus"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dött träd"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dött träd"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dött träd"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dau-båt",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "En dekorativ fiskebåt som paddlas av föraren",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamantvagn"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamantbana",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Passagerare åker parvis i säten som roterar runt tre långa, roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamantgruva"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamantformat träd"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Jollebana",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Passagerarna åker i uppblåsbara jollar ner för ett skruvat halvrunt eller helt slutet rörspår",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passagerare per livbåt"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurie"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurie"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurie"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurie"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaurie"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaurieägg",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Passagerarna åker i par i säten som roterar kring en rörlig dinosauriemamma.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Smutsig gångväg"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Radiobil",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Självdrivna elektriska radiobilar",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per vagn"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Abstrakt tema"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Delfinbana",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Delfinformade enmansvagnar som styrs av passageraren",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passagerare per vagn"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Delfinfontän"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Delfinstaty"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Dörröppning"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Dörröppning"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Dörröppning"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Dubbeldäckarkarusell",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditionell dubbeldäckskarusell med snidade trähästar.",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagerare"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Dubbeldäckat observationstorn",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Dubbeldäckad roterande observationskabin som åker upp för ett högt torn",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagerare"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Munkaffär",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "Ett stånd som säljer ringformade munkar"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Stor gråbrun tornbas"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Trasig stor gråbrun tornbas"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Gråbrunt mittparti för stort torn"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Stor gråbrun torntopp"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Gråbrun minaretdel 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Gråbrun minaretdel 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Gråbrun minaretdel 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Gråbrun takdel 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Gråbrun takdel 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Gråbrun takdel 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Gråbrun takdel 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Gråbrun liten tornbas"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Gråbrun bas för litet minarettorn"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Gråbrun liten torntopp eller mittparti"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Gråbrun trappa 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Gråbrun trappa 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Gråbrun väggdel 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Gråbrun väggdel 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Gråbrun väggdel 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Gråbrun väggdel 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Gråbrun väggdel 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Gråbrun väggdel 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Gråbrun väggdel 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Gråbrun väggdel 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Gråbrun väggdel 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Gråbrun väggdel 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Gråbrun väggdel 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Attackerande drake"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Berg- och drakbana",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Berg- och dalbana med drakvagnar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Trollslända",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Passagerarna hänger under en enspårsbana i specialdesignade vagnar som svingar fritt i sidled i kurvorna.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Dryckesstånd",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "Ett burkformat stånd där man säljer läsk"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Påskö-staty 1"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptisk pelare"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptisk staty"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptisk skylt"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptiskt tema"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptisk vägg"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Egyptiskt tema"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffeltornet"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Elektriskt staket"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Trasigt elektriskt staket"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Hörndel, elektriskt staket"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Omvänd hörndel, elektriskt staket"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Elektriskt staket med ljus"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elefantfontän"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Tom vagn"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Roterande hjul med hängande passagerarkapslar, som börjar med att rotera och sedan lutas upp av en stödarm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eukalyptusträd"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europeiskt tema"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "Europeiskt lärkträd"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "Ingång till europeisk park"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Hotfull samuraj"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé-ägg",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Passagerare åker parvis i säten som roterar kring tre långa, roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Omvänd skyttel",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Passagerarna sitter i par med ansiktena antingen bakåt eller framåt då de åker genom loopar och skruvar med snabba omkastningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Tivolitema"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantasitema"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Bondgårdsredskap"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fet buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Festmåltid"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Staket"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Staket"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Staket"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Staket och murar"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Pariserhjul",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Roterande stora hjul med öppna stolar",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passagerare"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Brinnande vårdkase"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Drakflygare",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Passagerare åker parvis i säten som roterar kring tre långa, roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Stridande riddare",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Hästformade radiobilar som förarna kan tornera med.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per bil"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Smällkaramell",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Ett roterande hjul med hängande åkvagnar som först snurrar och sedan lutas med hjälp av en stödarm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Brandpost"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "Första hjälpenrum",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "En plats för sjuka besökare att gå till för att bli snabbt friska"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fiskhål"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Hel staty"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Lågor"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo som äter"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo som tittar"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo som putsar fjädrarna"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Golvlös berg- och dalbana",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "Breda tåg utan golv ger passagerarna en luftkänsla när de glider genom skruvade spår och flera omkastningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Blomma"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower power",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Små blomformade jollar drivna av en centralt monterad motor som kontrolleras av passagerarna.",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagerare per vagn"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower power-t-shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stånd som säljer t-shirts med blommotiv."
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flygbåtar",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Flygbåt-formade vagnar åker på berg- och dalbanespår som tillåter snäva kurvor och djupa fall ned till lugnare vattenfyllda sektioner.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagerare per båt"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flygande berg- och dalbana",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Passagerarnas hålls fast i bekväma säten under spåret, åker genom skruvade spår som ger ultimat flygkänsla",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flygande tefat",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Självstyrda svävarfordon",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per vagn"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Fotboll"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Fotbollsbana",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Upphängda berg- och dalbanevagnar i form av fotbollar som gungar fritt runt hörn",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Förbjudna fruktens träd"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Skogsträd"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fontän"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fontän"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Inverterad hårnålsbana",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individuella vagnar kör nedanför ett spår med hårnålssvängar och kraftiga nerförsbackar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Friterad kycklingstånd",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "Ett stånd som säljer fat med friterad kyckling"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Stånd med friterade risnudlar",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "Ett stånd som säljer kinesiskt ris med nudlar"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruktkaramell"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruktkaramell"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruktträd"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruktträd"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruktglass-stånd",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "Ett temastånd som säljer fruktiga glassar"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Lustiga huset",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Byggnad med rörliga väggar och golv som gör besökare snurriga.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 besökare"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Trattkaksaffär",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "Ett stånd som säljer trattkakor"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Framtidstema"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristisk parkentré"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Galge"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangsterbil",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "20-talsinspirerade gangsterbilvagnar accelereras från stationen med induktionsmotorer och far fram genom slingrande och inverterade spår.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Rabatter"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "Diversehandel"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Stillsamt tema"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometrisk fontän"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisk skulptur"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisk skulptur"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisk skulptur"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisk skulptur"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometrisk skulptur"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgianskt platt takhörn"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgiansk platt tak-kant 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgiansk platt tak-kant 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgiansk väggdel för nedre våning 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgiansk väggdel för nedre våning 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgiansk väggdel för nedre våning 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgiansk väggdel för nedre våning 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgiansk väggdel för nedre våning 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgiansk väggdel för nedre våning 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgiansk takdel 6"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Slutdel för georgianskt tak 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Slutdel för georgianskt tak 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgiansk takdel 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgiansk takdel 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgiansk takdel 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgiansk takdel 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgiansk takdel 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgiansk takdel 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgiansk väggdel 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgiansk väggdel 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgiansk väggdel 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgiansk väggdel 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgiansk väggdel 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgiansk väggdel 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Gejsrar"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Spöktåg",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Motordrivna monsterformade vagnar som åker längs ett flernivåspår förbi spöklika scener och specialeffekter",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Jättebas"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Jättebönstjälk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Jättebönstjälk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Godislandstema"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Jättemorot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Enormt dinosauriefotavtryck"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Jättetrumset"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Jätteormbunke"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Jätte trädgårds-tema"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Jättegräs"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Jättegitarr"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Gigantiskt mangroveträd"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Jättepanda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Jättepumpa"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Jättesnöflinga"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Jättesnöflinga"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Jättesnöflinga"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga-banan",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "En gigantisk stålberg- och dalbana som klara mjuka fall och höjder på över 1000 m",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraff 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraff 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffstaty"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glastak"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glastak"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glasvägg"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glasvägg"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glasvägg"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glasvägg"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Kör själv- gokarts som är bensindrivna",
+    "reference-capacity": "single-seater",
+    "capacity": "enkelsäte"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Guldlama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Guldstaty 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Guldstaty 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Gyllene buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Gyllene Skinnet"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Guld-Hinoki-cypress"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Fredlig samuraj"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorillabana",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Berg- och dalbana med upphängda, gorillaformade vagnar som svänger fritt i kurvorna",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Gravsten"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Gravsten"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Gravsten"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Gravsten"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Kyrkogårdsmonument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Kyrkogårdsmonument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Kyrkogårdsmonument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Framdel till Kinesiska muren"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Kinesiska muren, bakre mur"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Kinesiska muren, trappa"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Kinesiska muren, hörn"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Kinesiska muren, rak del"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Vita hajen",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Rymliga vagnar med enkel fastspänning",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Grön asfaltgångväg"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Grönt vatten"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Vass dansare"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hadesstaty"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Spegelsal",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Byggnad med skeva speglar som förvrider reflektionen av den som speglar sig.",
+    "reference-capacity": "5 guests",
+    "capacity": "5 besökare"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Kaj"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Hamnvägg"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Vägghörndel, hamn"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Vägghörndel, hamn"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Hamnvägg med kaj"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Hamnvägg med fiskeredskap"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hamnvägg med förtöjning"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hamnvägg med förtöjning"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hamnvägg med förtöjning"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Hamnvägg med förtöjning"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Selbana",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Passagerarna åker liggande fastspända i speciella selar genom slingrande och inverterade spår, antingen på ryggen eller på magen.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hattstånd",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "Ett souvenirstånd som säljer stora skumhattar"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Spökhus",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Stor temabyggnad som innehåller skrämmande korridorer och spöklika rum",
+    "reference-capacity": "15 guests",
+    "capacity": "15 besökare"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Spökfängelse",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Byggnad med fängelsehålor och vaxdockor av inspärrade fångar avsedda att skrämma besökare.",
+    "reference-capacity": "16 guests",
+    "capacity": "16 besökare"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Spökslottet",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Motordrivna vagnar åker längs ett spår i flera nivåer förbi specialeffekter och scener",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Höbal"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Hjärtformat träd"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Golv, himmelskt bad"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Bassäng, himmelskt bad"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Bassänghörn, himmelskt bad"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Bassängkant, himmelskt bad"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Bassängtrappa, himmelskt bad"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tak, himmelskt bad"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tak, himmelskt bad"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tak, himmelskt bad"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Tak, himmelskt bad"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Fönster, himmelskt bad"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Båge, himmelskt bad"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Båge, himmelskt bad"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Båge, himmelskt bad"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arkitektur, himmelskt bad"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arkitektur, himmelskt bad"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arkitektur, himmelskt bad"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Arkitektur, himmelskt bad"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontän, himmelskt bad"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Fontän, himmelskt bad"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Trappa, himmelskt bad"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Trappa, himmelskt bad"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Häck"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Häck"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helikopterplatta"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Herkules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Flodhäst 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Flodhäst 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Flodhästbåt",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "En upphängd ubåt som följer en undervattensbana",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "passagerare per båt"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honungsakacia"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Skräcktema"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Häst"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Häststaty"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Ryttarstaty"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Hinderlopp",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Passagerarna åker hästformade fordon som kör längs en enspårig berg- och dalbana",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 passagerare per häst"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Varm chokladstånd",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "Ett stånd som säljer varma chokladdrinkar"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Korvkiosk",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "Ett stånd som säljer korv med bröd"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot rod"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot rod"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot rod-bana",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Efter en spektakulär, tryckluftsdriven start skjuts tåget uppför ett vertikalt spår för att sedan åka rakt vertikalt nedåt på andra sidan tillbaka till stationen.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "Hus"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Svävarcyklar",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Förarna sitter på futuristiska cykelformade fordon som färdas längs en enspårsbana.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagerare per fordon"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Svävarbilar",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Magnetteknologi har använts för att skapa en illusion av futuristiska svävarbilar.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Flygande svävarcykel"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Flygande svävarcykel"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Stillastående svävarcykel"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Stillastående svävarcykel"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Svävarbräda",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Passagerarna åker på futuristiska svävarbrädor som svingar fritt i sidled i kurvorna.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Flygande svävarbil"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Flygande svävarbil"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Stillastående svävarbil"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Stillastående svävarbil"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Hundsläde",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Eldrivna hundslädesvagnar följer en utlagd bana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister-tåg",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Rymligt tåg med enkla knäbyglar",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twistertåg (breda vagnar)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Breda vagnar tvärsöver varandra som upphöjda säten och enkla knästång",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hyperattraktion",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "En stor berg- och dalbana med stora stup och hög hastighet och bekväma vagnar med endast en stång som seldon över knäna",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Glasstrutsstånd",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "Ett stånd som säljer glasstrutar"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Iskub"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Isformation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Isformation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Isslott"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ingång till ispark"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Isrörsfot"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Isrörsavsnitt"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Isrörsventil"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Istak"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Isvägg"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Istema"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Istunnor"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Istunnor"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Istunnor"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Istestånd",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "Ett stånd som säljer iste"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Iglootak"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloovägg"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloovägg"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo-vägg"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Inverterad impulsbana",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Omvända berg- och dalbanevagnar som accelereras ut från stationen kör upp för en lodrät brant vänder sedan och åker baklänges genom stationen upp för en annan lodrät brant",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Doftceder"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indisk silkesflagga"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indisk silkesflagga"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indisk silkesflagga"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indisk silkesflagga"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indisk silkesflagga"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriell takhörndel"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industriell takhörndel"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industriell takdel"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriell vägghörndel"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industriell vägghörndel"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriella väggar"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriella väggar"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriella väggar"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industriella väggar"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industriell vägg med dörr"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industriell vägg med fönster"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Informationskiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "Ett stånd där besökarna kan hitta kartor över parken och köpa paraplyer"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italiensk cypress"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italiensk polisbil",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Passagerare åker parvis i säten som roterar kring tre långa, roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguarbana",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Berg- och dalbanevagnar i form av jaguarer",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Blomstrande japanskt körsbärsträd"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanskt körsbärsträd"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Ingång till japansk park"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japansk tall"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Shōji-tak"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Shōji-tak"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Shōji-tak"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japansk silkesflagga"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanskt snöbollsträd"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzmusiker"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzmusiker"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzmusiker"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazzmusiker"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Gelébaby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Gelébönor"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Gelémur"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jetplan"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jetplan"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jetplan"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jetpackfärd",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Passagerarna sitter i ett fordon som skjuts upp längs ett vertikalt spår.",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagerare per fordon"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jetbana",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "En kompakt berg- och dalbana med individuella vagnar och mjuka, slingrande fall.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Vattenskoter",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Ensitsig vattenskoter som besökaren kör själv",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 passagerare per fordon"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Riddartornering",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Passagerarna sitter på hästformade fordon och åker längs en enspårsbana.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagerare per fordon"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Hoppande fontäner"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Hoppande snöbollar"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Djungelstaket"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Skylt - Djungelstil"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Djungeltema"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Djungelträd 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Djungelträd 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Djungelträd med leoparder"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Djungelträd med lianer"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Djungeltema"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Skräp"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Skylt - Jurassic-stil"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic-tema"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Dinosaurietema"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Känguru"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Späckhuggare",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Passagerare färdas i en ubåt längs en undervattensbana",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "passagerare per vagn"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala-bana",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Rymliga vagnar störtar baklänges nedför en bana",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagerare per vagn"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Bas till stort Kreml-torn"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Mittparti till stort Kreml-torn"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Topp till stort Kreml-torn"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Del 1 till Kreml-minarettorn"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Del 2 till Kreml-minarettorn"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Del 3 till Kreml-minarettorn"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Takdel 1 till Kreml-torn"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Takdel 2 till Kreml-torn"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Bas till litet Kreml-torn"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Mittparti till litet Kreml-torn"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Bas för litet Kreml-torn"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Trappa 1 till Kreml-mur"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Trappa 2 till Kreml-mur"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kreml-mur del 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kreml-mur del 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kreml-mur del 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kreml-mur del 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kreml-mur del 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kreml-mur del 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kreml-mur del 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kreml-mur del 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "Induktionsberg- och dalbana",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Berg- och dalbanetågen accelereras ut från stationen med induktionsmotorer för att fara genom tvinnade inversioner",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Nyckelpigetåg",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Berg- och dalbanetåg med små nyckelpigeformade vagnar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lampa"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Stort vinklat mammutstaket"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Stort vinklat mammutstaket"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Stor alm"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Stort mammutstaket"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Stort mammutstaket"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Stor meteorkrater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Stor ek"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Regnskogsträd 4"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Stor röd meteorkrater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Stor rykande skorsten"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Stor högtalare"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Stor totempåle"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laserstaket"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Hörn, laserstaket"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Fritt fall",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Frifallsvagnar skjuts med lufttryck upp för ett ståltorn och får sen falla fritt ner",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson-cypress"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Upphängd miniflygbana",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Passagerarna  åker med ansiktet neråt i liggande ställning, upphängda i en specialdesignad vagn från enspårsbanan, svänger fritt från sida till sida runt svängarna",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagerare per vagn/bil"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Liggande berg- och dalbana",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Passagerarnas hålls fast i speciella seldon i liggande läge, åker genom ett tvinnat spår och inversioner antingen på rygg eller med ansiktet mot marken",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonadstånd",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "Ett marknadsstånd som säljer kyld, gammaldags lemonad"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Läskstånd",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "Ett stånd som säljer uppfriskande läskedrycker"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Hiss",
+    "reference-description": "Steel lift cabin",
+    "description": "Besökarna åker i en hiss upp och ner för ett lodrätt torn för att komma från en nivå till en annan",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lilja"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine-bana",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Berg- och dalbana med Limousine-vagnar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lejon"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lejonbana",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Berg- och dalbanevagnar i form av lejon",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Avfallskorg"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Avfallskorg"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Avfallskorg"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "skräpkorg"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Timmerkoja"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "takdel till timmerstuga"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "takdel till timmerstuga"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "takdel till timmerstuga"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Sidoskorsten för timmerkoja"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Väggdel till timmerstuga"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Stocktåg",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Berg- och dalbanetåg med små stockformade vagnar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Stockar"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Vattenrutschbana med stockar",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Stockformade båtar som åker längs en lång vattenkanal, plaskar ner längs branta lutningar för att blöta ner passagerarna",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagerare per båt"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Slickpinne"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy-poppel"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Berg- och dalbanetåg",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Berg- och dalbanetåg med knästänger som klarar av att åka genom lodräta loopar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Kolumndel till förlorad stad"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Kolumndel till förlorad stad"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Platt takdel för förlorad stad"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Platt takdel för förlorad stad"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Platt takdel för förlorad stad"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Trappa för förlorad stad"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Trappa för förlorad stad"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Trappa för förlorad stad"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Trappa för förlorad stad"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Trappa för förlorad stad"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Väggdel för förlorad stad"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Låg buske"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "För till lyxkryssare"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Mittsektion till lyxkryssare"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Akter till lyxkryssare"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Spikklubba",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Passagerarna sitter på stolar fastsatta på en motordriven snurrande arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 passagerare per stol"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magisk matta",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "En stor flygande matta som rör sig i cirklar upp och ner fasthållen av 4 armar",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagerare"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magisk rustning"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magisk hjälm"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magisk sköld"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magiskt svärd"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharadjans palats, båge 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharadjans palats, båge 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharadjans palats, kupol"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Del till maharadjans palats"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Del till maharadjans palats"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Del till maharadjans palats"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharadjans palats, tornbas"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharadjans palats, tornkolumn"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharadjans palats, torntopp"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Ånglok med vagnar",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Ett miniatyrtåg med täckta trävagnar som dras av ett gammalt ånglok och en kolvagn",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Svansjön",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Svanformade båtar som drivs av paddlande passagerare i båtens framsäte",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagerare per båt"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Regnskogsträd 3"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Djävulsrocka",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Stora båtar som forsar fram i en vattenfylld kanal, bogseras uppåt på transportband och stänker ned åskådare vid foten av dödsföraktande stup",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagerare per båt"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marmortak"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marmortak"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marmortak"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marmortak"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras-dansare"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras-dansare"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Tält"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallows"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallows"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Marsbyggnad"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Marsföremål"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Marsföremål"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Marsföremål"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Marsföremål"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Marsföremål"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Mars-tema"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Marsmur"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marstema"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Labyrint",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Labyrinten är konstruerad av 2 meter höga häckar eller murar, där besökarna vandrar runt och inte kan komma ut förrän de hittat utgången"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Köttbullssoppstånd",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "Ett stånd som säljer kinesisk köttbullssoppa"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mekaniktema"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mekaniktema"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medeltidstema"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Medeltidstema"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Män förvandlade till sten"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Män förvandlade till sten"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Män förvandlade till sten"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Män förvandlade till sten"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Barnkarusell",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditionell roterande karusell med snidade trähästar",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Nätstaket"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Nätstaket"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Hörn, meteorkrater"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Hörn, meteorkrater"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Omvänt hörn, meteorkrater"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Vägg, meteorkrater"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Hörn med kristaller, meteorkrater"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Hörn med kristaller, meteorkrater"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyers blåa en"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "Hippiebuss",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Passagerarna tittar på en film inuti en rörelsesimulator som vrider och rör på sig med hjälp av en hydraulisk arm.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Hippiebuss"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Vild gruvattraktion i trä",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Små gruvvagnar kör på ett zick-zackspår av trä, välter farligt runt hårnålssvängar och fruktansvärda backar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Gruvvagnar",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individuella vagnar formade som gruvvagnar av trä",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Gruvbana",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Berg- och dalbanevagnar av trä med stoppade säten och säkerhetsbälten",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Gruvbarack"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Gruvbarack"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Gruvhiss",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "Passagerare åker hiss upp eller ner mellan nivåer i ett vertikalt torn",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Gruvschakt"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Gruv-tema"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Gruvtågsattraktion",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Gruvtågsberg- och dalbana - tågen rusar fram längs stålskenor som ser ut som riktiga gamla järnvägsspår",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 eller 4 passagerare per vagn"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "Ett lugnt spel minigolf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Minihelikoptrar",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Motordrivna helikopterformade vagnar kör på ett stålspår och styrs med pedaler av passagerarna",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaurusstaty"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modernt tema"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkeypuzzle träd"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Motordrivna jättejeepar med 4-hjulsdrift som kan klättra upp för branta lutningar",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passagerare per lastbil"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey-cypress"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma-tall"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monument takdel 3"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monument takdel 1"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monument takdel 4"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monument takdel 4"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monument takdel 4"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monument takdel 4"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monument takdel 2"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Månjuice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "Stånd som säljer de senaste läskedryckerna."
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaikgång"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Rörelsesimulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Passagerarna ser en film på insidan av rörelsesimulatorns kapsel medan den snurras och rör sig runt en hydraulisk arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorcykeltävling",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Passagerarna åker motorcykelformade fordon längs en enspårig berg- och dalbana",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 passagerare per cykel"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcykel"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcykel"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Musvagnar",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individuella vagnar formade som möss",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Vildmus av trä",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Små musformade vagnar kör på ett träspår, vagnarna lutar farligt över då de korsar hårnålssvängar och skarpa nedgångar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Del av jordtak"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Del av jordvägg"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Flerdimensionståg",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Vagnar med säten som klarar att kasta passagerarna huvudstupa",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mytologisk entré"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mytologiskt tema"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Amerikansk indian"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Naturligt vatten"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautiskt hörntakräcke"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisk takdel"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisk takdel"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisk takdel"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisk takdel"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautisk takdel"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautiskt takräcke"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautisk väggdel"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Kaféskylt i neon"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Kaféskylt i neon"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Kaféskylt i neon"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Kaféskylt i neon"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptunus",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Passagerarna åker i par i säten som roterar kring en rörlig staty av Neptunus.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptunus havsdelikatesser",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "Stånd som säljer Neptunus salta godsaker."
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "Hörnutfyllnad, New York"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "Entré, New York"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omvänd hörndel, New York"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omvänd hörndel, New York"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omvänd hörndel, New York"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "Omvänd hörndel, New York"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "Omvänd takdel, New York"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "Takdel, New York"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "Takdel, New York"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "Takdel, New York"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "Takdel, New York"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "Takdel, New York"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "Väggdel, New York"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "Vägg med klädstreck, New York"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "Vägg med klädstreck, New York"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "Klädstreck, New York"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "Klädstreck, New York"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Ingen ingång"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "Ingång till nordamerikansk park"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "Nordamerikanskt tema"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norsk gran"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Ektunna",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Ektunnor forsar fram längs en bred vattenkanal genom plaskande vattenfall och skummande strömmar.",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagerare per båt"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Dörr, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Takdel, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Flack hörnsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Flack hörnsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Flack väggsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Brant hörnsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Brant väggsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Brant väggsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Brant väggsluttning, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Vägg, obsidianskyskrapa"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Vägg med fönster, obsidianskyskrapa"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Kontorsblock"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oljetunna"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oljepump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Gammalt överväxt träd"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange vatten"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Orgeltema"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Pagod-tema"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Prydnadsstruktur"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Prydnadsstruktur"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Prydnadsstruktur"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Prydnadsträd"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Dekorationsträd"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Dekorationsträd"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Dekorationsträd"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Prydnadsträd"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Utsmyckad marmorvägg"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Strutsbana",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "En spiralfylld berg- och dalbana där passagerare åker i stående ställning",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Utriggarbana",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Långa kanoter som paddlas av passagerare",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passagerare per kanot"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagod"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagod"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagod"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagod"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Skylt - Pagodstil"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagod-tema"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagodtorn"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Pandaskräpkorg"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Pandatema"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Pandatåg",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Berg- och dalbanetåg med gosiga pandavagnar",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagerare per vagn"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Entrébyggnad"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Ingångsportar till parken"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Bondstuga"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Maskindrivna fordon i form av Pegasus med vagn följer en spårbana.",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Pingvin-bob",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Passagerare susar fram i en kurvig bana i pingvinformade vagnar som enbart hålls kvar i den halvcirkulära banan med hjälp av kurvornas dosering",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Tidsenlig bil"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Tidsenlig bil"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Tidsenligt kafé"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Historisk flagga"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Tidsenlig yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Tidsenliga gatlyktor"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Tidsenlig lastbil"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Tidsenlig lastbil"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Bensinstation"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Motordrivna fordon i form av pickupen",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passagerare per lastbil"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Rör"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Rörsektion"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Rörsektion"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Rörsektion"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Piratflagga"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratskepp",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Stort svängande piratskepp",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Piratskepp"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirattema"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Pirattema"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizzastånd",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "Ett stånd som säljer pizzabitar"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Osmyckad marmorvägg"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Planta"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Spelkortsmur"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Spelkortsmur"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plint"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plog"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Berg- och isbjörnsbana",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Passagerare som sitter parvis i riktning framåt eller bakåt, färdas genom tvära svängar och spiraler",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Påle"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Påle"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Pålar"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Polisjakt",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "En berg- och dalbana med loopar där passagerarna åker sittande.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Polisbil",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "60-talsinspirerade polisbilvagnar åker på träspår och vänder i speciella vändsektioner.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcornstånd",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "Ett stånd som säljer jättebägare med popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Fällgallerdörr"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Fällgallerdörr"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Gruvattraktion",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Motordrivna gruvtåg rusar längs en mjuk tvinnad spårlayout",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 eller 4 passagerare per vagn"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Förhistorisk entré"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Förhistoriskt tema"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Kringlestånd",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "Ett stånd som säljer frasiga salta kringlor"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Urhav"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Dörr, fängelse"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Stängsel, fängelse"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Omvänd del, fängelse"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Vägghörn, fängelse"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Vägghörn, fängelse"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Väggdel, fängelse"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Takdel, fängelse"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Vakttorn, fängelse"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Trappa till vakttorn, fängelse"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Trappa till vakttorn, fängelse"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Vattentorn, fängelse"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodaktyl",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Passagerarna sitter i bekväma säten under spåret och färdas genom slingriga kurvor i en förstklassig urtidsflygtur.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpa"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpformat hus"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Kö-TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racerbilar",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Motordrivna fordon i form av racerbilar",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passagerare per vagn/bil"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Velociraptor-race",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Passagerarna sitter på velociraptor-formade fordon och åker längs en enspårig bana.",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 passagerare per fordon"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racinghögtalare"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radarantenn"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Flodflottar",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Flottformade båtar som lugnt snirklar sig runt ett flodspår",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagerare per flotte"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Glade Chapplies piano"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Räcken"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Räcken"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Räcken"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Räcken"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Ledstång"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Ledstång"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Ledstång"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Regnbågsgång"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Röd hörntakdel"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Platt röd hörntakdel"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Platt kantdel för rött tegeltak"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Omvänd röd tegeltakdel"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Röd tegeltakdel 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Röd tegeltakdel 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Röd tegeltakdel 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Röd tegelväggdel 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Röd tegelväggdel 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Röd tegelväggdel 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Röd tegelväggdel 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Röd tegelväggdel 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Röd tegelväggdel 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Röd tegelväggdel 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Röd tegelväggdel 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Röd tegelväggdel 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Röd tall"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Röd tall"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Rött meteorkraterhörn"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Rött meteorkraterhörn"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Rött omvänt meteorkraterhörn"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Röd meteorkratervägg"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwoodträd"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Enspårståg i retrostil",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Enspårståg med öppna hytter",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Baklänges fallande vagn",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Stor vagn för omvänd fritt-fall",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Vändberg- och dalbana",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogeyvagnar kör på ett träspår, vänder runt på speciella vändsektioner",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Noshörning"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Noshörningsbana",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "En berg- och dalbana av kompakt stål med ett spiralformat stigningsfält och vagnar med enkla säten placerade bakom varandra",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Riggning"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "Forsränning",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Runda båtar snirklar sig längs en lång bred vattenkanal, plaskar genom vattenfall och för de nervösa passagerarna genom skummande forsar",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passagerare per båt"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "Floden Styx",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Flottliknande båtar vaggar lugnt fram längs ett flodspår.",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passagerare per flotte"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Väg"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Parkentré, glada tjugotalet"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Glada tjugotalet-tema"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Väggar, glada tjugotalet"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Kinesisk korvkiosk",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "Ett stånd som säljer kinesiska korvar"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hoods läger"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods hydda"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hoods hydda"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Entré till rock'n'roll-park"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock'n'roll-tema"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rockbands turnébuss"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Stenblocksmur"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rocktema"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rocktema 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rocktema 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Stenvagnar",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Berg- och dalbanevagnar med stentema",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Stenig gång"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Staty över utmärkelse för åkattraktion"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Servitris på rullskridskor"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Romersk amfiteater"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Romersk pelare"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Romansk pelarmur"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Hörndel, romerskt palats"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Hörndel, romerskt palats"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Hörndel, romerskt palats"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Hörndel, romerskt palats"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skarvdel, romerskt palats"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skarvdel, romerskt palats"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skarvdel, romerskt palats"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Skarvdel, romerskt palats"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Kantdel, romerskt palats"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Kantdel, romerskt palats"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Rak del, romerskt palats"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Rak del, romerskt palats"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Rak del, romerskt palats"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Rak del, romerskt palats"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Romersk staty"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Romersk staty"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Romerskt tempel"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Romansk mur"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Romansk mur"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Romerskt tema"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Tak"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-fall",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "En ring med säten dras upp till toppen av ett högt torn medan det roterar sakta, därefter faller det fritt varefter det stoppas mjukt vid botten med hjälp av magnetbromsar",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66-skylt"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Londonbuss",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Exakta kopior av gamla bussar av London-typ",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagerare per buss"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Roddbåtar",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Roddbåtar som passagerarna ror själva",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Förstörd staty"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Hörndel till landningsbana"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Kantdel till landningsbana"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Omvänd hörndel till landningsbana"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Del till landningsbana"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Del till landningsbana"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Del till landningsbana"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Vildavästernbar"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "Spårvagn från San Francisco",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Gammal spårvagn",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagerare per vagn"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Nedre hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Nedre hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Nedre böjd sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Nedre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Grund till nedre sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Övre hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Övre böjd sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Övre böjd sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Dockningsstation, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Ingång, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Utfyllnad, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Utfyllnad, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Övre omvänt hörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Mitthörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Mitthörn, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Mittdel av böjd sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Mittdel av böjd sluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Hörn till mittsluttning, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Mittvägg, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Mittvägg, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Mittvägg, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Mittvägg, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Mittvägg, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Tak, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Takspira, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Takspira, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Gång, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Gång, sandstensskyskrapa"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Hörn, sandstensgång"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Skarvsektion, sandstensgång"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Slutsektion, sandstensgång"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "T-sektion, sandstensgång"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellit"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Parabolantenn"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "Skolbuss"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "Skolbuss",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Spårvagnar som ser ut som gula skolbussar.",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagerare per vagn"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Skotsk tall"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Rullskylt"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Rullande skylt"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Skulptur"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Skulptur"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Havsdelikatessbod",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "Ett stånd som säljer friterade tentakler"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sjöflygplan"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Spiralbana",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Berg- och dalbana av kompakt stål som ringlar sig fram genom korkskruvar och spiraler",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Sjöflygplansdepå"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Sjöflygplansdepå"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Sökljus"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Säten"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Buske"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Buske"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Buskar och prydnader"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Badmintonboll"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Badmintonboll"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji-mur"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Trottoargång"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Skylt"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Skyltar och föremål till gångvägar"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silverbjörk"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Sångare med pannlock"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Observationstorn",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Roterande utsiktskabin som åker upp för ett högt torn",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passagerare"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags tema"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Vertikalt stup",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extrabreda vagnar går ner för fullständigt lodräta spår för den ultimata frittfall-upplevelsen i berg- och dalbanan",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skelett"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Sittlift",
+    "reference-description": "Open cars for chairlift",
+    "description": "Öppna vagnar för linbana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo-bilar",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Elektriskt drivna radiobilar",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 passagerare per bil"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skalle"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skalle"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Väggdel till skyskrapa"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Väggdel till skyskrapa"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Väggdel till skyskrapa"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Luftgång"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Konkav del till skyskrapa"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Konkavformat tak till skyskrapa"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Konvex del till skyskrapa"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Konvexformat tak till skyskrapa"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Lyftdel till skyskrapa"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Lyftdel till skyskrapa"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Lyftdel till skyskrapa"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Lyftdel till skyskrapa"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Lyftdel till skyskrapa"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Konkav del till metallskrapa 1"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Konvex del till metallskrapa 1"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Väggdel till metallskrapa 1"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Konkav del till metallskrapa 2"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Konkav del till metallskrapa 2"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Konvex del till metallskrapa 2"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Väggdel till metallskrapa 2"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Väggdel till metallskrapa 2"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Takdel till skyskrapa"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Topp till skyskrapa"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Hängbana",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Upphängda berg- och dalbanevagnar som gungar fritt runt hörn",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Litet vinklat mammutstaket"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Litet vinklat mammutstaket"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Litet kugghjul"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Litet kugghjul"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Litet kugghjul"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Litet kugghjul"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Liten geosfär"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Liten meteorkrater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Små enspårsvagnar",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Små enspårsvagnar med öppna sidor",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Regnskogsträd 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Regnskogsträd 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Liten röd meteorkrater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Liten högtalare"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Fabriksskorsten, undre del"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Fabriksskorsten, mittdel"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snigel"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snötäckt skylt"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snökoppar",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Passagerarna åker i sätespar som roterar runt en snöman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snö- och istema"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Snötema"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snötäckt kaukasisk tall"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snötäckt norsk gran"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snötäckt röd tall"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snötäckt röd tall"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snöboll"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snöman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Lådbilsrally",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Passagerarna åker i lådbilar längs en enkelspårig berg- och dalbana",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Stånd med kramdjur",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "Stånd som säljer söta leksaksdinosaurier."
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "Sydamerikanskt tema"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "Ingång till sydamerikansk park"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenirstånd",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "Ett stånd som säljer kramgoa leksaker och paraplyer som souvenirer"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Sojamjölkstånd",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "Ett stånd som säljer sojamjölkpaket"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Rymdkapsel"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Rymdkapsel"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Rymdsfärer"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Rymdringar",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Koncentriska svängringar där passagerarna roterar fritt i alla riktningar",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 besökare var"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Rymdraket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Lastsektion, rymdskepp"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Kommunikationssektion, rymdskepp"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Kommandobrygga, rymdskepp"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Skarvsektion, rymdskepp"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Dockningssektion, rymdskepp"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Motorsektion, rymdskepp"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Bränslesektion, rymdskepp"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Gravitationssektion, rymdskepp"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Boendesektion, rymdskepp"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Forskningssektion, rymdskepp"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Solpaneler, rymdskepp"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Solkraftssektion, rymdskepp"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Rymdstilsgångväg"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Skylt - rymdstil"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Rymdtema"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Rymdtema"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spadformat träd"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sfinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spindel"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spetsigt staket"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Snurriga vilda möss",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Musformade vagnar rusar genom snäva svängar och korta backar och snurrar runt för att disorientera passagerarna",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiralberg- och dalbana",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "En solid stålberg- och dalbana med en spiralformad uppförsbacke och vagnar med  sätena på rad",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Träbyggnad med en inomhustrappa och en utvändig spiralbana att använda tillsammans med glidmattor"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Plaskbåtar",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Högkapacitetsbåtar färdas längs en bred vattenkanal, drivs upp för lutningar av ett transportband, accelererar ner för branter för att blöta ner passagerarna med ett jätteplask",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passagerare per båt"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spöktema"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sportbilar",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Motordrivna fordon i form av sportbilar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sportstema"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Flygande Sputnik",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Passagerare ligger med ansiktet nedåt i upphängt läge och gungar fritt längs en enspårsbana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Ekorrformat träd"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Diligensbana",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Berg- och dalbanevagnar av trä med stoppade säten och säkerhetsbälten",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Rusande flock",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "En berg- och dalbana med loopar och vagnar som ser ut som en framrusande dinosaurieflock.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stå-upp-berg- och dalbana",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "En loopberg- och dalbana där passagerarna åker stående",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stående skruvbana",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "Passagerarna åker stående i breda vagnar med specialdesignade seldon när de rusar ner för mjuka backar och genom flertalet omkastningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Stjärnfruktsdrycksstånd",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "Ett stånd som säljer stjärnfruktsdrycker"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Staty"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Staty"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Staty"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Frihetsgudinnan"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Ånglok",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniångtåg som består av en kopia av ånglokomotiv som mjukt drar de öppna trävagnarna",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagerare per fordon"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Ångtåg med täckta vagnar",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniångtåg som består av en kopia av ånglokomotiv  som mjukt drar trävagnarna med tygtak",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passagerare per fordon"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Ångande avlopp"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Stålblock"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Stålblock"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Stålstaket"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Stålgaller"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Stålmur"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stenålderstempel"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stenbänk"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stenblock"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Trappbas till stenskrapa"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Väggdel till stenskrapa"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Väggdel till stenskrapa"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Väggdel till stenskrapa"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Väggdel till stenskrapa"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Väggdel till stenskrapa"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stenmur"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stenmur"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stenmur"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stenmur"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Pall"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Pallar"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Strömlinjetåg på enspårsskena",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Högkapacitets enpårståg med vagnar med strömlinjeformad front och bak",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 eller 10 passagerare per vagn"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Baguettestånd",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "Ett stånd som säljer färska baguetter"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Undervattensattraktion",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Passagerarna åker i en nedsänkt ubåt genom en undervattensbana",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passagerare per ubåt"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa-stånd",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "Ett stånd som säljer Koreanska Sujeonggwadrinkar"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Sommartider"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Solglasögonstånd",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "Ett stånd som säljer alla sorters solglasögon"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sjunket skepp"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Stor processor till superdator"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Monitor till superdator"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Liten processor till superdator"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Stödstruktur"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Stödstruktur"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Stödstruktur"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfingbana",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Passagerarna står upp i breda vagnar som är utrustade med specialbälten och färdas utför branta stup och genom avsnitt med tvära omkastningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Upphängda enrälståg",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Högkapacitetsvagnar till bana av enspårstyp",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passagerare per vagn"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Sjöflygplan",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Hängande berg- och dalbanetåg med vagnar som svingar fritt i sidled i kurvorna.",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Upphängda svängflygplansvagnar",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Tåg till upphängd berg- och dalbana som består av flygplansformade vagnar som kan svänga fritt då tåget kör runt svängarna",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Upphängda svängande vagnar",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Tåg till upphängd berg- och dalbana som består av vagnar som kan svänga fritt när tåget kör runt svängarna",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Basdel för hängbro"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Baskopplingsdel för hängbro"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Kabelstation för hängbro"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Basmellandel för hängbro"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Startsida för hängbro 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Startsida för hängbro 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Tornsida för hängbro 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Tornsida för hängbro 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Träskbunke"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Träskgegga"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Träskplanta"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Träskplanta"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Träskplanta"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Svanar",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Svanformad båt, drivs med pedaler som passagerarna i framsätet trampar på",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passagerare per båt"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Gungande vagnar",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Små vagnar som gungar under spåret",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Gungande golvlösa vagnar",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Tåg till upphängd berg- och dalbana som består av linbanekorgar som kan svänga fritt när tåget kör runt svängarna",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Svängande skeppet",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Skeppet är fäst i en arm med en motvikt i andra ändan och svänger runt ett helt varv",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passagerare"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Svärd i sten"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-shirtstånd",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "Ett stånd som säljer souvenir T-shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV-tågbana",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Berg- och dalbanevagnar accelererar snabbt ut från stationen med hjälp av induktionsmotorer och susar genom avsnitt med tvära omkastningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT-tunnor"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT-lådor"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT-detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT-trave"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Hög lykta"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Hög lykta"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Högt trästaket"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Mål"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Asfalterad gångväg"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Värdshus"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Abstrakt tema"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee-pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleportör",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Gäster transporteras upp eller ned en nivå.",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passagerare"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Trasig tempelväggdel med huvud"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Tempeltakdel"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Tempelväggdel"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Tempelväggdel med huvud"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Hyreshus"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennisboll"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnätsvägg"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennisnätsvägg"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tält"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Indiantält"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termitstack"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Radhus"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terrakottaarmé"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Tidsmaskin",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Passagerarna sitter i en specialdesignad sfär och upplever en illusion av att resa i tiden.",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 per besökare"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Giftsvamp"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Kälkvagnar",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Kälkformade berg- och dalbanevagnar med sätena på rad",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Marknadsstånd med äppleklubbor",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "Ett stånd som säljer äpplen med klibbigt knäcköverdrag"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Äppelklubba",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "Ett äppleformat stånd som säljer äppelklubbor med knäcköverdrag"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Ordinära toaletter i en förtillverkad betongbyggnad"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toaletter i ett blockhus"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toaletter",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Ordinära toaletter i en förtillverkad betongbyggnad"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Kulspruta",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Passagerarna åker i par i säten som roterar kring en stor modellkulspruta.",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passagerare åker i en gondol upphängd i stora roterande armar, roterar framåt och bakåt helt vilt",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totempåle"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Rådhus"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Underlandstema"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant-bilar",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Berg- och dalbanevagnar av Trabant-typ",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Spårkurva"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Trasigt spår"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Spårände"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Spårförgrening"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Rak spårdel"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Traktor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Vanlig parkentré"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Gruvkärror",
+    "reference-description": "Old-timer replica trams",
+    "description": "Gammaldags gruvkärror",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passagerare per vagn"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Husbil"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Skattkista"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Skattkista"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Skattkista"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passagerarna åker i en vagn baserad på ett medeltidsvapen, som hänger i två stora balkar.",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passagerare"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Träd"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Träd"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratopsbilar",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Triceratops-formade radiobilar som förarna kan stångas med.",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per bil"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobitbåtar",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobit-formade vagnar åker på berg- och dalbanespår som tillåter snäva kurvor och djupa fall ned till lugnare vattenfyllda sektioner.",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passagerare per båt"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor-väggdel för nedre burspråk"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor-väggdel för nedre våning 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor-väggdel för nedre våning 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor-väggdel för nedre våning 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor-väggdel för nedre våning 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor-väggdel för nedre våning 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor-väggdel för nedre våning 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor-väggdel för nedre våning 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor-väggdel för nedre våning 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor-väggdel för nedre våning 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor-väggdel för nedre våning 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor-väggdel för nedre våning 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor-väggdel för nedre våning 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor-väggdel för nedre våning 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor-takdel 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor-takdel 1 förlängning"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor-takdel 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor-takdel 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor-takdel 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor-väggdel 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor-väggdel 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor-väggdel 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor-väggdel 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Sköldpaddsbana",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Små cirkelformade jollar drivs av en centralt monterad motor som kontrolleras av passagerare",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passagerare per båt"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Passagerarna åker i parsäten som roterar runt ändarna på tre långa roterande armar",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passagerare"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Spinnvagnar",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Berg- och dalbanevagnar som klarar hjärtlinjeskruvar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Spinnvagnar, startar baklänges",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Berg- och dalbanevagnar som klarar hjärtlinjeskruvar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twistberg- och dalbana",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Ett brett berg- och dalbanetåg som glider längs mjuka stålskenor, åker genom en blandning av omvändningar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "Kraschat ufo"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Noshörningsstaty"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Stadstema"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Stadstema"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyria"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyria"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyria",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Extra breda vagnar faller nedför ett fullkomligt lodrätt spår och ger passagerarna den ultimata fritt fall-upplevelsen.",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Horisontell 3D-skylt"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Inverterad lodrätt skyttel",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Passagerarna sitter i vagnar upphängda under spåret, dras baklänges uppåt längs ett lodrätt spår och släpps mot en loop och snos runt tajta inversioner",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Träd med lianer"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Veteranbilar",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Motordrivna fordon i form av veteranbilar som följer en spårbaserad bana",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginiavirveln",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Runda vagnar snurrar runt medan de åker längs ett zick-zack-spår av trä",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Vulkan"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Vulkan med små träd"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss gullregn"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Vagn"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Vagn"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Vagnshjul"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Mur"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Sköldbåge"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Väggar och tak"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Valnöt"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington-staty"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Geting"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Vattentema"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Vattenstråle"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Vattenvirvel"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Vattentrehjulingar",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Trehjuling med stora flytande hjul, drivs genom trampor",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passagerare per trehjuling"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Vattentema"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Vattenfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Flätverk, tak"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Flätverk, tak"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Flätverk, tak"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Flätverk, vägg"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Vapen"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Tårpil"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Hjul"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whiskytunna"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whiskytunnor"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "Vit löpare"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "Vit kung"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "Vit riddare"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "Vit schackpjäs"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "Vit poppel"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "Vit drottning"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "Vitt torn"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Vilda västern-tema"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Vilda västern-tema"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Vindformat konkavt takhörn"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Vindformat konkavt vägghörn"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Vindformat konkavt vägghörn"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Vindformat konvext takhörn"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Vindformat konvext vägghörn"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Vindformat konvext vägghörn"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Vindformad golvdel"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Vindformad golvdel"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Vindformad bergsfot"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Vindformad bergsfot"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Vindformat mittparti av berg"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Vindformat mittparti av berg"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Vindformat mittparti av berg"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Vindformat mittparti av berg"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Vindformad bergstopp"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Vindformad bergstopp"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Vindformad platt takdel"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Vindformad platt takdel"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Vindformad platt takdel"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Vindformad väggdel"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Väderkvarn"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Fönster"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Fönster"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Fönster"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Häxköket",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "Ett stånd som säljer en tjock spadliknande soppa"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Häxor runt kittel"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Larvbana",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Berg- och dalbana med larvformade vagnar",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passagerare per vagn"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Underlandstema"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton-soppstånd",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "Ett stånd som säljer Wonton-soppa"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Trästaket med slingerväxter"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Trästaket med slingerväxter"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Trästaket med döda rankor"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Trästaket med döda rankor"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Trästaket med döda rankor"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Trästaket med köttätande växt"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Träblock"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Trävagn"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Trästaket"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Trästängsel"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Trägång"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Stolpstaket"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Stolpstaket"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Stolpstaket"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Stolpstaket"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Tåg till träberg- och dalbana",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Tåg till träberg- och dalbana med stoppade säten och knästång",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Träberg- och dalbanetåg (6-sitsiga vagnar)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Tåg till träberg- och dalbana med stoppade säten och en knästång",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Berg- och dalbana (6-sitsiga trävagnar, kör baklänges)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Tåg till träberg- och dalbana stoppade sätten och knästång, åker baklänges",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passagerare per vagn"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Sidofriktionsvagnar av trä",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Grundvagnar till sidofriktionsberg- och dalbanan",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Träskylt"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Trävägg"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Trävägg"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Trävägg"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Trävägg"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Kraschat sjöflygplan"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "1 taxibana",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "En gigantisk berg- och dalbana av stål som färdas på och nedför över 90 meter höga kullar",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passagerare per vagn"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Idegran"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeusstaty"
+  }
+}

--- a/objects/tr-TR.json
+++ b/objects/tr-TR.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "'Goliath' Sign"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "'Medusa' Sign"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'Nitro' Sign"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "'Texas Giant' Sign"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D Cinema",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "reference-capacity": "20 guests",
+    "capacity": "20 guests"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D Sign"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "4-across Inverted Roller Coaster Trains",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "Suspended trains in which riders sit in rows",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "6-seater Bobsleighs",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "Bobsleighs with three seating rows, with room for two people on each",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "Abstract Themeing"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "Acid Green Water"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "Air Powered Vertical Coaster Trains",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "Air-powered launched roller coaster trains",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "Aleppo Pine Tree"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "Alligator Shaped Tree"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "American Football"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "American Football Helmet"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "American Style Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "Arizona Cypress Tree"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "Articulated Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "Roller coaster trains with short single-row cars and open fronts",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "Ash Footpath"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "Aspen Tree"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "Automobile Cars",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "Roller coaster cars in the shape of automobiles",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "Badminton Racket"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "Balloon Stall",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "A souvenir stall selling helium-filled balloons"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "Bank"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "Barrel"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "Ana blok"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "Ana blok"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "Ana blok"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "Ana blok"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "Beef Noodles Stall",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "A stall selling Chinese style beef noodles"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "Bench"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "Bicycles",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 rider per bicycle"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "Black Bishop"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "Black King"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "Black Knight"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "Black Pawn"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "Black Poplar Tree"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "Black Queen"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "Black Rook"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "Block"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "Bobsleigh Trains",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "Bone"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "Bone Fence"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "Bones"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "Brick Wall"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "Broken Wheel"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "Brown Tarmac Footpath"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "Building"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "Bulrushes"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "Bumper Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "Burger Bar",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "A burger-shaped building selling burgers"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "Bush"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "Butterfly"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "Cabbage Tree"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "Camperdown Elm Tree"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "Canary Palm Tree"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "Candy"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "Candy Stick"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "Candy Tree"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "Şeker dünyası tarzı"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "Candyfloss Stall",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "A candyfloss shaped building selling pink candyfloss"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "Cannon"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "Cannon Balls"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "Canvas Roof"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "Cash Machine",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "Castle Tower"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "Caucasian Fir Tree"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "Cauldron"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "Cedar of Lebanon Tree"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "Chairlift Cars",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "Checkerboard Block"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "Cheshire Cats",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "Powered cat-shaped vehicles",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2 passengers per cat"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "Chicken Nuggets Stall",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "A stall selling fried chicken nuggets"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "Chinese Cedar Tree"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "Chip Shop",
+    "reference-description": "A hut selling chips",
+    "description": "A hut selling chips"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "Chips Stall",
+    "reference-description": "A stall selling chips",
+    "description": "A stall selling chips"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "Chocolate Bar"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "Circus",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "Circus animal show inside a big-top tent",
+    "reference-capacity": "30 guests",
+    "capacity": "30 guests"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "Classical Style Sign"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "Classical/Roman Themeing"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "Cleopatra's Needle"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "Clock"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "Club Shaped Tree"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "Coaster Boats",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "Boat-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "Coffee Shop",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "An art-deco style shop selling cups of coffee"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "Cogwheel"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "Cola Candy"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "Colonnade"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "Common Juniper Tree"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "Common Oak Tree"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "Common Yew Tree"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "Compact Inverted Coaster Trains",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "Riders sit in pairs of seats suspended beneath the track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "Condor Trains",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "Conifer Hedge"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "Cookie Shop",
+    "reference-description": "A stall selling giant cookies",
+    "description": "A stall selling giant cookies"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "Corkscrew Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "Roller coaster trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "Corrugated Steel Base"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "Corrugated Steel Roof"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "Corrugated Steel Wall"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "Corsican Pine Tree"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "Crazy Paving Footpath"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "Creepy Themeing"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "Crooked House",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "Cupid Fountains"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "Curved Block"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "Curved Roof"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "Curved Wall"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "Özel müzik 1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "Özel müzik 2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "Daisy Lamp"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "Dead Tree"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "Diamond Shaped Tree"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "Dinghies",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 passengers per dinghy"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "Dinosaur"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "Dirt Footpath"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "Dodgems",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "Riders bump into each other in self-drive electric dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "Çarpışan araba tarzı"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "Dolphin Fountain"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "Dolphins Statue"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "Doorway"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "Double-deck Cabin",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "Twin-deck rotating observation cabin",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "Doughnut Shop",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "A stall selling ring-shaped doughnuts"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "Drinks Stall",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "A can-shaped stall selling fizzy drinks"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "Egyptian Column"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "Egyptian Statue"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "Egyptian Style Sign"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "Egyptian Themeing"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "Egyptian Wall"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "Mısırlı tarzı"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "Elephant Fountain"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "Enterprise",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "European Larch Tree"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "Face-off Cars",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "Atlıkarınca tarzı"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "Fantazi tarzı"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "Fence"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "Fences and Walls"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "Ferris Wheel",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "Rotating big wheel with open chairs",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "First Aid Room",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "A place for sick guests to go for faster recovery"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "Flames"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "Floorless Twister Trains",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "Flower"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "Flying Roller Coaster Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "Flying Saucers",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "Football"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "Fountain"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "Four-seater Cars",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "Fried Chicken Stall",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "A stall selling tubs of fried chicken"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "Fried Rice Noodles Stall",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "A stall selling Chinese style fried rice noodles"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "Fruit Drop"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "Fruit Tree"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "Fruity Ices Stall",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "A themed stall selling fruity ice creams"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "Funnel Cake Shop",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "A stall selling funnel cakes"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "Gallows"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "Gardens"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "General Store"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "Sakin tarz"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "Geometric Fountain"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "Geometric Sculpture"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "Ghost Train Cars",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "Powered monster-shaped cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "Giant Beanstalk"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "Giant Candy Themeing"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "Giant Carrot"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "Giant Fern"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "Giant Garden Themeing"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "Giant Grass"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "Giant Pumpkin"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "Giant Snowflake"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "Giga Coaster Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "Glass Roof"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "Glass Wall"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "Go-Karts",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "Self-drive petrol-engined go-karts",
+    "reference-capacity": "single-seater",
+    "capacity": "single-seater"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "Golden Hinoki Cypress Tree"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "Gong"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "Grave Stone"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "Graveyard Monument"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "Green Tarmac Footpath"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "Green Water"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "Hat Stall",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "A souvenir stall selling large foam hats"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "Haunted House",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "Large themed building containing scary corridors and spooky rooms",
+    "reference-capacity": "15 guests",
+    "capacity": "15 guests"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "Haunted Mansion Cars",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "Small powered cars that run on a ghost train track",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "Heart Shaped Tree"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "Hedge"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "Hiba Tree"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "Honey Locust Tree"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "Korku tarzı"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "Horse Statue"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "Horseman Statue"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "Horses",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "Single cars shaped like a horse",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 riders per horse"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "Hot Chocolate Stall",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "A stall selling hot chocolate drinks"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "Hot Dog Stall",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "A stall selling hot dogs in rolls"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "House"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "Hyper-Twister Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "Hyper-Twister Trains (wide cars)",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "Hypercoaster Trains",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "Comfortable trains with only lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "Ice Cream Cone Stall",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "A stall selling ice cream cones"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "Ice Cube"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "Ice Palace"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "Buz tarzı"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "Iced Tea Stall",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "A stall selling iced tea drinks"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "Igloo"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "Igloo Roof"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "Impulse Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "Incense Cedar Tree"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "Information Kiosk",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "A stall where guests can obtain park maps and purchase umbrellas"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "Italian Cypress Tree"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "Jelly Baby"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "Jellybean"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "Jellybean Wall"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "Jet Skis",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "Single-seater jet skis which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "Jumping Fountains"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "Jumping Snowballs"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "Jungle Fence"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "Jungle Style Sign"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "Jungle Themeing"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "Cengel tarzı"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "Junk"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "Jurassic Style Sign"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "Jurassic Themeing"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "Dinozor tarzı"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "LIM Launched Roller Coaster Trains",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "Roller coaster trains that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "Ladybird Trains",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "Roller coaster trains with small ladybird-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "Lamp"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "Launched Freefall Car",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "Lawson Cypress Tree"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "Lay-down Cars",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "Lay-down Roller Coaster Trains",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "Lemonade Stall",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "A stall selling refreshing lemonade drinks"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "Lift Cabin",
+    "reference-description": "Steel lift cabin",
+    "description": "Steel lift cabin",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "Lily"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "Litter Bin"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "Log Trains",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "Roller coaster trains with small log-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "Logs"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "Logs",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "Log-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "Lollypop"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "Lombardy Poplar Tree"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "Looping Roller Coaster Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "Magic Carpet",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "Magnolia Tree"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "Marshmallow"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "Martian Building"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "Martian Object"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "Martian Themeing"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "Martian Wall"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "Marslı tarzı"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "Maze",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "Meatball Soup Stall",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "A stall selling Chinese style meatball soup"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "Mechanical Themeing"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "Mekanik tarz"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "Medieval Themeing"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "Ortaçağ tarzı"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "Merry-Go-Round",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "Traditional rotating carousel with carved wooden horses",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "Mesh Fence"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "Meyer's Blue Juniper Tree"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "Cars shaped like an old mine cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "Mine Cars",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "Individual cars shaped like wooden mine trucks",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "Mine Hut"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "Mine Shaft"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "Mine Themeing"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "Mine train-themed roller coaster trains",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "Mini Golf",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "A gentle game of miniature golf",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "Mini Helicopters",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "Mint"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "Modern tarz"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "Monkey-Puzzle Tree"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "Monster Trucks",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 passengers per truck"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "Monterey Cypress Tree"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "Montezuma Pine Tree"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "Motion Simulator",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "Motorbikes",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "Single cars shaped like a motorbike",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 riders per bike"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "Individual cars shaped like mice",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "Mouse Cars",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "Individual cars shaped like a mouse",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "Multi-Dimension Coaster Trains",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "Cars with seats capable of pitching the riders head-over-heels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "Natural Water"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "Giriş kulübesi yok"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "Norway Spruce Tree"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "Office Block"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "Orange Water"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "Kilise tarzı"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "Oryantal tarzı"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "Ornamental Structure"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "Ornamental Tree"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "Pagoda Style Sign"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "Pagoda Themeing"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "Park Entrance Building"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "Park Entrance Gates"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "Petrol station"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "Pickup Trucks",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "Powered vehicles in the shape of pickup trucks",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 passenger per truck"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "Pipe Section"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "Pirate Flag"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship",
+    "reference-description": "Large swinging pirate ship",
+    "description": "Large swinging pirate ship",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "Pirate Ship"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "Pirates Themeing"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "Korsan tarzı"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "Pizza Stall",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "A stall selling portions of pizza"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "Plant"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "Playing Card Wall"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "Plinth"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "Pole"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "Poles"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "Popcorn Stall",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "A stall selling giant buckets of popcorn"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "Portcullis Door"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "Post"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "Powered Mine Trains",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "Mine train-themed roller coaster trains that propel themselves",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 passengers per car"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "Pretzel Stall",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "A stall selling crispy pretzels"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "Pumpkin"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "Pumpkin House"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "Pyramid"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "Queue Line TV"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "Racing Cars",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "Powered vehicles in the shape of racing cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "Rafts",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "Raft-shaped boats built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "Ragtime tarzı"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "Railings"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "Red Fir Tree"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "Retro-style Monorail Trains",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "Monorail trains with open cabins",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "Reverse Freefall Car",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "Reverser Cars",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Bogied cars capable of turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "Rigging"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "River Rapids Boats",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "Road"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "Roast Sausage Stall",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "A stall selling Chinese style roast sausage"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "Rock Wall"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "Rock tarzı"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "Rock tarzı 2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "Rock tarzı 3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "Rocket Cars",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "Roller coaster cars themed to look like rockets",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "Roman Colosseum"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "Roman Column"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "Roman Column Wall"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "Roman Statue"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "Roman Temple"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "Roman Wall"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "Roma tarzi"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "Roof"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "Çatı"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "Rowing Boats",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "Rowing boats which passengers row themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "Ruined Statue"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "Saloon"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "Satellite"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "Scots Pine Tree"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "Scrolling Sign"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "Sculpture"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "Sea Food Stall",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "A stall selling fried tentacles"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "Seats"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "Shrub"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "Shrubs and Ornaments"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "Shuttlecock"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "Sign"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "Signs and Items for Footpaths"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "Silver Birch Tree"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "Single-deck Cabin",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "Single-deck rotating observation cabin",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "Six Flags Themeing"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "Six-seater Twister Trains",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "Skeleton"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "Ski-lift Chairs",
+    "reference-description": "Open cars for chairlift",
+    "description": "Open cars for chairlift",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "Skull"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "Small Cogwheel"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "Small Monorail Cars",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "Small monorail cars with open sides",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "Snail"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "Snow Covered Sign"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "Snow Cups",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "Snow and Ice Themeing"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "Kar tarzı"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "Snow-covered Caucasian Fir Tree"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "Snow-covered Norway Spruce Tree"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "Snow-covered Red Fir Tree"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "Snowball"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "Snowman"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "Soap Boxes",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "Single cars shaped like a soap box",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 riders per car"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "Souvenir Stall",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "A stall selling souvenir cuddly toys and umbrellas"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "Soybean Milk Stall",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "A stall selling cartons of soybean milk"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "Space Capsule"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "Space Rings",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "Space Rocket"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "Space Style Footpath"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "Space Style Sign"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "Space Themeing"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "Uzay tarzı"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "Spade Shaped Tree"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "Sphinx"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "Spider"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "Spinning Mouse Cars",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "Spiral Roller Coaster Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "Compact roller coaster trains with cars with in-line seating",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "Spiral Slide",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "Splash Boats",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "Large capacity boats, built for water tracks with very steep drops",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 passengers per boat"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "Spooky Themeing"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "Sports Cars",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "Powered vehicles in the shape of sports cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "Sports Themeing"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "Squirrel Shaped Tree"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "Stand-up Roller Coaster Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "Roller coaster trains in which the riders ride in a standing position",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "Stand-up Twister Trains",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "A train with shoulder restraints, in which the riders stand up",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "Star Fruit Drink Stall",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "A stall selling star fruit drinks"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "Statue"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "Steam Trains with Covered Cars",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "Steel Block"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "Steel Fence"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "Steel Latticework"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "Steel Wall"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "Stone Bench"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "Stone Block"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "Stone Wall"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "Streamlined Monorail Trains",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "Large capacity monorail trains with streamlined front and rear cars",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5 or 10 passengers per car"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "Sub Sandwich Stall",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "A stall selling fresh sub sandwiches"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "Submarines",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "Riders ride in a submerged submarine through an underwater course",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 passengers per submarine"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa Stall",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "A stall selling Korean style Sujeonggwa drinks"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "Yaz tarzı"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "Sunglasses Stall",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "A stall selling all kinds of sunglasses"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "Support Structure"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "Suspended Monorail Trains",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "Large capacity monorail train cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "Suspended Swinging Aeroplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "Suspended Swinging Cars",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "Swamp Goo"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "Swans",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "Swinging Cars",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "Small cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "Swinging Floorless Cars",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "Swinging Inverter Ship",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T-Shirt Stall",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "A stall selling souvenir T-Shirts"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "Tall Wooden Fence"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "Target"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "Tarmac Footpath"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "Tavern"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "Tekno tarzı"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "Tenement"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "Tennis Ball"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "Tennis Net Wall"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "Tent"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "Tepee"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "Terraced House"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "Toadstool"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "Toboggan Cars",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "Toffee Apple Stall",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "An apple-shaped stall selling toffee apples on a stick"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "Toilets housed in a log cabin style building"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "Toilets",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "Basic toilets housed in a prefabricated concrete building"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "Top Spin",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "Totem Pole"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "Town Hall"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "Oyuncak dünyası tarzı"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "Traditional Park Entrance"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "Trams",
+    "reference-description": "Old-timer replica trams",
+    "description": "Old-timer replica trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "Tree"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "Trees"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "Twist",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "Twister Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "Roller coaster cars capable of heartline twists",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "Twister Cars (starting reversed)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "Twister Trains",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "Spacious trains with shoulder restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "Unicorn Statue"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "Urban Themeing"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "Şehir tarzı"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "Vertical 3D Sign"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "Vertical Shuttle Cars",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "Vintage Cars",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "Powered vehicles in the shape of vintage cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "Virginia Reel Tubs",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "Circular cars that spin around as they travel along the track",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "Volcano"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "Voss's Laburnam Tree"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "Wagon"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "Wall"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "Wall Arch"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Geçitli duvar"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "Walls and Roofs"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "Walnut Tree"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "Wasp"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "Water Feature Themeing"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "Water Jet"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "Water Spout"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "Water Tricycles",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "Pedal-tricycle with large buoyant wheels",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 passengers per tricycle"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "Su tarzı"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "Waterfall"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "Weeping Willow Tree"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "Wheels"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "White Bishop"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "White King"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "White Knight"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "White Pawn"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "White Poplar Tree"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "White Queen"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "White Rook"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "Wild West Themeing"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "Vahşi batı tarzı"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "Window"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "Wonderland Themeing"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "Wonton Soup Stall",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "A stall selling Wonton Soup"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "Wooden Block"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "Wooden Fence"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "Wooden Fence Wall"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "Wooden Post Fence"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "Wooden Post Wall"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "Wooden Roller Coaster Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "Wooden Roller Coaster Trains (6 seater)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "Wooden Side-Friction Cars",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "Basic cars for the Side-Friction Roller Coaster",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "Wooden Sign"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "Wooden Wall"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/zh-CN.json
+++ b/objects/zh-CN.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "「葛利亚」招牌"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "「美杜莎」招牌"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'「尼特若」招牌"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "德州巨大招牌"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920s Racing Cars",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "1920s race car themed go-karts",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950s Car"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950年代火箭游乐设施",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "倒悬的云霄飞车被加速推出车站到垂直轨道顶端,再翻转回头到车站的另一端垂直轨道顶端",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每车限乘4人"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D立体电影院",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "电影院是一座由测地线球体形状组成的建筑物内部播放３Ｄ立体影片",
+    "reference-capacity": "20 guests",
+    "capacity": "２０位客人"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D立体招牌"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D立体招牌"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "倒转式过山车",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "游客坐在悬吊在轨道下的座椅上，当快速通过大型旋转回圈，令人感觉有俯冲下坠感。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "飞行旋转",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "乘客在大型雪橇车内以几何率在半圆形轨道上弯曲冲锋陷阵",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "摘要"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "现代抽象主题区"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "有酸味的绿水"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "Active Volcanic Vent"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "印度成象"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "成人期的熊猫"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "非洲公园入口"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "气压式垂直过山车",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "在令人振奋的气压式发射後,列车冲向垂直轨道,并垂直下冲到另一侧再回到车站",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "Airship Themed Monorail Trains",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 位乘客/每个车厢"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "松树"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "Alien Historical Structures"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "Alien Plant"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "Alien Skylight Large"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "Alien Skylight Small"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "Alien Structure Large"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "Alien Structure Small"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "Alien Tower Bottom"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "Alien Tower Middle"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "Alien Tower Top"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "Alien Tree"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "短吻鳄形的树"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "美式足球"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "美式足球"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "美式橄榄球头盔"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "美国风格蒸汽火车",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "微型蒸汽火车是由酷似蒸汽火车及媒车拖拉具有布织车顶的木制四轮马车所组成的。",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6位乘客/每辆马车"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "蛇游乐设施",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "有简单护膝装置的宽敞列车",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "每辆车限乘6人"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "Animal cooking on Spit"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "活跃的营火"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "Animatronic All Seeing Eye"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "Animatronic Argonaut"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "Animatronic Astronaut"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "Animatronic Caveman lighting Fire"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "Animatronic Chained Maiden"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "Animatronic Clansman"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "Animatronic Dark Knight"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "Animatronic Dragonflies"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "Animatronic Eagle on Cage"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "Animatronic Evil Alien"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "Animatronic Fireman"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "Animatronic Firing Cannon"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "Animatronic Gangster"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "Animatronic Good Alien"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "Animatronic Knight"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "Animatronic Medusa"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "Animatronic Police Officer"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "Animatronic Robin Hood"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "Animatronic Skeletal Army"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "Animatronic Space Ranger"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "Animatronic Stegosaurus"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "Animatronic T-Rex"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "Animatronic Triceratops"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "Animatronic Waving King"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "Animatronic attacking Scorpion"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "Animatronic flapping Pterodactyl"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "雌性羚羊"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "雄性羚羊"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "成对羚羊"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "Anti-Gravity LCD Billboard"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "Archery Target"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "亚利桑那柏树"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "Art Deco Corner Section"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "Art Deco Corner with Railings"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "Art Deco Corner with Windows"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "Art Deco Food Stall",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "A stall selling noodles and fresh Lemonade"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "Art Deco Inverted Corner Section"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "Art Deco Roof Section"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "Art Deco Top Corner Section"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "Art Deco Top Section"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "Art Deco Wall Section"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "Art Deco Wall with Door"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "Art Deco Wall with Railings"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "Art Deco Wall with Windows"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "绞接式的过山车",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "过山车以短截单排列车及前面开放型的",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每个车厢"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "梣木步道"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "Ash Tree with Nymphs"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "亚洲的铜锣"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "山杨树"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "Atlas Statue"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "澳大拉西亚公园入口"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "冲锋汽车",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "过山车车辆的外形是汽车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "B-Movie Giant Octopus"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "B-Movie Giant Spider"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "B-Movie Giant Spider Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "印度幼象"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "幼儿期的熊猫"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "羽毛球拍"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "羽球拍"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "球形灯笼"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "球形灯笼"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "气球店",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "一家纪念品店卖充氦气的气球"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "竹子林"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "竹架"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "竹顶"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "竹顶"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "竹顶"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "Bamboo Shoots"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "竹墙"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "Band Member"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "银行"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "Barnstorming Trains",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "垒包"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "垒包"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "垒包"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "垒包"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "Battering Ram Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "牛肉面 店",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "一家卖中式牛肉面的店"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "长椅"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "长椅"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "长椅"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "Benches"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "孟加拉虎云霄飞车",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "云霄飞车能以中心作旋转",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "空中脚踏车",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "特殊的脚踏车在单轨铁路轨道上运行,由乘客自行脚踏前进",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 位乘客/每辆脚踏车"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "英国议会古钟摆"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "大型地质"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "Biker"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "黑主教"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "伦敦出租车游乐设施",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "以伦敦出租车为外型具动力的载运工具",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每辆车限乘2人"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "Black Death Trains",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "黑棋国王"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "黑棋骑士"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "黑棋兵"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "黯淡白杨树"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "黑棋皇后"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "黑棋车"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "Blob from Outer Space",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 passengers"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "积木"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "积木"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "雪橇过山车",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "以雪橇成型的车子，在弯曲的斜坡铁轨上仅由曲率导引向下俯冲",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每个车厢"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "Boiling Pot"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "骨头"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "骨头栅栏"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "骨头"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "回旋标"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "回力式游乐设施",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "在一阵令人兴奋的高速气压式堆进器激活,列车以高速冲向垂直顶端轨道,接着再垂直下坠到车站的另一端再回到车站",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "?每辆车限乘2人"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "砖墙"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "砖墙"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "砖墙"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "英国邮筒"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "英国电话亭"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "破轮子"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "棕色柏油碎石步道"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "Bubbling Tarpit"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "Bucket"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "建筑物"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "建筑物"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "子弹列车",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "以日本的子弹列车为主题车辆的云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "香蒲"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "碰碰船",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "由乘客在有动力装制的小型圆型小船内操控中心马达",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 位乘客/每艘船"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "Buoy"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "汉堡店",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "汉堡形状的建筑物在卖汉堡"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "树丛"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "蝴蝶"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "小屋门廊"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "小屋门廊"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋屋顶一片"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋屋顶一片"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "小屋屋顶一片"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "小屋顶部"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "小屋墙面一片"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "甘蓝树"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "榆树"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "加那利岛棕榈树"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "糖果棒"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "糖果树"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "糖果树"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "糖果树"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "糖果风格"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "棉花糖店",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "一间棉花糖式的建筑物在卖粉红色棉色糖"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "大炮"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "大炮"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "炮弹"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "独木舟",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "长型的独木舟由游客自行划桨前进",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2位乘客/每个独木舟"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "帆布屋顶"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "帆布帐篷"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "推车把手"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "提款机",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "一台提款机可以提供游客钱花光时可以提领现金"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "城堡 (灰色)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "Castle Corner Piece"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "Castle Entrance"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "Castle Inverted Corner"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "Castle Portcullis"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "Castle Ramparts"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "Castle Ramparts Corner"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "Castle Ramparts Inverted Corner"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "城楼"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "城楼"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔楼"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔楼"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔楼"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔楼"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "Castle Tower Corner Piece"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "Castle Tower Cross Piece"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "Castle Tower Straight Piece"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "Castle Tower T Piece"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "城堡墙"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "Castle Wall"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "牛头盖骨"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "高加索冷杉树"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "大汽锅"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "Cave Entrance"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "Caveman Cars",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "Self-drive go-karts in Stone Age style",
+    "reference-capacity": "Single-seater",
+    "capacity": "Single-seater"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "黎巴嫩西洋杉"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "Cerberus Trains",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "升降机列车",
+    "reference-description": "Open cars for chairlift",
+    "description": "开放列车让游客上下山使用",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "西洋跳棋棋盘"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "笑笑?",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "猫咪样式的动力车-循着固定轨道进行",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "2位客人/辆"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "香鸡肉珍品店",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "一家卖炸鸡肉的店"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "中国雪松"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "中国吉龙"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "东方祥龙游乐设施",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "自助式电动碰碰车",
+    "reference-capacity": "1 person per car",
+    "capacity": "每辆车限乘1人"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "中国舢舨游乐设施",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "船是以在相对尾端的平衡力距以360度摇摆行进",
+    "reference-capacity": "12 passengers",
+    "capacity": "限乘12人"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "薯片店",
+    "reference-description": "A hut selling chips",
+    "description": "一间卖薯片的小屋子"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "炸薯条店",
+    "reference-description": "A stall selling chips",
+    "description": "一家卖炸薯条的店"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "巧克力条"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "Circuit FootPath"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "马戏团",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "马戏团的动物在大帐篷里表演节目",
+    "reference-capacity": "30 guests",
+    "capacity": "30位客人"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "经典 / 罗马"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "古典风格 招牌"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "古典/古罗马主题区"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "古埃及艳后针柱"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "Climbing Vine Tree"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "时钟"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "梅花形的树"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "飞船",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "船形式的过山车车辆",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 位乘客/每辆船"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "咖啡杯游乐设施",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "乘客搭乘以末端三支长型旋转臂旋转的成对座位设施",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "咖啡店",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "一间立体派装饰风格的商店在卖咖啡"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "木齿铁轮"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "木齿铁轮"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "木齿铁轮"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "木齿铁轮"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "可乐糖果"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "柱廊"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "一般桧树"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "一般橡树"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "一般紫杉树"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "简洁的反转过山车",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "乘客成对地坐在悬挂在轨道下的坐椅一起历经牢固的反转回圈快速旋转",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "兀鹰游乐设施",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "乘客以躺卧姿势面向下乘坐,以特殊设计的单轨悬吊辆车,在转弯时自由左右摇摆",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "鳗鱼飞车",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "一座以钢铁轨道组成的云霄飞车它的鳗鱼外型列车会穿过曲折循环的轨道",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "松柏篱芭"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "松柏篱芭"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "运输带转弯"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "运输带转弯回转"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "运输带终点"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "运输带升起"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "运输带直线"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "小饼乾店",
+    "reference-description": "A stall selling giant cookies",
+    "description": "一家卖巨大饼乾的店"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "Cool Dude"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "螺旋体过山车",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "一座过山车列车穿过成圈结实的钢制螺旋式轨道曲折前进",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "金属类屋顶"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "波纹的钢制基底"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "波纹的钢制屋顶"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "波纹铁墙"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "金属类墙面"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "松树"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "牛仔1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "牛仔2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "古怪步道"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "战栗主题区"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "鳄鱼游乐设施",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "鳄鱼造型的船沿着水道运行,在斜坡上滑水而下使乘客浸泡到水中",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "每艘船限乘4人"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "妙妙屋",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "建筑物内含有变形的房间及多方向走廊使通过它的人容易迷失方向",
+    "reference-capacity": "5 guests",
+    "capacity": "5位客人"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "邱比特喷泉"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "弯曲式积木"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "弯曲式积木"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "曲线泥墙"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "曲线泥墙"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "曲线泥墙"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "弯曲式屋顶"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "弯曲式屋顶"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "弯曲状墙"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "弯曲状墙"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "自定义音乐1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "自定义音乐2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "Cyclops Ride",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "Riders drive the Eye of a Giant Cyclops",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "Cyclops Statue"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "雏菊灯"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "水塔"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "Dark Age Entrance"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "Dark Age Themeing"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "Dark Age Village Corner Roof Piece"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "Dark Age Village Inverted Roof Piece"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "Dark Age Village Lower Corner Piece"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "Dark Age Village Lower Wall Piece"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "Dark Age Village Roof Piece"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "Dark Age Village Roof with Chimney"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "Dark Age Village Upper Corner Piece"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "Dark Age Village Upper Wall Piece"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "Dark Age Village Window Box"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "Dark Age Village Window Box Roof"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "Dark Ages Tavern"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "枯树"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "枯树"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "枯树"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "帆船水上游乐设施",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "装饰的钓鱼船，由游客自行踩踏行进",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "每艘船限乘2人"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "钻石小推车"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "钻石游乐设施",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "乘客乘坐在成对的座位上循着末端三支长形旋转臂旋转",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "钻石把手"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "恐龙形状的树"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "澳洲民俗乐器"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "滑行小船",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "乘客在膨胀的小船滑下到半圆型或完整封闭管道内滑行",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 位乘客 /每艘小船"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "恐龙"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "恐龙"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "恐龙"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "恐龙"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "恐龙"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "Dinosaur Egg Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "泥土步道"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "电动碰碰车",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "每一位游客开一辆电动碰碰车",
+    "reference-capacity": "1 person per car",
+    "capacity": "1位乘客/每个车厢"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "碰碰车节奏风格"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "海豚游乐设施",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "由乘客自行驾驶单一座位以海豚为外型的运载工具",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "每辆车限乘1人"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "海豚喷泉"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "海豚雕像"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "门口"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "入口"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "门口"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "Double Deck Carousel",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 passengers"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "双层式了望台",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "双层式观察舱旋转移动到高塔上面",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 位乘客"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "甜甜圈店",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "一家卖圆形的油炸圈饼"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "Dragon Attacking"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "龙舟",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "以龙为主题车辆的云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "Dragonfly Cars",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "Dragonfly-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "饮料店",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "一家饮料罐外形的店在卖气泡式饮料"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "古埃及柱廊"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "埃及的雕像"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "埃及风格 招牌"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "埃及主题区"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "埃及的墙"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "埃及风格"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "艾菲尔铁塔"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "Electric Fence"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "Electric Fence Broken"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "Electric Fence Corner Piece"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "Electric Fence Inverted Corner Piece"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "Electric Fence with Light"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "大象喷水池"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "空空的推车"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "食火鸡"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "飞天转轮",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "旋转轮以悬吊游客太空舱,首先以旋转开始再以一支支架支撑升起",
+    "reference-capacity": "16 passengers",
+    "capacity": "16位客人"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "尤加利树"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "欧洲落叶松树"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "邪恶的武士"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "亮艳彩蛋游乐设施",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "乘客搭乘以末端三支长型旋转臂旋转的成对座位设施",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "反向穿梭过山车",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "乘客面对面或背对背坐着一起历经牢固的反转回圈快速旋转",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "游乐场风琴风格"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "梦幻风格"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "Farm Tools"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "喜佛陀"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "Feast Table"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "栅栏"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "栅栏"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "栅栏"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "栅栏和墙"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "摩天轮",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "大型的轮子上有16张座椅",
+    "reference-capacity": "32 passengers",
+    "capacity": "32位客人"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "Fiery Beacon"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "技术风筝游乐设施",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "游客乘坐在成对座位上循着末端的三座长形旋转臂旋转",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "Fighting Knights Dodgems",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "Riders joust on horse-themed dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "烟火缤纷游乐设施",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "旋转悬挂着乘客的座舱，先以旋转开始，再以支撑臂倾斜升起",
+    "reference-capacity": "16 passengers",
+    "capacity": "限乘16人"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "Fire Hydrant"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "急救室",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "一间让生病的游客能迅速回复的急救室"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "钓鱼孔"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "火焰"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "饲育红鹤"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "照育红鹤"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "红鹤用喙理毛"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "无地板式过山车",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "狂黟的过山车列车没有给乘客地板,在疾速经过旋转轨道及多样反转刺激时感受在空中的感觉",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "花"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "Flower Power Ride",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "Flower Power T-Shirts",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "Stall selling T-shirts with a flower motif"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "Flying Boats",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "Roller coaster cars shaped like flying boats",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "飞行过山车",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "乘客被固定轨道下的舒适座位,途经穿过最终极疯狂轨道的飞行体验",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "水上飞行",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "每位乘客搭乘气垫船工具",
+    "reference-capacity": "1 person per car",
+    "capacity": "1位乘客/每个车厢"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "足球"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "足球游乐设施",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "悬吊式云霄飞车以足球为车辆外型使其能在转弯时能自由摆动摇荡",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "?每辆车限乘4人"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "Forbidden Fruit Tree"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "Forest Trees"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "喷水池"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "喷泉"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "反转U型过山车",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "反转过山车在U型回转及垂直向下急转轨道上运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "炸鸡店",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "一间卖整桶式炸鸡的商店"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "炒米粉 店",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "一家卖中式炒米粉的店"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "成熟果实"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "成熟果实"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "果树"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "果树"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "水果冰店",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "以水果冰淇淋为主题的商店"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "Fun House",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "Building containing moving walls and floors to disorientate people walking through it",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "糕饼店",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "一家卖糕饼的店"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "Future Themeing"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "Futuristic Park Entrance"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "绞刑台"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "Gangster Cars",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "花园花园"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "花园"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "日本艺妓Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "普通商店"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "温和风格"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "几何状的水池"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "几何状的雕刻品"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "几何状的雕刻品"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "几何状的雕刻品"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "几何状的雕刻品"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "几何状的雕刻品"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "Geysers"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "幽灵列车",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "有机动装置的怪物造型列车游历着多层次的轨道经过有幽灵式的景物及特殊特效",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每个车厢"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "Giant Bass Guitar"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大的豆茎"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大的豆茎"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "糖果屋主题"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "巨大的胡萝卜"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "Giant Dinosaur Footprint"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "Giant Drum Kit"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "巨大的蕨"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "巨大花园主题区"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "大型牧草"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "Giant Guitar"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "Giant Mangrove Tree"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "Giant Panda"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "巨大南瓜"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "巨大过山车",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "一座巨大的钢制过山车有能力可以缓慢的落下及爬坡达300英尺",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4位乘客/每个车厢"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "长颈鹿1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "长颈鹿2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "Giraffe Statue长颈鹿雕像"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "玻璃屋顶"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "玻璃屋顶"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃墙"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃墙"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃墙"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃墙"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "高卡赛车",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "自己驾驶汽油引擎式的高卡赛车",
+    "reference-capacity": "single-seater",
+    "capacity": "单一乘客"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "金佛Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "Golden Fleece"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "黄金Hinoki扁柏树"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "铜锣"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "光明武士"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "大猩猩游乐设施",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "由大猩猩外型车辆组成的悬挂式云霄飞车列车在转弯处自由摇荡运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓园遗迹"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓园遗迹"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓园遗迹"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "万里长城正面墙面区段"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "万里长城后背墙面区段"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "万里长城增设墙面区段"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "万里长城转弯的塔楼"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "万里长城笔直的塔楼"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "巨大的大白鲨游乐设施",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "有简单护膝的宽敞列车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "绿色柏油碎石步道"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "绿水"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "Groovy Dancer"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "Endeavour 船舰"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "Hades Statue"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "Hall of Mirrors",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "reference-capacity": "5 guests",
+    "capacity": "5 guests"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "Harbour Dock"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "Harbour Wall"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "Harbour Wall Corner Piece"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "Harbour Wall with Dock"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "Harbour Wall with Fishing Gear"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "Harbour Wall with Moor"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "Harpies Trains",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "帽子店",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "纪念品店卖各式各样的帽子"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "鬼屋",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "大型的主题建筑物包含可怕的长廊以及幽灵房间",
+    "reference-capacity": "15 guests",
+    "capacity": "15位游客"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "Haunted Jail House",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "reference-capacity": "16 guests",
+    "capacity": "16 guests"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "猛鬼屋",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "动力式车辆延着多层次轨道通过一些特效及景物",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "Hay Bale"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "心形的树"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "Heavenly Bath Floor"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "Heavenly Bath Pool"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "Heavenly Bath Pool Corner"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "Heavenly Bath Pool Edge"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "Heavenly Bath Pool Steps"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "Heavenly Bath Roof"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "Heavenly Bath Window"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "Heavenly Baths Arch"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "Heavenly Baths Architecture"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "Heavenly Baths Fountain"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "Heavenly Baths Stairway"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "围篱"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "围篱"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "直升飞机场"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "Hercules"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "桸柏树"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "河马1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "河马2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "河马游乐设施",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "乘客乘坐在水中的潜艇在水中顺着水流行进",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "?每辆车限乘?人"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "黄金洋槐树"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "恐怖风格"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "Horse"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "马雕像"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "骑马者雕像"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "越野障碍赛马",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "乘客骑着马形车辆循着单轨式过山车轨道",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 位乘客/每辆马"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "热巧克力店",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "一家卖热巧克力饮料的店"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "热狗店",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "一家在卖热狗的店"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "Hot Rod Car"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "Hot Rod Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "Hover Bikes",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "Futuristic bike-shaped single vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "Hover Cars",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "Hoverbike Flying"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "Hoverbike on Stand"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "Hoverboards",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "Hovercar Flying"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "Hovercar on Stand"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "哈士奇车",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "依循着基层轨道运行以哈士奇雪橇为外形的动力式运载工具",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每辆车限乘2人"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "极度旋转列车",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "宽敝的列车有着简单的膝式安全装置",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "极速旋转列车",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "宽阔的4 人座的浮雕式车辆及简单式的安全装置",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "超速过山车",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "一座超大的非倒吊式过山车只有一条压制膝部的安全条以大规模方式高速落下",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "冰淇淋店",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "一间卖蛋角冰淇淋的店"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "冰块"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "冰块构成体"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "冰块构成体"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "冰殿"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "冰霜公园入口"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "冰块导管基底"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "冰块导管区段"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "冰块导管出口"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "冰块屋顶"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "冰墙"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "冰封风格"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "冰桶"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "冰桶"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "冰桶"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "冰红茶店",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "一家卖冰红茶的店"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "圆顶小屋"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "圆屋顶"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "圆顶墙"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "圆顶墙"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "圆屋顶的小屋的墙"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "瞬间反转过山车",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "反转过山车是由车站加速射出如大钉子般垂直轨道上方,然後再倒退回到车站并冲向另一边垂直轨道上",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "檀香杉树"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "印度丝织旗"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "印度丝织旗"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "印度丝织旗"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "印度丝织旗"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "印度丝织旗"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "Industrial Roof Corner Piece"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "Industrial Roof Piece"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "Industrial Wall Corner Piece"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "Industrial Wall Set"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "Industrial Wall with Doorway"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "Industrial Wall with Window"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "服务台",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "一处游客可以取得游乐园地图及卖到雨伞的地方"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "古老土著"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "古老土著"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "义大利扁柏树"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "意大利警局设施",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "乘客搭乘以末端三支长型旋转臂旋转的成对座位设施",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "美洲?游乐设施",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "乘客以躺卧姿势面向下乘坐,以特殊设计的单轨悬吊辆车,在转弯时自由左右摇摆",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "日本樱花树"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "日本樱桃树Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "障子墙"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "日本的公园入口"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "日本松树"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "障子屋顶"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "障子屋顶"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "障子屋顶"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "日本的丝织旗"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "日本雪球树"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "Jazz Band Member"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "娃娃软糖"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "软豆糖"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "豆型糖果墙"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "Jet Aeroplane"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "Jet Pack Booster",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "Jet Plane Cars",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "Roller coaster cars in the shape of jet planes",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "喷射滑橇",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "每台单一乘客自行操纵它的运作",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1位乘客／每部机器"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "Jousting Knights",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "跳跃喷泉"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "跳跃雪球"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "丛林"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "丛林式栅栏"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "丛林式风格 招牌"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "丛林主题区"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "热带树林1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "热带树林2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "热带树林与美洲?"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "热带树藤蔓"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "丛林敲击风格"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "废弃物"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "侏罗纪风格 招牌"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "侏罗纪主题区"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "侏罗纪风格"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "袋鼠"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "杀人鲸",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "乘客乘坐在水中的潜艇在水中顺着水流行进",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "? 每辆车限乘?人"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "无尾熊游乐设施",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "大型云霄飞车颠倒自由落下",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "每辆车限乘8人"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "极限发射过山车",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "过山车列车由车站被直线加速机械射出到反转式旋转轨道",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "瓢虫列车",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "过山车列车是以瓢虫外形的车辆",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "灯"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "灯"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "灯"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "灯"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "灯"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "Large Angled Mammoth Fence"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "Large Elm Tree"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "Large Mammoth Fence"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "Large Meteor Crater"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "Large Oak"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "Large Red Meteor Crater"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "Large Smoking Chimney"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "Large Speaker"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "大型的图腾柱"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "Laser Fence"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "Laser Fence Corner"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "发射自由落体",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "自由落体车辆以气压式发射朝高塔上方上升然後再自行自由落下",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "罗生扁柏树"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "迷你悬挂式飞行列车",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "乘客乘坐在横卧向下的方向,悬挂在特殊设计的列车并在单轨轨道环行转角处时自由摇晃",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 位乘客/每个车厢"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "横卧式过山车",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "乘客被以棋卧姿势固定在特殊挽具上,历经疾迅旋转轨道及反转,甚至以几近贴地方式与地面接触",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "Lemonade Market Stall",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "A themed stall selling old style, fresh lemonade."
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "柠檬水店",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "一家卖清凉的柠檬水饮料的商店"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "电梯",
+    "reference-description": "Steel lift cabin",
+    "description": "游客在垂直塔楼内的电梯上下,由某一楼层到其它楼层",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 位乘客"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "百合花"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "小巴云霄飞车",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "以小型巴士车辆为主题的云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每车限乘4人"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "狮子"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "狮子游乐设施",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "??狮子游乐设施",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "木造小屋"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "木屋"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "原木舱屋顶一块"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "原木舱屋顶一块"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "原木舱屋顶一块"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "原木舱边的烟囱"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "原木墙一片"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "原木列车",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "过山车列车是以小型原木外形的",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "原木"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "原木溪谷",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "原木风格的船延着水道在陡峭斜坡急速下滑水溢四溅喷洒到游客",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 位乘客 /每艘船"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "棒棒糖"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "白杨树"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "火车的过山车",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "火车的过山车在历经垂直回圈时有膝部安全设备",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "矮木丛"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "Luxury Liner Bow"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "Luxury Liner Mid Section"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "Luxury Liner Stern"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "Mace Ride",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "1 guest per chair"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "魔毯",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "一辆超大飞毯特色的车由底部四支支架循环式地上上下下移动",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 位乘客"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "Magical Armour"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "Magical Helmet"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "Magical Shield"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "Magical Sword"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "木兰花树"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "印度邦主皇宫拱门1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "印度邦主皇宫拱门2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "印度邦主皇宫圆屋顶"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "印度邦主皇宫片段"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "印度邦主皇宫片段"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "印度邦主皇宫片段"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "印度邦主皇宫高楼基部"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "印度邦主皇宫高楼圆柱"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "印度邦主皇宫高楼顶部"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "蒸气火车",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "小型蒸气火车是由蒸气火车头及给煤车复制制造，拖拉着木制乘客车箱",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "每节车箱限乘6人"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "鸳鸯水上游乐设施",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "天鹅造型的船，由前前座位的乘客踩踏前进",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "每艘船限乘4人"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "蝠魟游乐设施",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "大型容量的船沿着宽敞的水道,以传道带送上斜坡,再加速荡下溅起巨大水花淋湿乘客",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "每辆车限乘6人"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "大理石墙"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "大理石墙"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "大理石墙"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "大理石墙"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "Marquee"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "药用蜀葵"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "药用蜀葵"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "火星人的建筑物"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物体"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物体"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物体"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物体"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物体"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "火星人主题区"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "火星人的墙"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "火星风格"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "迷宫",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "迷宫是由六尺高的围离所构成的。游客会对迷宫的摆设觉得疑惑，而只有当游客找到出口时，他们才能够离开这个迷宫。"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "贡丸汤店",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "一家卖中国式贡丸汤的店"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "机械主题区"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "机械风格"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "中古世纪主题区"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "中世纪风格"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "Men Turned to Stone"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "旋转木马",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "有着雕刻木马的传统旋转木马 。",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 位乘客"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "网状栅栏"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "网状栅栏"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "Meteor Crater Corner"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "Meteor Crater Wall"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "Meteor Crater Wall with Crystals"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "梅格蓝桧树"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "MicroBus Ride",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "Microbus"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "木制狂放矿坑列车",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "极小的矿坑列车在急转弯的木架轨道上运行,使它不安全的倾斜并U型回转及瞬间坠下的恐怖感",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "矿坑车辆",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "像矿坑中载木货车的独特车形",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "矿车游乐设施",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "有装填物的座位及护膝吧装置的木制云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "圹坑小屋"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "圹坑小屋"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "坑道升降机",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "游客搭乘上升或下降的电梯在垂直大楼某一层楼到另一层楼",
+    "reference-capacity": "16 passengers",
+    "capacity": "限乘16人"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "圹坑井状通道"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "小人国"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "坑道冲锋车",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "坑道冲锋车是以过山车列车延着看起来像老旧铁路轨道的钢制过山车轨道全速前进",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 or 4 位乘客/每个车厢"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "迷你高尔夫",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "一种温和的小小高尔夫游戏",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "矿坑升降机",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "具动力的升降机外形列车在钢制轨道上运行由乘客的踏板控制速度",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "Minotaur Statue"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "薄荷"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "摩登风格"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "使猴子困惑的树"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "怪物货车",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "以4 x 4大型动力货车爬上陡峭的斜坡",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "2 位乘客 /每辆货车"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "蒙特瑞柏树"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "西班牙松树"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "Moon Juice",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "A stall selling the latest soft drinks"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "Mosaic FootPath"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "摸拟天体运行",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "游客坐在摸拟天体运行舱内观看影片利用水力学支臂使旋转及移动",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "摩托车竞速赛",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "乘客搭着摩托车形的过山车车辆延着单轨轨道前进",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 位乘客/每辆摩托车"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "Motorcycle"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "老鼠小车车",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "像老鼠外形特色的车辆",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "木制野地飞鼠",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "小老鼠外形的车辆在木架轨道上运行,车子以倾斜穿越U型转弯及陡峭坠下时有极大的不安全刺激感",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "泥顶"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "泥墙块"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "多种尺寸冲锋列车",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "车辆以高脚跟式投射乘客坐椅",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "Mythological Entrance"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "Mythological Themeing"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "印第安人"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "自然水源"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "Neon Diner Sign"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "Neptune Ride",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "Neptune's Seafood Stall",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "A stall selling Neptune's salty treats"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "New York Corner Filler"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "New York Entrance"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "New York Inverted Corner Piece"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "New York Inverted Corner Roof"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "New York Roof Piece"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "New York Wall Piece"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "New York Wall with Line"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "New York Washing Line"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "隐藏入口"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "没有入口, 没有站台"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "北美公园入口"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "挪威杉木"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "Oak Barrels",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 passengers per boat"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "Obsidian SkyScraper Door Piece"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "Obsidian SkyScraper Roof Piece"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "Obsidian SkyScraper Shallow Slope Corner"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "Obsidian SkyScraper Shallow Sloped Wall"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "Obsidian SkyScraper Steep Slope Corner"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "Obsidian SkyScraper Steep Sloped Wall"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "Obsidian SkyScraper Wall"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "Obsidian SkyScraper Wall with Window"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "办公室区块"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "Oil Barrel"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "石油帮浦Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "柳橙水"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "风琴风格"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "东方风格"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "装饰用结构"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "装饰用的结构"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "装饰用的结构"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "装饰用的树"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "装饰用的树"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "装饰用的树"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "装饰用的树"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "装饰用的树"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "华丽的大理石墙"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "驼鸟游乐设施",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "一座由乘客以站立姿态乘座的循环式云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "水上浮舟游乐设施",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "由乘客自行踩踏的长型独木舟",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "每舟限乘2人"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "塔"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "凉亭"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "东方文化的凉亭a"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "东方文化的凉亭a"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "东方文化的凉亭a"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "塔/凉亭风格 招牌"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "塔/凉亭主题区"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "东方文化的凉亭"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "棕榈树"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "棕榈树"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "棕榈树"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "棕榈树"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "棕榈树"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "Panda Litter Bin"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "Panda Themeing"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "Panda Trains",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "Roller coaster trains with cuddly panda cars",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 passenger per car"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "游乐园入口建造"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "游乐园入口栅门"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "Peasant Hut"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "Pegasus Cars",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "企鹅雪橇",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "乘客在企鹅造型车辆中只有依循着弯曲的半圆形轨道急速地猛冲旋转前进",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每辆车限乘2人"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "Period Automobile"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "Period Diner"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "Period Flag"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "Period Sailing Yacht"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "Period Street Lamps"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "Period Truck"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "加油站"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "载运货车",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "载运货车的外形具有动力机械的车辆",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 位乘客/每辆货车"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "输送管"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "段落的水管"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "段落的水管"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "段落的水管"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "海盗旗"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "海盗船",
+    "reference-description": "Large swinging pirate ship",
+    "description": "大规模摆动的海盗船",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 位乘客"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "海盗船"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "海盗主题馆"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "海盗风格"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "比萨店",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "一间卖比萨的店"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "平地"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "印度成象"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "卜克牌墙"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "卜克牌墙"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "圆柱柱脚"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "Plough"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "北极熊云霄飞车",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "乘客成对而坐当他们在通过牢固的倒转回旋时会面临向前或向后的运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "柱子"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "柱子"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "柱子"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "Police Car Trains",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "Police Cars",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "爆米花店",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "卖大桶爆米花的店"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "升降闸门"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "升降闸门"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "柱子"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "矿坑列车",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "具动力式矿坑列车冲向平滑旋转式轨道上",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 或 4 位乘客/每个车厢"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "Prehistoric Entrance"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "Prehistoric Themeing"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "椒盐脆饼店",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "一家卖酥脆的椒盐脆饼的店"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "Primordial Soup"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "Prison Door"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "Prison Fence"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "Prison Inverted Piece"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "Prison Wall Corner"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "Prison Wall Piece"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "Prison Wall Roof"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "Prison Watch Tower"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "Prison Watch Tower Stairs"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "Prison Water Tower"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "Pterodactyl Trains",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "南瓜"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "南瓜屋"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "金字塔"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "等待区电视"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "赛车",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "赛车外形具动力机械的车辆",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 位乘客/每个车厢"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "Racing Raptors",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "Separate raptor-shaped vehicles",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "2 riders per vehicle"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "Racing Tannoy"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "雷达碟盘"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "水上橡皮艇",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "橡皮艇外形的船在水道上温和地曲折前进",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 位乘客 /每艘橡皮艇"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "拉格泰姆风格"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "栏杆"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "栏杆"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "栏杆"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "栏杆"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "Rainbow FootPath"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "红杉木树"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "红杉木树"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "Red Meteor Crater Corner"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "Red Meteor Crater Inverted Corner"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "Red Meteor Crater Wall"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "红杉木"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "复古型单轨列车",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "以开放式客舱的单轨列车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4位乘客/每个车厢"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "倒退式自由落体",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "大型的车辆是倒退式自由落体设施",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "倒退式过山车",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "妖怪列车在木架轨道上运行,转进特殊倒转区域",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "犀牛"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "犀牛游乐设施",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "一座以螺旋上升斜坡结合钢铁轨道的云霄飞车且以成列就座的车辆运行",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "每辆车限乘6人"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "索具"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "急流",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "圆形船体沿着水道航道进行,穿过溅下的瀑布及令人兴奋的急湍水流",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 位乘客 /每艘船"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "River Styx boats",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 passengers per raft"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "道路"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "Roaring Twenties Park Entrance"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "Roaring Twenties Themeing"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "Roaring Twenties Wall Sets"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "烤香肠店",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "一家卖中国式烤香肠的店"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "Robin Hood's Camp"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "Robin Hood's Hut"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "Robot"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "Rock 'n' Roll Park Entrance"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "Rock 'n' Roll Themeing"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "Rock Band Tour Bus"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "岩石墙"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "摇滚风格"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "摇滚风格2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "摇滚风格3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "火箭车",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "过山车列车的特色像火箭",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "Rocky FootPath"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "云霄飞车雕像"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "Rollerskating Waitress"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "古罗马圆形大竞技场"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "罗马柱廊"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "罗马圆柱墙"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "Roman Palace Corner Piece"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "Roman Palace Cross Section"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "Roman Palace End Piece"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "Roman Palace Straight Piece"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "罗马雕像"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "罗马雕像"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "古罗马教堂"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "罗马墙"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "罗马墙"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "罗马号角风格"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "屋顶"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "落下旋转车Roto-Drop",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "一个环状坐位被拉到高塔顶端再温和地旋转及自由缓慢地落下利用底部的磁性煞车温和地停止住",
+    "reference-capacity": "16 passengers",
+    "capacity": "16位客人"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "66道路标志"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "伦敦有轨电车巴士",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "有轨电车复制品",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "每辆车限乘10人"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "划船",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "由乘客靠自己划船",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 位乘客 /每艘船"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "毁坏的雕像"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "Runway Corner Piece"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "Runway Edge Piece"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "Runway Inverted Corner Piece"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "Runway Piece"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "餐厅"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "旧金山有轨电车",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "有轨电车复制品",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "每辆车限乘10人"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "Sandstone Skyscraper Bottom Corner"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "Sandstone Skyscraper Bottom Curved Slope"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "Sandstone Skyscraper Bottom Inverted Corner"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "Sandstone Skyscraper Bottom Slope Base"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "Sandstone Skyscraper Corner Top"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "Sandstone Skyscraper Curved Slope Top"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "Sandstone Skyscraper Docking Bay"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "Sandstone Skyscraper Doorway"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "Sandstone Skyscraper Filler"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "Sandstone Skyscraper Inverted Corner Top"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "Sandstone Skyscraper Mid Corner"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "Sandstone Skyscraper Mid Curved Slope"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "Sandstone Skyscraper Mid Slope Corner"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "Sandstone Skyscraper Mid Wall Section"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "Sandstone Skyscraper Roof"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "Sandstone Skyscraper Roof Spire"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "Sandstone Skyscraper Walkway"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "Sandstone Walkway Corner"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "Sandstone Walkway Cross Section"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "Sandstone Walkway End Section"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "Sandstone Walkway T-Junction"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "卫星"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "卫星碟盘"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "School Bus"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "School Bus Trams",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "Miniature trams themed to look like North American school buses",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "苏格兰松树"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "卷动式招牌"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "卷动招牌"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "雕刻品"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "雕刻品"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "海鲜店",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "一家卖炸触角的店"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "Sea Plane"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "海豹云霄飞车",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "一座以螺旋循环式运行前进并以钢铁轨道组合而成的云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "Seaplane Pits"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "搜寻光线"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "座位"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "印度神像-湿婆"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "灌木及装饰品"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "羽毛球"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "羽毛球"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "障子墙"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "Sidewalk FootPath"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "招牌"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "道路标示与事物"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "银桦树"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "Singer with Quiff"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "了望台",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "观察舱旋转移动到高塔上面。",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 位乘客"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "六旗主题区"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "自由落体过山车",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "完全延着垂直斜度轨道落下的附加大型列车体验由顶点自由落下的快感",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "骨骼"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "升降滑雪椅",
+    "reference-description": "Open cars for chairlift",
+    "description": "开放列车让游客上下山使用",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每个车厢"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "雪橇碰碰车",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "自助式电动碰碰车",
+    "reference-capacity": "1 person per car",
+    "capacity": "每辆车限乘1人"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "头骨"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "头骨"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高楼大厦墙面"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高楼大厦墙面"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "高楼大厦墙面"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "Sky Walk FootPath"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "摩天大楼凹面体一片"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "摩天大楼凹面体屋顶"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "摩天大楼凸面体一片"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "摩天大楼凸面体屋顶"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "摩天大楼电梯一座"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "摩天大楼电梯一座"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "摩天大楼电梯区段"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "摩天大楼电梯区段"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "摩天大楼电梯区段"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "摩天大楼金属合金设定一面凹面体"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "摩天大楼金属合金设定一面凸面体"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "摩天大楼金属合金设定一面墙"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "摩天大楼金属合金设定二面凹面体"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "摩天大楼金属合金设定二面凹面体"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "摩天大楼金属合金设定二面凸面体"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "摩天大楼金属合金设定二面墙"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "摩天大楼金属合金设定二面墙"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "高楼大厦屋顶块"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "高楼大厦顶端"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "树猍游乐设施",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "悬吊式云霄飞车以树猍 为车辆外型使其能在转弯时能自由摆动摇荡",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "?每辆车限乘4人"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "Small Angled Mammoth Fence"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齿铁轮"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齿铁轮"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齿铁轮"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齿铁轮"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "小型地质"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "Small Meteor Crater"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "小型单轨列车",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "二侧车门开放式的小型单轨列车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4位乘客/每个车厢"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "Small Red Meteor Crater"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "Small Speaker"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "Smoke Stack Base"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "Smoke Stack Mid"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "蜗牛"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "雪 / 冰"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "覆雪式招牌"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "雪杯",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "乘客乘坐在围绕着中央雪人的成对坐位上",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 位乘客"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "冰雪主题区"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "雪地风格"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "被雪覆盖的高加索冷杉树"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "被雪覆盖的挪威杉木"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "被雪覆盖的红杉木"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "被雪覆盖的红杉木"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "雪球"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "雪人"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "肥皂盒德贝赛车",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "乘客乘坐在肥皂盒外形的车辆延着单轨式的过山车",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "Soft Toy Stall",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "A stall selling a cute soft toy dinosaur"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "纪念品店",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "一家在卖纪念品 酷迪玩具 和 雨伞的店"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "豆浆店",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "一家卖盒装豆浆的店"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "太空"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "太空囊"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "太空船"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "太空球体"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "环形空间",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "在中心枢轴上转动,允许乘客自由转动方向",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "太空火箭"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "Space Ship Cargo Section"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "Space Ship Comms Section"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "Space Ship Control Deck"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "Space Ship Cross Section"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "Space Ship Docking Section"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "Space Ship Engine Section"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "Space Ship Fuel Section"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "Space Ship Gravity Section"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "Space Ship Living Section"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "Space Ship Science Section"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "Space Ship Solar Panels"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "Space Ship Solar Section"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "太空风格步道"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "太空式风格 招牌"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "太空世界主题区"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "太空风格"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "铲子形状的树"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "斯芬克斯"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "蜘蛛"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "Spiked Fence"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "太空飞鼠",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "老鼠外形车辆疾迅穿过牢固转角及短程下坡,再温和地旋转着使你迷失方向感",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "螺旋式过山车",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "一座紧密的钢制轨道的过山车有着螺旋上升斜坡及同轴列车座椅",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "螺旋滑道",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "木制结构，内部有一个楼梯，而外部则是有螺旋状的坡道可以滑下来"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "水花四溅",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "大型容量的船体延着水道利用传输带送上斜坡,再加速向下滑落并溅起水花使乘客浸泡到水",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 位乘客 /每艘船"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "幽灵主题区"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "运动车",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "运动车外形的动力机械车辆",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "运动主题区"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "人造卫星悬吊飞行设施",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "乘客以躺卧姿势面向下乘坐,以特殊设计的单轨悬吊辆车,在转弯时自由左右摇摆",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每辆车限乘2人"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "松鼠形状的树"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "公车巴士云霄飞车",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "有装填物的座位及护膝吧装置的木制云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "Stampeding Herd Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "站立式过山车",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "一座循环式过山车让乘客以站立姿势搭乘",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "站立式旋转过山车",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "乘客搭乘在站立式的列车内以特殊设计的安全装置以确保在疾迅下坠及穿过多样式反转轨道时的安全",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "杨桃汁店",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "一家卖杨桃汁饮料的店"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "自由女神像"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "蒸气火车",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "微型蒸汽火车是由酷似蒸汽火车及媒车拖拉具有布织车顶的木制四轮马车所组成的",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 位乘客/每辆马车"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "有屋顶的蒸汽火车",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "微型蒸汽火车是由酷似蒸汽火车及媒车拖拉具有布织车顶的木制四轮马车所组成的",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 位乘客/每辆马车"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "Steaming Drains"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "铁块"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "钢铁墙"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "铁栅栏"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "铁格子"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "钢铁墙"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "钢铁墙"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "铁墙"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "铁墙"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "铁墙"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "铁墙"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "Stone Age Temple"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "石椅"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "石块"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "石制摩天大楼楼梯基底"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石制摩天大楼墙一片"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石制摩天大楼墙一片"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石制摩天大楼墙一片"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石制摩天大楼墙一片"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "石制摩天大楼墙一片"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "石墙"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "石墙"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "石墙"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "石墙"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "Stool"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "Stools"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "现代化单轨列车",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "前後列车为流线设计，具高载客量的单轨火车。",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "5或10位乘客/每个车厢"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "潜水艇三明治店",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "一家卖新鲜潜水艇三明治的店"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "海底旅行Submarine Ride",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "乘客坐在水中的潜艇在水面下游动参观",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 位乘客 /每艘潜艇"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "姜糖茶店",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "一家卖韩式姜糖茶饮料的店"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "夏日风格"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "太阳眼镜店",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "一家卖各种款式的太阳眼镜的店"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "沉船"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "Super Computer Large CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "Super Computer Monitor"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "Super Computer Small CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "支架结构"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "支架结构"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "支架结构"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "冲浪设施",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "乘客搭乘有特殊设计保护的宽敞列车中以站立姿态平稳地通过下坠及多样化的回转装置",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "悬挂式单轨铁路列车",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "大容量的单轨铁路车辆",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 位乘客/每个车厢"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "Suspended Seaplane Cars",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "悬晃式飞机列车",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "悬挂式过山车列车是由飞机外形的车辆所组成的,车辆在经过转角处时会自由摆动摇晃",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "悬晃列车",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "是由当列车在转角处转弯时列车自由摇摆晃动组成的悬挂式过山车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "吊桥基底一块"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "吊桥基底间隔一块"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "吊桥缆索区段1"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "吊桥中央部份区域一块"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "吊桥起点1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "吊桥起点1"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "吊桥塔楼点1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "吊桥塔楼点2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "Swamp Fern"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "天鹅"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "Swamp Plant"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "天鹅",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "天鹅外形的船, 由前座的乘客脚踏前进",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 位乘客/每艘船"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "摇摆车",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "小型车辆在铁道上振动摇摆",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "摇摆列车",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "悬挂式过山车列车的的组成是由升降机式坐椅可以在行进间经过转角处时自由摆动摇晃",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "倒转摆动的船",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "船是依附在一对面基底上平衡力支架的,以360度摆动方式运行",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 位乘客"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "Sword in the Stone"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T恤店",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "一家卖T恤纪念品的店"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "大众捷运列车云霄飞车",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "云霄飞车列车被直线推进动力以加速推离车站并快速通过倒置旋转轨道",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "炸药筒"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "装炸药箱"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "炸药雷管"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "炸药堆"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "大型灯笼"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "大型灯笼"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "高大的木式栅栏"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "目标"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "柏油碎石步道"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "小酒馆"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "科幻风格"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "印第安人旅行皮革屋"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "Teleporter Cabin",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "租屋"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "网球"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "网球网墙"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "网球网墙"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "帐蓬"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "圆锥帐篷"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "白蚁堆"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "连栋房屋"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "兵马俑"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "Time Machine",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "1 guest per time machine"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "伞菌"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "伞菌"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "伞菌"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "伞菌;毒菌"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "伞菌"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "伞菌"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "平底雪橇",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "平底雪橇外形的过山车与同轴座位",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "Toffee Apple Market Stall",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "A themed stall selling sticky toffee apples"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "太妃糖苹果店",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "一间太妃糖苹果店在卖太妃糖苹果棒"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "厕所",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "一座基本厕所建筑物"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "厕所",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "厕所房子是一座原木小屋风格的建筑物"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "厕所",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "一座基本厕所建筑物"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "Tommy Gun Ride",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "上空旋转",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "乘客搭乘着悬挂式小船由大型旋臂,旋转向前及向後运作",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "图腾柱"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "市政府"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "童真风格"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "东欧车设施",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "以汽车为车辆外型的云霄飞车",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "轨道弯曲"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "破损轨道"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "轨道终点"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "轨道裂缝"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "笔直轨道"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "拖拉机"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "传统游乐园入口"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "有轨电车",
+    "reference-description": "Old-timer replica trams",
+    "description": "古老式复制有轨电车",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 位乘客/每个车厢"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "Traveller Van"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "珠宝盒"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "珠宝盒"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "Treasure Chest"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "Trebuchet Ride",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 passengers"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "树"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "树"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "Triceratops Dodgems",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "Riders lock horns with each other in triceratops dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "Trilobite Boats",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "Trilobite-shaped roller coaster cars",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "海龟水上设施",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "小型圆型小艇由中心马达操控每个乘客的方向",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "? 每艘船限乘2人"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "龙卷风",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "乘客坐在成对的座位上,由底部三支旋转臂旋转环绕运行",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 位乘客"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "旋转列车",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "过山车车辆可以中心旋转运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "旋转列车(反转出发)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "过山车车辆可以中心旋转运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "旋风式过山车",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "过山车列车延着平滑的轨道上一起穿过多变反转式的钢制轨道滑行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO Crash Site"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "独角兽雕像"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "都市化主题"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "都市风格"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "Valkyrie"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "Valkyries Trains",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "直立式3D立体招牌"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "短程垂直反转穿梭",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "乘客坐在车辆内悬挂在轨道下方,被向後垂直方向向上拉然後再快速坠下到旋转回圈紧接反转运行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "树藤"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "葡萄酒列车",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "具动力装置及葡萄酒外型的车辆在即定航线轨道上运行",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每个车厢"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "维吉尼亚式旋转",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "圆形车辆延着急弯的木架轨道自旋",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "火山"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "Volcano with small trees"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "金链花树"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "马车"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "马车"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "货车车轮"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "墙"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "拱门"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "墙和 屋顶"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "胡桃树"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "华盛顿像"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "黄蜂"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "水世界"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "水上摩托车"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "喷水"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "水上三轮车",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "有大型浮力轮子的脚踏-三轮车",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 位乘客 /每辆三轮车"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "水上风格"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "瀑布"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "泥芭屋顶"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "泥芭屋顶"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "泥芭屋顶"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "泥芭墙"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "Weapon Set"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "柳叶树"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "车子"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "Whisky Barrel"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "Whisky Barrels"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "白主教"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "白棋国王"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "白棋骑士"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "白棋兵"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "白杨树"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "白棋皇合"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "白棋车"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "西部荒野主题区"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "西部荒野风格"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "风蚀造形凹面的屋顶转角"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "风蚀造形凹面的墙转角"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "风蚀造形凹面的墙转角"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "风蚀造形凸面的屋顶转角"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "风蚀造形凸面的墙转角"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "风蚀造形凸面的墙转角"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "风蚀造形地板一块"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "风蚀造形地板一块"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "风蚀造形岩块组成的基底部位"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "风蚀造形岩块组成的基底部位"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "风蚀造形岩块组成的中间区段"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "风蚀造形岩块组成的中间区段"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "风蚀造形岩块组成的中间区段"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "风蚀造形岩块组成的中间区段"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "风蚀造形岩块组成的顶端"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "风蚀造形岩块组成的顶端"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "风蚀造形屋顶平面覆盖一块"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "风蚀造形屋顶平面覆盖一块"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "风蚀造形屋顶平面覆盖一块"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "风蚀造形墙面基底"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "风蚀造形墙面基底"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "风蚀雕饰墙面一片"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "风蚀雕饰墙面一片"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "风蚀雕饰墙面一片"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "风蚀雕饰墙面一片"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "风车"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "窗户"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "窗户"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "窗户"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "Witches Brew Soup",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "A stall selling a thick broth-style soup"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "Witches around Cauldron"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "令人垂涎的树虫游乐设施",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "云霄飞车列车以幼小的澳大利亚树虫为车辆外型",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每辆车限乘2人"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "仙境主题区"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "馄饨汤 店",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "一家卖馄饨汤的店"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "Wood Fence with Climbing Vines"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "Wood Fence with Dead Vines"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "Wood Fence with Man Eating Plant"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "木质"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "木块"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "Wooden Cart"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "木式栅栏"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "木式栅栏"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "木式栅栏"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "木桩栅栏"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "木式栅栏"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "木式栅栏"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "木式围墙"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "Wooden FootPath"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "木桩栅栏"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木桩墙"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木桩墙"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木桩墙"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "木架过山车列车",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "木架过山车列车是装填垫料座椅及膝部有安全护条装置",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "木制式过山车列车(6 个座位)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "木制式过山车是有安全装置护具的列车",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "木制式过山车列车(6 个座位)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "木制式过山车是有安全装置护具的列车是采向後运行方式",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每个车厢"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "木架的摩擦侧边列车",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "摩擦侧边的过山车的基本车辆",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每个车厢"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "森林招牌"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "木式墙"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "木式墙"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "木式墙"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "木式墙"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "Wrecked Seaplane"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "1 出租车设施",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "一座巨大的云霄飞车可以缓慢地降落及拉升到300英尺高的山丘A",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每辆车限乘4人"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "Yew Tree"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "斑马"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "Zeus Statue"
+  }
+}

--- a/objects/zh-TW.json
+++ b/objects/zh-TW.json
@@ -1,0 +1,9578 @@
+{
+  "rct2.glthent": {
+    "reference-name": "'Goliath' Sign",
+    "name": "「葛利亞」招牌"
+  },
+  "rct2.mdsaent": {
+    "reference-name": "'Medusa' Sign",
+    "name": "「美杜莎」招牌"
+  },
+  "rct2.nitroent": {
+    "reference-name": "'Nitro' Sign",
+    "name": "'「尼特若」招牌"
+  },
+  "rct2.walltxgt": {
+    "reference-name": "'Texas Giant' Sign",
+    "name": "德州巨大招牌"
+  },
+  "rct2.tt.1920racr": {
+    "reference-name": "1920s Racing Cars",
+    "name": "1920 年代賽車",
+    "reference-description": "1920s race car themed go-karts",
+    "description": "乘客乘坐以 1920 年代為主題的高卡賽車互相競速",
+    "reference-capacity": "Single-seater",
+    "capacity": "單一乘客"
+  },
+  "rct2.tt.1950scar": {
+    "reference-name": "1950s Car",
+    "name": "1950年代車輛"
+  },
+  "rct2.tt.gbeetlex": {
+    "reference-name": "1950s Car",
+    "name": "1950年代車輛"
+  },
+  "rct2.ww.50rocket": {
+    "reference-name": "1950s Rocket",
+    "name": "1950s Rocket"
+  },
+  "rct2.ww.rocket": {
+    "reference-name": "1950s Rockets",
+    "name": "1950s Rockets",
+    "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.c3d": {
+    "reference-name": "3D Cinema",
+    "name": "3D立體電影院",
+    "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
+    "description": "電影院是一座由測地線球體形狀組成的建築物內部播放３Ｄ立體影片",
+    "reference-capacity": "20 guests",
+    "capacity": "２０位客人"
+  },
+  "rct2.ssig2": {
+    "reference-name": "3D Sign",
+    "name": "3D立體招牌"
+  },
+  "rct2.ssig4": {
+    "reference-name": "3D Sign",
+    "name": "3D立體招牌"
+  },
+  "rct2.nemt": {
+    "reference-name": "4-across Inverted Roller Coaster Trains",
+    "name": "倒轉式雲霄飛車",
+    "reference-description": "Suspended trains in which riders sit in rows",
+    "description": "遊客坐在懸吊在軌道下的座椅上，當快速通過大型旋轉迴圈，令人感覺有俯衝下墜感。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.intbob": {
+    "reference-name": "6-seater Bobsleighs",
+    "name": "飛行旋轉",
+    "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
+    "description": "乘客在大型雪橇車內以幾何率在半圓形軌道上彎曲衝鋒陷陣",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.ww.waborg06": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg02": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg04": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg08": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg05": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg01": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg03": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.waborg07": {
+    "reference-name": "Aboriginal Art Set Piece",
+    "name": "Aboriginal Art Set Piece"
+  },
+  "rct2.ww.1x2abr01": {
+    "reference-name": "Aboriginal Plain Tile",
+    "name": "Aboriginal Plain Tile"
+  },
+  "rct2.ww.1x2abr02": {
+    "reference-name": "Aboriginal Snake Artwork",
+    "name": "Aboriginal Snake Artwork"
+  },
+  "rct2.ww.1x2abr03": {
+    "reference-name": "Aboriginal Spirit Artwork",
+    "name": "Aboriginal Spirit Artwork"
+  },
+  "rct2.station.abstract": {
+    "reference-name": "Abstract",
+    "name": "Abstract"
+  },
+  "rct2.scgabstr": {
+    "reference-name": "Abstract Themeing",
+    "name": "現代抽象主題區"
+  },
+  "rct2.wtrgreen": {
+    "reference-name": "Acid Green Water",
+    "name": "有酸味的綠水"
+  },
+  "rct2.tt.volcvent": {
+    "reference-name": "Active Volcanic Vent",
+    "name": "活火山口"
+  },
+  "rct2.ww.adultele": {
+    "reference-name": "Adult Indian Elephant",
+    "name": "Adult Indian Elephant"
+  },
+  "rct2.ww.adpanda": {
+    "reference-name": "Adult Panda",
+    "name": "Adult Panda"
+  },
+  "rct2.ww.africent": {
+    "reference-name": "Africa Park Entrance",
+    "name": "Africa Park Entrance"
+  },
+  "rct2.ww.scgafric": {
+    "reference-name": "Africa Themeing",
+    "name": "Africa Themeing"
+  },
+  "rct2.thcar": {
+    "reference-name": "Air Powered Vertical Coaster Trains",
+    "name": "氣壓式垂直飛車",
+    "reference-description": "Air-powered launched roller coaster trains",
+    "description": "在令人振奮的氣壓式發射後,列車衝向垂直軌道,並垂直下衝到另一側再回到車站",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.tt.zeplelin": {
+    "reference-name": "Airship Themed Monorail Trains",
+    "name": "太空船主題單軌列車",
+    "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
+    "description": "前後列車為流線設計，具高載客量的單軌火車。",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 位乘客/每個車廂"
+  },
+  "rct2.tap": {
+    "reference-name": "Aleppo Pine Tree",
+    "name": "松樹"
+  },
+  "rct2.tt.histfix2": {
+    "reference-name": "Alien Historical Structures",
+    "name": "外星人的歷史建築"
+  },
+  "rct2.tt.histfix1": {
+    "reference-name": "Alien Historical Structures",
+    "name": "外星人的歷史建築"
+  },
+  "rct2.tt.alenplt1": {
+    "reference-name": "Alien Plant",
+    "name": "外星植物"
+  },
+  "rct2.tt.alenplt2": {
+    "reference-name": "Alien Plant",
+    "name": "外星植物"
+  },
+  "rct2.tt.alnstr11": {
+    "reference-name": "Alien Skylight Large",
+    "name": "外星天窗(大)"
+  },
+  "rct2.tt.alnstr04": {
+    "reference-name": "Alien Skylight Small",
+    "name": "外星天窗(小)"
+  },
+  "rct2.tt.alnstr10": {
+    "reference-name": "Alien Structure Large",
+    "name": "外星建築(大)"
+  },
+  "rct2.tt.alnstr09": {
+    "reference-name": "Alien Structure Large",
+    "name": "外星建築(大)"
+  },
+  "rct2.tt.alnstr08": {
+    "reference-name": "Alien Structure Large",
+    "name": "外星建築(大)"
+  },
+  "rct2.tt.alnstr01": {
+    "reference-name": "Alien Structure Small",
+    "name": "外星建築物(小)"
+  },
+  "rct2.tt.alnstr03": {
+    "reference-name": "Alien Structure Small",
+    "name": "外星建築物(小)"
+  },
+  "rct2.tt.alnstr02": {
+    "reference-name": "Alien Structure Small",
+    "name": "外星建築物(小)"
+  },
+  "rct2.tt.alnstr05": {
+    "reference-name": "Alien Tower Bottom",
+    "name": "外星塔底"
+  },
+  "rct2.tt.alnstr06": {
+    "reference-name": "Alien Tower Middle",
+    "name": "外星塔中段"
+  },
+  "rct2.tt.alnstr07": {
+    "reference-name": "Alien Tower Top",
+    "name": "外星塔頂"
+  },
+  "rct2.tt.alentre2": {
+    "reference-name": "Alien Tree",
+    "name": "外星樹木"
+  },
+  "rct2.tt.alentre1": {
+    "reference-name": "Alien Tree",
+    "name": "外星樹木"
+  },
+  "rct2.tal": {
+    "reference-name": "Alligator Shaped Tree",
+    "name": "短吻鱷形的樹"
+  },
+  "rct2.ball2": {
+    "reference-name": "American Football",
+    "name": "美式足球"
+  },
+  "rct2.ball1": {
+    "reference-name": "American Football",
+    "name": "美式足球"
+  },
+  "rct2.helmet1": {
+    "reference-name": "American Football Helmet",
+    "name": "美式橄欖球頭盔"
+  },
+  "rct2.aml1": {
+    "reference-name": "American Style Steam Trains",
+    "name": "美式蒸氣火車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "配備著復刻蒸氣火車頭及煤水車的小型蒸氣火車, 拉著帶有帆布車頂的木製車廂",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "每車廂6位乘客"
+  },
+  "rct2.ww.anaconda": {
+    "reference-name": "Anaconda Trains",
+    "name": "Anaconda Trains",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "Spacious trains with simple lap restraints",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.tt.cookspit": {
+    "reference-name": "Animal cooking on Spit",
+    "name": "動物在噴火處煮食"
+  },
+  "rct2.ww.sballoon": {
+    "reference-name": "Animated Balloons",
+    "name": "Animated Balloons"
+  },
+  "rct2.ww.campfani": {
+    "reference-name": "Animated Camp Fire",
+    "name": "Animated Camp Fire"
+  },
+  "rct2.tt.allseeye": {
+    "reference-name": "Animatronic All Seeing Eye",
+    "name": "全知之眼機械偶"
+  },
+  "rct2.tt.argonau1": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "阿爾戈號機械偶"
+  },
+  "rct2.tt.argonau2": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "阿爾戈號機械偶"
+  },
+  "rct2.tt.argonau3": {
+    "reference-name": "Animatronic Argonaut",
+    "name": "阿爾戈號機械偶"
+  },
+  "rct2.tt.astrongt": {
+    "reference-name": "Animatronic Astronaut",
+    "name": "太空人機械偶"
+  },
+  "rct2.tt.cavemenx": {
+    "reference-name": "Animatronic Caveman lighting Fire",
+    "name": "原始人生火機械偶"
+  },
+  "rct2.tt.chanmaid": {
+    "reference-name": "Animatronic Chained Maiden",
+    "name": "被鐵鍊綑綁的少女機械偶"
+  },
+  "rct2.tt.clnsmen1": {
+    "reference-name": "Animatronic Clansman",
+    "name": "王室機械偶"
+  },
+  "rct2.tt.knfight2": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "黑暗騎士機械偶"
+  },
+  "rct2.tt.knfight1": {
+    "reference-name": "Animatronic Dark Knight",
+    "name": "黑暗騎士機械偶"
+  },
+  "rct2.tt.sdragfly": {
+    "reference-name": "Animatronic Dragonflies",
+    "name": "蜻蜓機械偶"
+  },
+  "rct2.tt.cagdstat": {
+    "reference-name": "Animatronic Eagle on Cage",
+    "name": "洞穴上的老鷹機械偶"
+  },
+  "rct2.tt.evalien2": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "邪惡外星人機械偶"
+  },
+  "rct2.tt.evalien1": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "邪惡外星人機械偶"
+  },
+  "rct2.tt.evalien3": {
+    "reference-name": "Animatronic Evil Alien",
+    "name": "邪惡外星人機械偶"
+  },
+  "rct2.tt.firemanx": {
+    "reference-name": "Animatronic Fireman",
+    "name": "消防隊機械偶"
+  },
+  "rct2.tt.fircanon": {
+    "reference-name": "Animatronic Firing Cannon",
+    "name": "火砲機械偶"
+  },
+  "rct2.tt.gangster": {
+    "reference-name": "Animatronic Gangster",
+    "name": "流氓機械偶"
+  },
+  "rct2.tt.gdalien2": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "善良外星人機械偶"
+  },
+  "rct2.tt.gdalien1": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "善良外星人機械偶"
+  },
+  "rct2.tt.gdalien3": {
+    "reference-name": "Animatronic Good Alien",
+    "name": "善良外星人機械偶"
+  },
+  "rct2.tt.dkfight1": {
+    "reference-name": "Animatronic Knight",
+    "name": "騎士機械偶"
+  },
+  "rct2.tt.dkfight2": {
+    "reference-name": "Animatronic Knight",
+    "name": "騎士機械偶"
+  },
+  "rct2.tt.mdusasta": {
+    "reference-name": "Animatronic Medusa",
+    "name": "美杜莎機械偶"
+  },
+  "rct2.tt.polwtbtn": {
+    "reference-name": "Animatronic Police Officer",
+    "name": "警察機械偶"
+  },
+  "rct2.tt.robnhood": {
+    "reference-name": "Animatronic Robin Hood",
+    "name": "羅賓漢機械偶"
+  },
+  "rct2.tt.skeleto1": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "骷?軍團機械偶"
+  },
+  "rct2.tt.skeleto2": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "骷?軍團機械偶"
+  },
+  "rct2.tt.skeleto3": {
+    "reference-name": "Animatronic Skeletal Army",
+    "name": "骷?軍團機械偶"
+  },
+  "rct2.tt.spacrang": {
+    "reference-name": "Animatronic Space Ranger",
+    "name": "太空騎警機械偶"
+  },
+  "rct2.tt.spiktail": {
+    "reference-name": "Animatronic Stegosaurus",
+    "name": "劍龍機械偶"
+  },
+  "rct2.tt.tyranrex": {
+    "reference-name": "Animatronic T-Rex",
+    "name": "暴龍機械偶"
+  },
+  "rct2.tt.strictop": {
+    "reference-name": "Animatronic Triceratops",
+    "name": "三角龍機械偶"
+  },
+  "rct2.tt.waveking": {
+    "reference-name": "Animatronic Waving King",
+    "name": "揮手的國王機械偶"
+  },
+  "rct2.tt.gscorpon": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "蠍子機械偶"
+  },
+  "rct2.tt.gscorpo2": {
+    "reference-name": "Animatronic attacking Scorpion",
+    "name": "蠍子機械偶"
+  },
+  "rct2.tt.spterdac": {
+    "reference-name": "Animatronic flapping Pterodactyl",
+    "name": "翼手龍機械偶"
+  },
+  "rct2.ww.scgartic": {
+    "reference-name": "Antarctic Themeing",
+    "name": "Antarctic Themeing"
+  },
+  "rct2.ww.antilopf": {
+    "reference-name": "Antelope Female",
+    "name": "Antelope Female"
+  },
+  "rct2.ww.antilopm": {
+    "reference-name": "Antelope Male",
+    "name": "Antelope Male"
+  },
+  "rct2.ww.antilopp": {
+    "reference-name": "Antelope Pair",
+    "name": "Antelope Pair"
+  },
+  "rct2.tt.fltsign2": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "反重力LCD廣告板"
+  },
+  "rct2.tt.fltsign1": {
+    "reference-name": "Anti-Gravity LCD Billboard",
+    "name": "反重力LCD廣告板"
+  },
+  "rct2.tt.medtrget": {
+    "reference-name": "Archery Target",
+    "name": "箭靶"
+  },
+  "rct2.tac": {
+    "reference-name": "Arizona Cypress Tree",
+    "name": "亞利桑那柏樹"
+  },
+  "rct2.tt.artdec07": {
+    "reference-name": "Art Deco Corner Section",
+    "name": "裝飾藝術牆角區段"
+  },
+  "rct2.tt.artdec12": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "裝置藝術牆角(含欄杆)"
+  },
+  "rct2.tt.artdec26": {
+    "reference-name": "Art Deco Corner with Railings",
+    "name": "裝置藝術牆角(含欄杆)"
+  },
+  "rct2.tt.artdec14": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "裝置藝術牆角(含窗戶)"
+  },
+  "rct2.tt.artdec11": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "裝置藝術牆角(含窗戶)"
+  },
+  "rct2.tt.artdec25": {
+    "reference-name": "Art Deco Corner with Windows",
+    "name": "裝置藝術牆角(含窗戶)"
+  },
+  "rct2.tt.1920sand": {
+    "reference-name": "Art Deco Food Stall",
+    "name": "裝置藝術食物攤位",
+    "reference-description": "A stall selling noodles and fresh Lemonade",
+    "description": "販賣麵類與新鮮檸檬水的攤位"
+  },
+  "rct2.tt.artdec29": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "反向裝置藝術牆角區段"
+  },
+  "rct2.tt.artdec02": {
+    "reference-name": "Art Deco Inverted Corner Section",
+    "name": "反向裝置藝術牆角區段"
+  },
+  "rct2.tt.artdec28": {
+    "reference-name": "Art Deco Roof Section",
+    "name": "裝飾藝術屋頂區段"
+  },
+  "rct2.tt.artdec08": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "裝飾藝術頂部牆角區段"
+  },
+  "rct2.tt.artdec13": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "裝飾藝術頂部牆角區段"
+  },
+  "rct2.tt.artdec27": {
+    "reference-name": "Art Deco Top Corner Section",
+    "name": "裝飾藝術頂部牆角區段"
+  },
+  "rct2.tt.artdec06": {
+    "reference-name": "Art Deco Top Section",
+    "name": "裝飾藝術頂部區段"
+  },
+  "rct2.tt.artdec18": {
+    "reference-name": "Art Deco Top Section",
+    "name": "裝飾藝術頂部區段"
+  },
+  "rct2.tt.artdec17": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec16": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec09": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec20": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec10": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec19": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec01": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec15": {
+    "reference-name": "Art Deco Wall Section",
+    "name": "裝飾藝術牆面區段"
+  },
+  "rct2.tt.artdec03": {
+    "reference-name": "Art Deco Wall with Door",
+    "name": "裝置藝術牆面(含門)"
+  },
+  "rct2.tt.artdec22": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "裝置藝術牆面(含欄杆)"
+  },
+  "rct2.tt.artdec23": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "裝置藝術牆面(含欄杆)"
+  },
+  "rct2.tt.artdec21": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "裝置藝術牆面(含欄杆)"
+  },
+  "rct2.tt.artdec24": {
+    "reference-name": "Art Deco Wall with Railings",
+    "name": "裝置藝術牆面(含欄杆)"
+  },
+  "rct2.tt.artdec04": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "裝置藝術牆面(含窗戶)"
+  },
+  "rct2.tt.artdec05": {
+    "reference-name": "Art Deco Wall with Windows",
+    "name": "裝置藝術牆面(含窗戶)"
+  },
+  "rct2.mft": {
+    "reference-name": "Articulated Roller Coaster Trains",
+    "name": "絞接式的雲霄飛車",
+    "reference-description": "Roller coaster trains with short single-row cars and open fronts",
+    "description": "雲霄飛車以前面開放型的短截單排列車為主",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每個車廂"
+  },
+  "rct2.pathash": {
+    "reference-name": "Ash Footpath",
+    "name": "梣木步道"
+  },
+  "rct2.tt.ashnymph": {
+    "reference-name": "Ash Tree with Nymphs",
+    "name": "自然諸女神與梣木"
+  },
+  "rct2.ww.scgasia": {
+    "reference-name": "Asia Themeing",
+    "name": "Asia Themeing"
+  },
+  "rct2.ww.oriegong": {
+    "reference-name": "Asian Gong",
+    "name": "Asian Gong"
+  },
+  "rct2.tas": {
+    "reference-name": "Aspen Tree",
+    "name": "山楊樹"
+  },
+  "rct2.tt.titansta": {
+    "reference-name": "Atlas Statue",
+    "name": "泰坦神雕像"
+  },
+  "rct2.ww.atomium": {
+    "reference-name": "Atomium",
+    "name": "Atomium"
+  },
+  "rct2.ww.ozentran": {
+    "reference-name": "Australasian Park Entrance",
+    "name": "Australasian Park Entrance"
+  },
+  "rct2.ww.scgaustr": {
+    "reference-name": "Australasian Themeing",
+    "name": "Australasian Themeing"
+  },
+  "rct2.ww.fountrow": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.ww.fountarc": {
+    "reference-name": "Australian Fountain Set 2",
+    "name": "Australian Fountain Set 2"
+  },
+  "rct2.wcatc": {
+    "reference-name": "Automobile Cars",
+    "name": "衝鋒汽車",
+    "reference-description": "Roller coaster cars in the shape of automobiles",
+    "description": "雲霄飛車車輛的外形是汽車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.ggntocto": {
+    "reference-name": "B-Movie Giant Octopus",
+    "name": "二流片大章魚"
+  },
+  "rct2.tt.ggntspid": {
+    "reference-name": "B-Movie Giant Spider",
+    "name": "二流片大蜘蛛"
+  },
+  "rct2.tt.gintspdr": {
+    "reference-name": "B-Movie Giant Spider Ride",
+    "name": "二流片大蜘蛛遊樂設施",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
+    "description": "乘客兩人一組乘坐在主題座椅上，繞著一隻二流片中的大蜘蛛旋轉",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.ww.babyele": {
+    "reference-name": "Baby Indian Elephant",
+    "name": "Baby Indian Elephant"
+  },
+  "rct2.ww.babpanda": {
+    "reference-name": "Baby Panda",
+    "name": "Baby Panda"
+  },
+  "rct2.badrack": {
+    "reference-name": "Badminton Racket",
+    "name": "羽毛球拍"
+  },
+  "rct2.wallbadm": {
+    "reference-name": "Badminton Racket",
+    "name": "羽球拍"
+  },
+  "rct2.ww.balllant": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.ww.balllan2": {
+    "reference-name": "Ball Lantern",
+    "name": "Ball Lantern"
+  },
+  "rct2.balln": {
+    "reference-name": "Balloon Stall",
+    "name": "氣球店",
+    "reference-description": "A souvenir stall selling helium-filled balloons",
+    "description": "一家紀念品店賣充氦氣的氣球"
+  },
+  "rct2.ww.bamboobs": {
+    "reference-name": "Bamboo Bush",
+    "name": "Bamboo Bush"
+  },
+  "rct2.ww.bamboopl": {
+    "reference-name": "Bamboo Plinth",
+    "name": "Bamboo Plinth"
+  },
+  "rct2.ww.bamborf2": {
+    "reference-name": "Bamboo Roof",
+    "name": "Bamboo Roof"
+  },
+  "rct2.ww.bamborf1": {
+    "reference-name": "Bamboo Roof Corner",
+    "name": "Bamboo Roof Corner"
+  },
+  "rct2.ww.bamborf3": {
+    "reference-name": "Bamboo Roof Inverted Corner",
+    "name": "Bamboo Roof Inverted Corner"
+  },
+  "rct2.dlc.pandagr": {
+    "reference-name": "Bamboo Shoots",
+    "name": "竹子林"
+  },
+  "rct2.ww.wbambo13": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo05": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo21": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo02": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo11": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo03": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo04": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo15": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo01": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo14": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambopc": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.ww.wbambo12": {
+    "reference-name": "Bamboo Wall",
+    "name": "Bamboo Wall"
+  },
+  "rct2.tt.stgband4": {
+    "reference-name": "Band Member",
+    "name": "樂團成員"
+  },
+  "rct2.tt.stgband2": {
+    "reference-name": "Band Member",
+    "name": "樂團成員"
+  },
+  "rct2.tt.stgband1": {
+    "reference-name": "Band Member",
+    "name": "樂團成員"
+  },
+  "rct2.tt.stgband3": {
+    "reference-name": "Band Member",
+    "name": "樂團成員"
+  },
+  "rct2.wwbank": {
+    "reference-name": "Bank",
+    "name": "銀行"
+  },
+  "rct2.tt.barnstrm": {
+    "reference-name": "Barnstorming Trains",
+    "name": "巡迴演出雲霄飛車",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
+    "description": "遊客坐在懸吊在軌道下的座椅上，當快速通過大型旋轉迴圈，令人感覺有俯衝下墜感。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.tbr1": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr4": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr2": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.tbr3": {
+    "reference-name": "Barrel",
+    "name": "桶"
+  },
+  "rct2.brbase2": {
+    "reference-name": "Base Block",
+    "name": "壘包"
+  },
+  "rct2.brbase": {
+    "reference-name": "Base Block",
+    "name": "壘包"
+  },
+  "rct2.brbase3": {
+    "reference-name": "Base Block",
+    "name": "壘包"
+  },
+  "other.xxbbbr01": {
+    "reference-name": "Base Block",
+    "name": "壘包"
+  },
+  "rct2.tt.battrram": {
+    "reference-name": "Battering Ram Trains",
+    "name": "破城槌雲霄飛車",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
+    "description": "一座以螺旋上升斜坡結合鋼鐵軌道的雲霄飛車且以成列就座的車輛運行",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "每輛車限乘6人"
+  },
+  "rct2.bnoodles": {
+    "reference-name": "Beef Noodles Stall",
+    "name": "牛肉麵 店",
+    "reference-description": "A stall selling Chinese style beef noodles",
+    "description": "一家賣中式牛肉麵的店"
+  },
+  "rct2.bench1": {
+    "reference-name": "Bench",
+    "name": "長椅"
+  },
+  "rct2.benchlog": {
+    "reference-name": "Bench",
+    "name": "長椅"
+  },
+  "rct2.benchspc": {
+    "reference-name": "Bench",
+    "name": "長椅"
+  },
+  "rct2.tt.medbench": {
+    "reference-name": "Benches",
+    "name": "板凳"
+  },
+  "rct2.ww.tigrtwst": {
+    "reference-name": "Bengal Tiger Cars",
+    "name": "Bengal Tiger Cars",
+    "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.monbk": {
+    "reference-name": "Bicycles",
+    "name": "空中腳踏車",
+    "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
+    "description": "特殊的腳踏車在單軌鐵路軌道上運行,由乘客自行腳踏前進",
+    "reference-capacity": "1 rider per bicycle",
+    "capacity": "1 位乘客/每輛腳踏車"
+  },
+  "rct2.ww.bigben": {
+    "reference-name": "Big Ben and the Houses of Parliament",
+    "name": "Big Ben and the Houses of Parliament"
+  },
+  "rct2.ww.biggeosp": {
+    "reference-name": "Big Geosphere",
+    "name": "Big Geosphere"
+  },
+  "rct2.tt.bkrgang1": {
+    "reference-name": "Biker",
+    "name": "摩托車騎士"
+  },
+  "rct2.tb2": {
+    "reference-name": "Black Bishop",
+    "name": "黑主教"
+  },
+  "rct2.ww.blackcab": {
+    "reference-name": "Black Cabs",
+    "name": "Black Cabs",
+    "reference-description": "Powered vehicles in the shape of London Taxis",
+    "description": "Powered vehicles in the shape of London Taxis",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.blckdeth": {
+    "reference-name": "Black Death Trains",
+    "name": "黑死病遊樂設施",
+    "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "乘客在老鼠外形的車輛中只有依循著彎曲的半圓形軌道急速地猛衝旋轉前進",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.tk4": {
+    "reference-name": "Black King",
+    "name": "黑棋國王"
+  },
+  "rct2.tk2": {
+    "reference-name": "Black Knight",
+    "name": "黑棋騎士"
+  },
+  "rct2.tp2": {
+    "reference-name": "Black Pawn",
+    "name": "黑棋兵"
+  },
+  "rct2.tbp": {
+    "reference-name": "Black Poplar Tree",
+    "name": "黯淡白楊樹"
+  },
+  "rct2.tq2": {
+    "reference-name": "Black Queen",
+    "name": "黑棋皇后"
+  },
+  "rct2.tr2": {
+    "reference-name": "Black Rook",
+    "name": "黑棋車"
+  },
+  "rct2.tt.bmvoctps": {
+    "reference-name": "Blob from Outer Space",
+    "name": "外太空生物遊樂設施",
+    "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
+    "description": "主題觀察艙旋轉移動到高塔上面",
+    "reference-capacity": "20 passengers",
+    "capacity": "限乘20人"
+  },
+  "rct2.sktbaset": {
+    "reference-name": "Block",
+    "name": "積木"
+  },
+  "rct2.sktbase": {
+    "reference-name": "Block",
+    "name": "積木"
+  },
+  "rct2.bob1": {
+    "reference-name": "Bobsleigh Trains",
+    "name": "雪橇飛車",
+    "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "以雪橇成型的車子，在彎曲的斜坡鐵軌上僅由曲率導引向下俯衝",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每個車廂"
+  },
+  "rct2.tt.bolpot01": {
+    "reference-name": "Boiling Pot",
+    "name": "沸騰的鍋子"
+  },
+  "rct2.tbn": {
+    "reference-name": "Bone",
+    "name": "骨頭"
+  },
+  "rct2.wbw": {
+    "reference-name": "Bone Fence",
+    "name": "骨頭柵欄"
+  },
+  "rct2.tbn1": {
+    "reference-name": "Bones",
+    "name": "骨頭"
+  },
+  "rct2.ww.1x1brang": {
+    "reference-name": "Boomerang",
+    "name": "Boomerang"
+  },
+  "rct2.ww.bomerang": {
+    "reference-name": "Boomerang Trains",
+    "name": "Boomerang Trains",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "description": "Air-powered launched roller coaster trains in the shape of boomerangs",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct1.edge.brick": {
+    "reference-name": "Brick",
+    "name": "Brick"
+  },
+  "rct2.wbr1": {
+    "reference-name": "Brick Wall",
+    "name": "磚牆"
+  },
+  "rct2.wbr1a": {
+    "reference-name": "Brick Wall",
+    "name": "磚牆"
+  },
+  "rct2.wbrg": {
+    "reference-name": "Brick Wall",
+    "name": "磚牆"
+  },
+  "rct2.ww.postbox": {
+    "reference-name": "British Post Box",
+    "name": "British Post Box"
+  },
+  "rct2.ww.ukphone": {
+    "reference-name": "British Telephone Box",
+    "name": "British Telephone Box"
+  },
+  "rct2.ww.bstatue1": {
+    "reference-name": "Broken Statue",
+    "name": "Broken Statue"
+  },
+  "rct2.tbw": {
+    "reference-name": "Broken Wheel",
+    "name": "破輪子"
+  },
+  "rct2.tarmacb": {
+    "reference-name": "Brown Tarmac Footpath",
+    "name": "棕色柏油碎石步道"
+  },
+  "rct1.pathtilb": {
+    "reference-name": "Brown Tiled Footpath",
+    "name": "Brown Tiled Footpath"
+  },
+  "rct2.tt.tarpit03": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit05": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit11": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit04": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit10": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit12": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit02": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit09": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit13": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit07": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit06": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit14": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit08": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.tarpit01": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.4x4trpit": {
+    "reference-name": "Bubbling Tarpit",
+    "name": "冒泡的瀝青坑"
+  },
+  "rct2.tt.mdbucket": {
+    "reference-name": "Bucket",
+    "name": "木桶"
+  },
+  "rct2.tsc2": {
+    "reference-name": "Building",
+    "name": "建築物"
+  },
+  "rct2.toh3": {
+    "reference-name": "Building",
+    "name": "建築物"
+  },
+  "rct2.ww.bullet": {
+    "reference-name": "Bullet Trains",
+    "name": "Bullet Trains",
+    "reference-description": "Japanese Bullet Train themed roller coaster cars",
+    "description": "Japanese Bullet Train themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tbr": {
+    "reference-name": "Bulrushes",
+    "name": "香蒲"
+  },
+  "rct2.bboat": {
+    "reference-name": "Bumper Boats",
+    "name": "碰碰船",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "由乘客在有動力裝置的小型圓型小船內操控中心馬達",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 位乘客/每艘船"
+  },
+  "rct2.tt.schnbouy": {
+    "reference-name": "Buoy",
+    "name": "救生圈"
+  },
+  "rct2.tt.schnbost": {
+    "reference-name": "Buoy",
+    "name": "救生圈"
+  },
+  "rct2.burgb": {
+    "reference-name": "Burger Bar",
+    "name": "漢堡店",
+    "reference-description": "A burger-shaped building selling burgers",
+    "description": "漢堡形狀的建築物在賣漢堡"
+  },
+  "rct2.tjb4": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb3": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh2": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb1": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh3": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh0": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tjb2": {
+    "reference-name": "Bush",
+    "name": "灌木"
+  },
+  "rct2.tsh5": {
+    "reference-name": "Bush",
+    "name": "樹叢"
+  },
+  "rct2.buttfly": {
+    "reference-name": "Butterfly",
+    "name": "蝴蝶"
+  },
+  "rct2.ww.sbwplm02": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sb2palm1": {
+    "reference-name": "Cabana Porch",
+    "name": "Cabana Porch"
+  },
+  "rct2.ww.sbwplm03": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm05": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm04": {
+    "reference-name": "Cabana Roof Piece",
+    "name": "Cabana Roof Piece"
+  },
+  "rct2.ww.sbwplm01": {
+    "reference-name": "Cabana Top",
+    "name": "Cabana Top"
+  },
+  "rct2.ww.sbwplm07": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm08": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.sbwplm06": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm03": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm01": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm04": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm02": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.ww.wpalm05": {
+    "reference-name": "Cabana Wall Piece",
+    "name": "Cabana Wall Piece"
+  },
+  "rct2.tct": {
+    "reference-name": "Cabbage Tree",
+    "name": "甘藍樹"
+  },
+  "rct2.tbc": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.tsc": {
+    "reference-name": "Cactus",
+    "name": "仙人掌"
+  },
+  "rct2.ww.sbh3cac2": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac3": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.ww.sbh3cac1": {
+    "reference-name": "Cactus",
+    "name": "Cactus"
+  },
+  "rct2.tce": {
+    "reference-name": "Camperdown Elm Tree",
+    "name": "榆樹"
+  },
+  "rct2.th1": {
+    "reference-name": "Canary Palm Tree",
+    "name": "加那利島棕櫚樹"
+  },
+  "rct2.allsort1": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.allsort2": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.tas4": {
+    "reference-name": "Candy",
+    "name": "糖果"
+  },
+  "rct2.cndyrk1": {
+    "reference-name": "Candy Stick",
+    "name": "糖果棒"
+  },
+  "rct2.tas2": {
+    "reference-name": "Candy Tree",
+    "name": "糖果樹"
+  },
+  "rct2.tas3": {
+    "reference-name": "Candy Tree",
+    "name": "糖果樹"
+  },
+  "rct2.tas1": {
+    "reference-name": "Candy Tree",
+    "name": "糖果樹"
+  },
+  "rct2.music.candy": {
+    "reference-name": "Candy style",
+    "name": "糖果風格"
+  },
+  "rct2.cndyf": {
+    "reference-name": "Candyfloss Stall",
+    "name": "棉花糖店",
+    "reference-description": "A candyfloss shaped building selling pink candyfloss",
+    "description": "一間棉花糖式的建築物在賣粉紅色棉花糖"
+  },
+  "rct2.tcn": {
+    "reference-name": "Cannon",
+    "name": "大砲"
+  },
+  "rct2.prcan": {
+    "reference-name": "Cannon",
+    "name": "大砲"
+  },
+  "rct2.cnballs": {
+    "reference-name": "Cannon Balls",
+    "name": "砲彈"
+  },
+  "rct2.cboat": {
+    "reference-name": "Canoes",
+    "name": "獨木舟",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "長型的獨木舟由遊客自行划槳前進",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2位乘客/每個獨木舟"
+  },
+  "rct2.tntroof1": {
+    "reference-name": "Canvas Roof",
+    "name": "帆布屋頂"
+  },
+  "rct2.station.canvastent": {
+    "reference-name": "Canvas Tent",
+    "name": "Canvas Tent"
+  },
+  "rct2.ww.crnvbfly": {
+    "reference-name": "Carnival Butterfly Cars",
+    "name": "Carnival Butterfly Cars",
+    "reference-description": "Cars in the shape of butterfly carnival floats",
+    "description": "Cars in the shape of butterfly carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvfrog": {
+    "reference-name": "Carnival Frog Cars",
+    "name": "Carnival Frog Cars",
+    "reference-description": "Cars in the shape of frog carnival floats",
+    "description": "Cars in the shape of frog carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.crnvlzrd": {
+    "reference-name": "Carnival Lizard Cars",
+    "name": "Carnival Lizard Cars",
+    "reference-description": "Cars in the shape of lizard carnival floats",
+    "description": "Cars in the shape of lizard carnival floats",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.ww.trckprt4": {
+    "reference-name": "Cart Shaft",
+    "name": "Cart Shaft"
+  },
+  "rct2.atm1": {
+    "reference-name": "Cash Machine",
+    "name": "提款機",
+    "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
+    "description": "一台提款機可以提供遊客錢花光時可以提領現金"
+  },
+  "rct2.station.castlebrown": {
+    "reference-name": "Castle (Brown)",
+    "name": "Castle (Brown)"
+  },
+  "rct2.station.castlegrey": {
+    "reference-name": "Castle (Grey)",
+    "name": "Castle (Grey)"
+  },
+  "rct2.tt.mcastl09": {
+    "reference-name": "Castle Corner Piece",
+    "name": "城堡牆角塊"
+  },
+  "rct2.tt.mcastl19": {
+    "reference-name": "Castle Corner Piece",
+    "name": "城堡牆角塊"
+  },
+  "rct2.tt.mcastl12": {
+    "reference-name": "Castle Entrance",
+    "name": "城堡入口"
+  },
+  "rct2.tt.mcastl01": {
+    "reference-name": "Castle Inverted Corner",
+    "name": "反向城堡牆角塊"
+  },
+  "rct2.tt.mcastl11": {
+    "reference-name": "Castle Portcullis",
+    "name": "城堡升降門"
+  },
+  "rct2.tt.mcastl06": {
+    "reference-name": "Castle Ramparts",
+    "name": "城堡壁壘"
+  },
+  "rct2.tt.mcastl05": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城堡壁壘牆角"
+  },
+  "rct2.tt.mcastl10": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城堡壁壘牆角"
+  },
+  "rct2.tt.mcastl07": {
+    "reference-name": "Castle Ramparts Corner",
+    "name": "城堡壁壘牆角"
+  },
+  "rct2.tt.mcastl08": {
+    "reference-name": "Castle Ramparts Inverted Corner",
+    "name": "反向城堡壁壘牆角"
+  },
+  "rct2.tct1": {
+    "reference-name": "Castle Tower",
+    "name": "城樓"
+  },
+  "rct2.tct2": {
+    "reference-name": "Castle Tower",
+    "name": "城樓"
+  },
+  "rct2.stg2": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔樓"
+  },
+  "rct2.stb2": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔樓"
+  },
+  "rct2.stg1": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔樓"
+  },
+  "rct2.stb1": {
+    "reference-name": "Castle Tower",
+    "name": "城堡塔樓"
+  },
+  "rct2.tt.mcastl13": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "城樓牆角塊"
+  },
+  "rct2.tt.mcastl14": {
+    "reference-name": "Castle Tower Corner Piece",
+    "name": "城樓牆角塊"
+  },
+  "rct2.tt.mcastl15": {
+    "reference-name": "Castle Tower Cross Piece",
+    "name": "城樓交叉塊"
+  },
+  "rct2.tt.mcastl16": {
+    "reference-name": "Castle Tower Straight Piece",
+    "name": "城樓直線塊"
+  },
+  "rct2.tt.mcastl17": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "城樓 T 形塊"
+  },
+  "rct2.tt.mcastl18": {
+    "reference-name": "Castle Tower T Piece",
+    "name": "城樓 T 形塊"
+  },
+  "rct2.wc10": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc9": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc4": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc11": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc2": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc12": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc13": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc1": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc8": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc7": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc6": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.wc5": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.tt.mcastl02": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.tt.mcastl04": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.tt.mcastl03": {
+    "reference-name": "Castle Wall",
+    "name": "城堡牆"
+  },
+  "rct2.ww.sbh3cskl": {
+    "reference-name": "Cattle Skull",
+    "name": "Cattle Skull"
+  },
+  "rct2.tcf": {
+    "reference-name": "Caucasian Fir Tree",
+    "name": "高加索冷杉樹"
+  },
+  "rct2.tcd": {
+    "reference-name": "Cauldron",
+    "name": "大汽鍋"
+  },
+  "rct2.tt.caventra": {
+    "reference-name": "Cave Entrance",
+    "name": "洞穴入口"
+  },
+  "rct2.tt.cavmncar": {
+    "reference-name": "Caveman Cars",
+    "name": "原始人列車",
+    "reference-description": "Self-drive go-karts in Stone Age style",
+    "description": "乘客以石器時代高卡賽車彼此競速",
+    "reference-capacity": "Single-seater",
+    "capacity": "單一乘客"
+  },
+  "rct2.tcl": {
+    "reference-name": "Cedar of Lebanon Tree",
+    "name": "黎巴嫩西洋杉"
+  },
+  "rct2.tt.cerberus": {
+    "reference-name": "Cerberus Trains",
+    "name": "三頭狗雲霄飛車",
+    "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
+    "description": "坐在只有單純循環設施的舒適列車中，享受著列車平穩地下降及轉彎和在山丘上空遊覽的空中時間。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.clift1": {
+    "reference-name": "Chairlift Cars",
+    "name": "纜車車卡",
+    "reference-description": "Open cars for chairlift",
+    "description": "供纜車使用的開放式車卡",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每車卡2位乘客"
+  },
+  "rct2.chbbase": {
+    "reference-name": "Checkerboard Block",
+    "name": "西洋跳棋棋盤"
+  },
+  "rct2.surface.chequerboard": {
+    "reference-name": "Chequerboard",
+    "name": "Chequerboard"
+  },
+  "rct2.ctcar": {
+    "reference-name": "Cheshire Cats",
+    "name": "笑臉貓遊",
+    "reference-description": "Powered cat-shaped vehicles",
+    "description": "帶有動力的貓型車輛跟隨著軌道的路線遊覽周邊",
+    "reference-capacity": "2 passengers per cat",
+    "capacity": "每輛車2位乘客"
+  },
+  "rct2.chknug": {
+    "reference-name": "Chicken Nuggets Stall",
+    "name": "香雞肉珍品店",
+    "reference-description": "A stall selling fried chicken nuggets",
+    "description": "一家賣炸雞肉的店"
+  },
+  "rct2.tcc": {
+    "reference-name": "Chinese Cedar Tree",
+    "name": "中國雪松"
+  },
+  "rct2.ww.cdragon": {
+    "reference-name": "Chinese Dragon",
+    "name": "Chinese Dragon"
+  },
+  "rct2.ww.dragdodg": {
+    "reference-name": "Chinese Dragonhead Ride",
+    "name": "Chinese Dragonhead Ride",
+    "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
+    "description": "Guests battle each other in dragonhead-shaped dodgems",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.ww.junkswng": {
+    "reference-name": "Chinese Junk Swing Ride",
+    "name": "Chinese Junk Swing Ride",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 passengers"
+  },
+  "rct2.chpsh": {
+    "reference-name": "Chip Shop",
+    "name": "洋芋片店",
+    "reference-description": "A hut selling chips",
+    "description": "一間賣洋芋片的小屋子"
+  },
+  "rct2.chpsh2": {
+    "reference-name": "Chips Stall",
+    "name": "炸薯條店",
+    "reference-description": "A stall selling chips",
+    "description": "一家賣炸薯條的店"
+  },
+  "rct2.chocroof": {
+    "reference-name": "Chocolate Bar",
+    "name": "巧克力條"
+  },
+  "rct2.tt.futrpath": {
+    "reference-name": "Circuit FootPath",
+    "name": "循環道路"
+  },
+  "rct2.circus1": {
+    "reference-name": "Circus",
+    "name": "馬戲團",
+    "reference-description": "Circus animal show inside a big-top tent",
+    "description": "於大型帳幕內進行動物馬戲團表演",
+    "reference-capacity": "30 guests",
+    "capacity": "30位遊客"
+  },
+  "rct2.ww.circus": {
+    "reference-name": "Circus",
+    "name": "Circus"
+  },
+  "rct2.station.classical": {
+    "reference-name": "Classical / Roman",
+    "name": "Classical / Roman"
+  },
+  "rct2.bn3": {
+    "reference-name": "Classical Style Sign",
+    "name": "古典風格 招牌"
+  },
+  "rct2.scgclass": {
+    "reference-name": "Classical/Roman Themeing",
+    "name": "古典/古羅馬主題區"
+  },
+  "rct2.ten": {
+    "reference-name": "Cleopatra's Needle",
+    "name": "古埃及豔后針柱"
+  },
+  "rct2.tt.killrvin": {
+    "reference-name": "Climbing Vine Tree",
+    "name": "爬藤樹"
+  },
+  "rct2.tck": {
+    "reference-name": "Clock",
+    "name": "時鐘"
+  },
+  "rct2.tcb": {
+    "reference-name": "Club Shaped Tree",
+    "name": "梅花形的樹"
+  },
+  "rct2.cstboat": {
+    "reference-name": "Coaster Boats",
+    "name": "飛船",
+    "reference-description": "Boat-shaped roller coaster cars",
+    "description": "船形式的雲霄飛車車輛",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 位乘客/每輛船"
+  },
+  "rct2.ww.coffeecu": {
+    "reference-name": "Coffee Cup Ride",
+    "name": "Coffee Cup Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.coffs": {
+    "reference-name": "Coffee Shop",
+    "name": "咖啡店",
+    "reference-description": "An art-deco style shop selling cups of coffee",
+    "description": "一間立體派裝飾風格的商店在賣咖啡"
+  },
+  "rct2.cog1r": {
+    "reference-name": "Cogwheel",
+    "name": "木齒鐵輪"
+  },
+  "rct2.cog1ur": {
+    "reference-name": "Cogwheel",
+    "name": "木齒鐵輪"
+  },
+  "rct2.cog1": {
+    "reference-name": "Cogwheel",
+    "name": "木齒鐵輪"
+  },
+  "rct2.cog1u": {
+    "reference-name": "Cogwheel",
+    "name": "木齒鐵輪"
+  },
+  "rct2.colagum": {
+    "reference-name": "Cola Candy",
+    "name": "可樂糖果"
+  },
+  "rct2.scln": {
+    "reference-name": "Colonnade",
+    "name": "柱廊"
+  },
+  "rct2.tcj": {
+    "reference-name": "Common Juniper Tree",
+    "name": "一般檜樹"
+  },
+  "rct2.tco": {
+    "reference-name": "Common Oak Tree",
+    "name": "一般橡樹"
+  },
+  "rct2.tcy": {
+    "reference-name": "Common Yew Tree",
+    "name": "一般紫杉樹"
+  },
+  "rct2.slct": {
+    "reference-name": "Compact Inverted Coaster Trains",
+    "name": "簡潔的反轉飛車",
+    "reference-description": "Riders sit in pairs of seats suspended beneath the track",
+    "description": "乘客成對地坐在懸掛在軌道下的坐椅一起歷經牢固的反轉迴圈快速旋轉",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.ww.condorrd": {
+    "reference-name": "Condor Trains",
+    "name": "神鷹暢遊",
+    "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
+    "description": "乘客乘坐於軌道下的神鷹造型列車上, 將會於飛馳中體驗飛一般的快感",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每車卡4位乘客"
+  },
+  "rct2.ww.congaeel": {
+    "reference-name": "Conger Eel Trains",
+    "name": "Conger Eel Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
+    "description": "Trains with shoulder restraints, in the shape of conger eels",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.wch": {
+    "reference-name": "Conifer Hedge",
+    "name": "松柏籬芭"
+  },
+  "rct2.wchg": {
+    "reference-name": "Conifer Hedge",
+    "name": "松柏籬芭"
+  },
+  "rct2.ww.conveyr1": {
+    "reference-name": "Conveyer Belt Corner",
+    "name": "Conveyer Belt Corner"
+  },
+  "rct2.ww.conveyr5": {
+    "reference-name": "Conveyer Belt Corner Reverse",
+    "name": "Conveyer Belt Corner Reverse"
+  },
+  "rct2.ww.conveyr3": {
+    "reference-name": "Conveyer Belt End",
+    "name": "Conveyer Belt End"
+  },
+  "rct2.ww.conveyr2": {
+    "reference-name": "Conveyer Belt Rise",
+    "name": "Conveyer Belt Rise"
+  },
+  "rct2.ww.conveyr4": {
+    "reference-name": "Conveyer Belt Straight",
+    "name": "Conveyer Belt Straight"
+  },
+  "rct2.cookst": {
+    "reference-name": "Cookie Shop",
+    "name": "小餅乾店",
+    "reference-description": "A stall selling giant cookies",
+    "description": "一家賣巨大餅乾的店"
+  },
+  "rct2.tt.rcknrolr": {
+    "reference-name": "Cool Dude",
+    "name": "酷哥"
+  },
+  "rct2.arrt1": {
+    "reference-name": "Corkscrew Roller Coaster Trains",
+    "name": "螺旋體雲霄飛車",
+    "reference-description": "Roller coaster trains with shoulder restraints",
+    "description": "一座雲霄飛車列車穿過成圈結實的鋼製螺旋式軌道曲折前進",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ww.rcorr02": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr03": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr10": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr05": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr07": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr01": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr09": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr04": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr08": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.ww.rcorr11": {
+    "reference-name": "Corrugated Roof Piece",
+    "name": "Corrugated Roof Piece"
+  },
+  "rct2.corroof2": {
+    "reference-name": "Corrugated Steel Base",
+    "name": "波紋的鋼製基底"
+  },
+  "rct2.corroof": {
+    "reference-name": "Corrugated Steel Roof",
+    "name": "波紋的鋼製屋頂"
+  },
+  "rct2.wallco16": {
+    "reference-name": "Corrugated Steel Wall",
+    "name": "波紋鐵牆"
+  },
+  "rct2.ww.wcorr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr12": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr15": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr06": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr16": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr13": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr01": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr10": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w3corr07": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr11": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr04": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr08": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr03": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr14": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr02": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.w2corr05": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.ww.wcorr09": {
+    "reference-name": "Corrugated Wall Piece",
+    "name": "Corrugated Wall Piece"
+  },
+  "rct2.tcrp": {
+    "reference-name": "Corsican Pine Tree",
+    "name": "松樹"
+  },
+  "rct2.ww.cowboy01": {
+    "reference-name": "Cowboy 1",
+    "name": "Cowboy 1"
+  },
+  "rct2.ww.cowboy02": {
+    "reference-name": "Cowboy 2",
+    "name": "Cowboy 2"
+  },
+  "rct2.pathcrzy": {
+    "reference-name": "Crazy Paving Footpath",
+    "name": "古怪步道"
+  },
+  "rct2.scghallo": {
+    "reference-name": "Creepy Themeing",
+    "name": "戰慄主題區"
+  },
+  "rct2.ww.crocflum": {
+    "reference-name": "Crocodile Boats",
+    "name": "Crocodile Boats",
+    "reference-description": "Crocodile-shaped boats built for running in water channels",
+    "description": "Crocodile-shaped boats built for running in water channels",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.chbuild": {
+    "reference-name": "Crooked House",
+    "name": "古怪屋",
+    "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
+    "description": "一座建築物, 含有扭曲房間及傾斜走道使人於行走中失去方向感",
+    "reference-capacity": "5 guests",
+    "capacity": "5位遊客"
+  },
+  "rct2.tqf": {
+    "reference-name": "Cupid Fountains",
+    "name": "邱比特噴泉"
+  },
+  "rct2.cwfcrv33": {
+    "reference-name": "Curved Block",
+    "name": "彎曲式積木"
+  },
+  "rct2.cwbcrv33": {
+    "reference-name": "Curved Block",
+    "name": "彎曲式積木"
+  },
+  "rct2.ww.rmud01": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud03": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.ww.rmud02": {
+    "reference-name": "Curved Mud Wall Piece",
+    "name": "Curved Mud Wall Piece"
+  },
+  "rct2.brcrrf2": {
+    "reference-name": "Curved Roof",
+    "name": "彎曲式屋頂"
+  },
+  "rct2.brcrrf1": {
+    "reference-name": "Curved Roof",
+    "name": "彎曲式屋頂"
+  },
+  "rct2.cwbcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "彎曲狀牆"
+  },
+  "rct2.cwfcrv32": {
+    "reference-name": "Curved Wall",
+    "name": "彎曲狀牆"
+  },
+  "rct2.music.custom1": {
+    "reference-name": "Custom music 1",
+    "name": "自訂音樂1"
+  },
+  "rct2.music.custom2": {
+    "reference-name": "Custom music 2",
+    "name": "自訂音樂2"
+  },
+  "rct2.tt.cyclopsx": {
+    "reference-name": "Cyclops Ride",
+    "name": "獨眼巨人遊樂設施",
+    "reference-description": "Riders drive the Eye of a Giant Cyclops",
+    "description": "乘客駕駛獨眼巨人之眼",
+    "reference-capacity": "1 person per car",
+    "capacity": "每輛車限乘1人"
+  },
+  "rct2.tt.cyclopss": {
+    "reference-name": "Cyclops Statue",
+    "name": "獨眼巨人雕像"
+  },
+  "rct2.lampdsy": {
+    "reference-name": "Daisy Lamp",
+    "name": "雛菊燈"
+  },
+  "rct2.ww.damtower": {
+    "reference-name": "Dam Tower",
+    "name": "Dam Tower"
+  },
+  "rct2.tt.medientr": {
+    "reference-name": "Dark Age Entrance",
+    "name": "黑暗時代入口"
+  },
+  "rct2.tt.scgmediv": {
+    "reference-name": "Dark Age Themeing",
+    "name": "黑暗時代主題區"
+  },
+  "rct2.tt.psntwl31": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "黑暗時代村莊屋頂轉角塊"
+  },
+  "rct2.tt.psntwl27": {
+    "reference-name": "Dark Age Village Corner Roof Piece",
+    "name": "黑暗時代村莊屋頂轉角塊"
+  },
+  "rct2.tt.psntwl15": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "反向黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl28": {
+    "reference-name": "Dark Age Village Inverted Roof Piece",
+    "name": "反向黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl08": {
+    "reference-name": "Dark Age Village Lower Corner Piece",
+    "name": "黑暗時代矮牆角塊"
+  },
+  "rct2.tt.psntwl07": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl06": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl05": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl02": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl04": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl03": {
+    "reference-name": "Dark Age Village Lower Wall Piece",
+    "name": "黑暗時代矮牆塊"
+  },
+  "rct2.tt.psntwl16": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl17": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl14": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl26": {
+    "reference-name": "Dark Age Village Roof Piece",
+    "name": "黑暗時代村莊屋頂塊"
+  },
+  "rct2.tt.psntwl01": {
+    "reference-name": "Dark Age Village Roof with Chimney",
+    "name": "黑暗時代村莊屋頂(含煙囪)"
+  },
+  "rct2.tt.psntwl23": {
+    "reference-name": "Dark Age Village Upper Corner Piece",
+    "name": "黑暗時代高牆牆角塊"
+  },
+  "rct2.tt.psntwl10": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "黑暗時代高牆塊"
+  },
+  "rct2.tt.psntwl09": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "黑暗時代高牆塊"
+  },
+  "rct2.tt.psntwl11": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "黑暗時代高牆塊"
+  },
+  "rct2.tt.psntwl12": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "黑暗時代高牆塊"
+  },
+  "rct2.tt.psntwl13": {
+    "reference-name": "Dark Age Village Upper Wall Piece",
+    "name": "黑暗時代高牆塊"
+  },
+  "rct2.tt.psntwl25": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "黑暗時代村莊窗框"
+  },
+  "rct2.tt.psntwl24": {
+    "reference-name": "Dark Age Village Window Box",
+    "name": "黑暗時代村莊窗框"
+  },
+  "rct2.tt.psntwl21": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "黑暗時代村莊屋頂窗框"
+  },
+  "rct2.tt.psntwl29": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "黑暗時代村莊屋頂窗框"
+  },
+  "rct2.tt.psntwl30": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "黑暗時代村莊屋頂窗框"
+  },
+  "rct2.tt.psntwl20": {
+    "reference-name": "Dark Age Village Window Box Roof",
+    "name": "黑暗時代村莊屋頂窗框"
+  },
+  "rct2.tt.tavernxx": {
+    "reference-name": "Dark Ages Tavern",
+    "name": "黑暗時代酒館"
+  },
+  "rct2.tdt2": {
+    "reference-name": "Dead Tree",
+    "name": "樹"
+  },
+  "rct2.tdt3": {
+    "reference-name": "Dead Tree",
+    "name": "?樹"
+  },
+  "rct2.tdt1": {
+    "reference-name": "Dead Tree",
+    "name": "?樹"
+  },
+  "rct2.ww.dhowwatr": {
+    "reference-name": "Dhow Boats",
+    "name": "Dhow Boats",
+    "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
+    "description": "Decorative fishing boats, which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.ww.trckprt1": {
+    "reference-name": "Diamond Cart",
+    "name": "Diamond Cart"
+  },
+  "rct2.ww.diamondr": {
+    "reference-name": "Diamond Ride",
+    "name": "Diamond Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "description": "Riders ride in pairs of themed seats rotating around a large diamond",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.trckprt3": {
+    "reference-name": "Diamond Shaft",
+    "name": "Diamond Shaft"
+  },
+  "rct2.tdm": {
+    "reference-name": "Diamond Shaped Tree",
+    "name": "恐龍形狀的樹"
+  },
+  "rct2.ww.1x1didge": {
+    "reference-name": "Digeridoo",
+    "name": "Digeridoo"
+  },
+  "rct2.ding1": {
+    "reference-name": "Dinghies",
+    "name": "滑行小船",
+    "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
+    "description": "乘客在膨脹的小船滑下到半圓型或完整封閉管道內滑行",
+    "reference-capacity": "2 passengers per dinghy",
+    "capacity": "2 位乘客 /每艘小船"
+  },
+  "rct2.tdn4": {
+    "reference-name": "Dinosaur",
+    "name": "恐龍"
+  },
+  "rct2.tdn5": {
+    "reference-name": "Dinosaur",
+    "name": "恐龍"
+  },
+  "rct2.sdn1": {
+    "reference-name": "Dinosaur",
+    "name": "恐龍"
+  },
+  "rct2.sdn2": {
+    "reference-name": "Dinosaur",
+    "name": "恐龍"
+  },
+  "rct2.sdn3": {
+    "reference-name": "Dinosaur",
+    "name": "恐龍"
+  },
+  "rct2.tt.dinoeggs": {
+    "reference-name": "Dinosaur Egg Ride",
+    "name": "恐龍蛋遊樂設施",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
+    "description": "乘客兩人一組乘坐在各種主題的座位上，繞著動畫恐龍媽媽旋轉。",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.surface.dirt": {
+    "reference-name": "Dirt",
+    "name": "Dirt"
+  },
+  "rct2.pathdirt": {
+    "reference-name": "Dirt Footpath",
+    "name": "泥土步道"
+  },
+  "rct2.dodg1": {
+    "reference-name": "Dodgems",
+    "name": "碰碰車",
+    "reference-description": "Riders bump into each other in self-drive electric dodgems",
+    "description": "自助駕駛的電力碰碰車",
+    "reference-capacity": "1 person per car",
+    "capacity": "每車輛1位乘客"
+  },
+  "rct2.music.dodgems": {
+    "reference-name": "Dodgems beat style",
+    "name": "碰碰車節奏風格"
+  },
+  "rct2.ww.dolphinr": {
+    "reference-name": "Dolphin Boats",
+    "name": "Dolphin Boats",
+    "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1 rider per vehicle"
+  },
+  "rct2.tdf": {
+    "reference-name": "Dolphin Fountain",
+    "name": "海豚噴泉"
+  },
+  "rct2.tstd": {
+    "reference-name": "Dolphins Statue",
+    "name": "海豚雕像"
+  },
+  "rct2.wallcfdr": {
+    "reference-name": "Doorway",
+    "name": "門口"
+  },
+  "rct2.wallbrdr": {
+    "reference-name": "Doorway",
+    "name": "入口"
+  },
+  "rct2.wallcbdr": {
+    "reference-name": "Doorway",
+    "name": "門口"
+  },
+  "rct2.tt.mgr2": {
+    "reference-name": "Double Deck Carousel",
+    "name": "雙層旋轉木馬",
+    "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
+    "description": "傳統隔絕式雙層旋轉木馬,內有木雕馬匹",
+    "reference-capacity": "32 passengers",
+    "capacity": "限乘32人"
+  },
+  "rct2.obs2": {
+    "reference-name": "Double-deck Cabin",
+    "name": "雙層式瞭望台",
+    "reference-description": "Twin-deck rotating observation cabin",
+    "description": "雙層式觀察艙旋轉移動到高塔上面",
+    "reference-capacity": "32 passengers",
+    "capacity": "32 位乘客"
+  },
+  "rct2.dough": {
+    "reference-name": "Doughnut Shop",
+    "name": "甜甜圈店",
+    "reference-description": "A stall selling ring-shaped doughnuts",
+    "description": "一家賣圓形的油炸圈餅"
+  },
+  "rct2.ww.rdrab02": {
+    "reference-name": "Drab Large Tower Base",
+    "name": "Drab Large Tower Base"
+  },
+  "rct2.ww.rdrab04": {
+    "reference-name": "Drab Large Tower Broken Base",
+    "name": "Drab Large Tower Broken Base"
+  },
+  "rct2.ww.rdrab01": {
+    "reference-name": "Drab Large Tower Mid-Section",
+    "name": "Drab Large Tower Mid-Section"
+  },
+  "rct2.ww.rdrab03": {
+    "reference-name": "Drab Large Tower Top",
+    "name": "Drab Large Tower Top"
+  },
+  "rct2.ww.rdrab08": {
+    "reference-name": "Drab Minaret Piece 1",
+    "name": "Drab Minaret Piece 1"
+  },
+  "rct2.ww.rdrab09": {
+    "reference-name": "Drab Minaret Piece 2",
+    "name": "Drab Minaret Piece 2"
+  },
+  "rct2.ww.rdrab10": {
+    "reference-name": "Drab Minaret Piece 3",
+    "name": "Drab Minaret Piece 3"
+  },
+  "rct2.ww.rdrab11": {
+    "reference-name": "Drab Roof Piece 1",
+    "name": "Drab Roof Piece 1"
+  },
+  "rct2.ww.rdrab12": {
+    "reference-name": "Drab Roof Piece 2",
+    "name": "Drab Roof Piece 2"
+  },
+  "rct2.ww.rdrab13": {
+    "reference-name": "Drab Roof Piece 3",
+    "name": "Drab Roof Piece 3"
+  },
+  "rct2.ww.rdrab14": {
+    "reference-name": "Drab Roof Piece 4",
+    "name": "Drab Roof Piece 4"
+  },
+  "rct2.ww.rdrab07": {
+    "reference-name": "Drab Small Tower Base",
+    "name": "Drab Small Tower Base"
+  },
+  "rct2.ww.rdrab05": {
+    "reference-name": "Drab Small Tower Minaret Base",
+    "name": "Drab Small Tower Minaret Base"
+  },
+  "rct2.ww.rdrab06": {
+    "reference-name": "Drab Small Tower Top or Mid-Section",
+    "name": "Drab Small Tower Top or Mid-Section"
+  },
+  "rct2.ww.wdrab09": {
+    "reference-name": "Drab Step-up Piece 1",
+    "name": "Drab Step-up Piece 1"
+  },
+  "rct2.ww.wdrab13": {
+    "reference-name": "Drab Step-up Piece 2",
+    "name": "Drab Step-up Piece 2"
+  },
+  "rct2.ww.wdrab01": {
+    "reference-name": "Drab Wall Piece 1",
+    "name": "Drab Wall Piece 1"
+  },
+  "rct2.ww.wdrab11": {
+    "reference-name": "Drab Wall Piece 10",
+    "name": "Drab Wall Piece 10"
+  },
+  "rct2.ww.wdrab12": {
+    "reference-name": "Drab Wall Piece 11",
+    "name": "Drab Wall Piece 11"
+  },
+  "rct2.ww.wdrab02": {
+    "reference-name": "Drab Wall Piece 2",
+    "name": "Drab Wall Piece 2"
+  },
+  "rct2.ww.wdrab03": {
+    "reference-name": "Drab Wall Piece 3",
+    "name": "Drab Wall Piece 3"
+  },
+  "rct2.ww.wdrab04": {
+    "reference-name": "Drab Wall Piece 4",
+    "name": "Drab Wall Piece 4"
+  },
+  "rct2.ww.wdrab05": {
+    "reference-name": "Drab Wall Piece 5",
+    "name": "Drab Wall Piece 5"
+  },
+  "rct2.ww.wdrab06": {
+    "reference-name": "Drab Wall Piece 6",
+    "name": "Drab Wall Piece 6"
+  },
+  "rct2.ww.wdrab07": {
+    "reference-name": "Drab Wall Piece 7",
+    "name": "Drab Wall Piece 7"
+  },
+  "rct2.ww.wdrab08": {
+    "reference-name": "Drab Wall Piece 8",
+    "name": "Drab Wall Piece 8"
+  },
+  "rct2.ww.wdrab10": {
+    "reference-name": "Drab Wall Piece 9",
+    "name": "Drab Wall Piece 9"
+  },
+  "rct2.tt.drgnattk": {
+    "reference-name": "Dragon Attacking",
+    "name": "火龍攻擊"
+  },
+  "rct2.ww.dragon": {
+    "reference-name": "Dragon Trains",
+    "name": "Dragon Trains",
+    "reference-description": "Dragon-themed roller coaster cars",
+    "description": "Dragon-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.dragnfly": {
+    "reference-name": "Dragonfly Cars",
+    "name": "大蜻蜓雲霄飛車",
+    "reference-description": "Dragonfly-shaped cars which swing from the rail above",
+    "description": "乘客搭乘懸掛在單軌軌道上的特殊車輛，在軌道兩端自由?盪",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.drnks": {
+    "reference-name": "Drinks Stall",
+    "name": "飲料店",
+    "reference-description": "A can-shaped stall selling fizzy drinks",
+    "description": "一家飲料罐外形的店在賣氣泡式飲料"
+  },
+  "rct2.ww.easerlnd": {
+    "reference-name": "Easter Island Statue",
+    "name": "Easter Island Statue"
+  },
+  "rct2.tep": {
+    "reference-name": "Egyptian Column",
+    "name": "古埃及柱廊"
+  },
+  "rct2.tes1": {
+    "reference-name": "Egyptian Statue",
+    "name": "埃及的雕像"
+  },
+  "rct2.bn4": {
+    "reference-name": "Egyptian Style Sign",
+    "name": "埃及風格 招牌"
+  },
+  "rct2.scgegypt": {
+    "reference-name": "Egyptian Themeing",
+    "name": "埃及主題區"
+  },
+  "rct2.wew": {
+    "reference-name": "Egyptian Wall",
+    "name": "埃及的牆"
+  },
+  "rct2.music.egyptian": {
+    "reference-name": "Egyptian style",
+    "name": "埃及風格"
+  },
+  "rct2.ww.eiffel": {
+    "reference-name": "Eiffel Tower",
+    "name": "Eiffel Tower"
+  },
+  "rct2.tt.elecfen2": {
+    "reference-name": "Electric Fence",
+    "name": "通電柵欄"
+  },
+  "rct2.tt.elecfen4": {
+    "reference-name": "Electric Fence Broken",
+    "name": "通電柵欄損壞"
+  },
+  "rct2.tt.elecfen1": {
+    "reference-name": "Electric Fence Corner Piece",
+    "name": "通電柵欄牆角塊"
+  },
+  "rct2.tt.elecfen5": {
+    "reference-name": "Electric Fence Inverted Corner Piece",
+    "name": "反向通電柵欄牆角塊"
+  },
+  "rct2.tt.elecfen3": {
+    "reference-name": "Electric Fence with Light",
+    "name": "有燈光的通電柵欄"
+  },
+  "rct2.tef": {
+    "reference-name": "Elephant Fountain",
+    "name": "大象噴水池"
+  },
+  "rct2.ww.trckprt2": {
+    "reference-name": "Empty Cart",
+    "name": "Empty Cart"
+  },
+  "rct2.ww.1x1emuxx": {
+    "reference-name": "Emu",
+    "name": "Emu"
+  },
+  "rct2.enterp": {
+    "reference-name": "Enterprise",
+    "name": "飛天轉輪",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "旋轉輪以懸吊遊客太空艙,首先以旋轉開始再以一支支架支撐升起",
+    "reference-capacity": "16 passengers",
+    "capacity": "16位客人"
+  },
+  "rct2.ww.3x3eucal": {
+    "reference-name": "Eucalyptus Tree",
+    "name": "Eucalyptus Tree"
+  },
+  "rct2.ww.scgeurop": {
+    "reference-name": "Europe Themeing",
+    "name": "Europe Themeing"
+  },
+  "rct2.tel": {
+    "reference-name": "European Larch Tree",
+    "name": "歐洲落葉松樹"
+  },
+  "rct2.ww.euroent": {
+    "reference-name": "European Park Entrance",
+    "name": "European Park Entrance"
+  },
+  "rct2.ww.evilsam": {
+    "reference-name": "Evil Samurai",
+    "name": "Evil Samurai"
+  },
+  "rct2.ww.faberge": {
+    "reference-name": "Fabergé Egg Ride",
+    "name": "Fabergé Egg Ride",
+    "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.slcfo": {
+    "reference-name": "Face-off Cars",
+    "name": "反向穿梭飛車",
+    "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "乘客面對面或背對背坐著一起歷經牢固的反轉迴圈快速旋轉",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.music.fairground": {
+    "reference-name": "Fairground organ style",
+    "name": "遊樂場風琴風格"
+  },
+  "rct2.music.fantasy": {
+    "reference-name": "Fantasy style",
+    "name": "夢幻風格"
+  },
+  "rct2.tt.medtools": {
+    "reference-name": "Farm Tools",
+    "name": "耕田工具"
+  },
+  "rct2.ww.fatbudda": {
+    "reference-name": "Fat Buddha",
+    "name": "Fat Buddha"
+  },
+  "rct2.tt.feastabl": {
+    "reference-name": "Feast Table",
+    "name": "宴席桌"
+  },
+  "rct2.wpf": {
+    "reference-name": "Fence",
+    "name": "柵欄"
+  },
+  "rct2.wc16": {
+    "reference-name": "Fence",
+    "name": "柵欄"
+  },
+  "rct2.wpfg": {
+    "reference-name": "Fence",
+    "name": "柵欄"
+  },
+  "rct2.scgfence": {
+    "reference-name": "Fences and Walls",
+    "name": "柵欄和牆"
+  },
+  "rct2.fwh1": {
+    "reference-name": "Ferris Wheel",
+    "name": "摩天輪",
+    "reference-description": "Rotating big wheel with open chairs",
+    "description": "不斷旋轉, 附有露天座椅的巨大輪環",
+    "reference-capacity": "32 passengers",
+    "capacity": "32位乘客"
+  },
+  "rct2.tt.frbeacon": {
+    "reference-name": "Fiery Beacon",
+    "name": "烽火臺"
+  },
+  "rct2.ww.fightkit": {
+    "reference-name": "Fighting Kite Ride",
+    "name": "Fighting Kite Ride",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.tt.figtknit": {
+    "reference-name": "Fighting Knights Dodgems",
+    "name": "戰鬥騎士碰碰車",
+    "reference-description": "Riders joust on horse-themed dodgems",
+    "description": "乘客在主題為馬的碰碰車上競技",
+    "reference-capacity": "1 person per car",
+    "capacity": "每輛車限乘1人"
+  },
+  "rct2.ww.firecrak": {
+    "reference-name": "Fire Cracker Ride",
+    "name": "Fire Cracker Ride",
+    "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.tt.firhydrt": {
+    "reference-name": "Fire Hydrant",
+    "name": "消防栓"
+  },
+  "rct2.faid1": {
+    "reference-name": "First Aid Room",
+    "name": "急救室",
+    "reference-description": "A place for sick guests to go for faster recovery",
+    "description": "一間讓生病的遊客能迅速回復的急救室"
+  },
+  "rct2.ww.fishhole": {
+    "reference-name": "Fish Hole",
+    "name": "Fish Hole"
+  },
+  "rct2.ww.fstatue1": {
+    "reference-name": "Fixed Statue",
+    "name": "Fixed Statue"
+  },
+  "rct2.fire1": {
+    "reference-name": "Flames",
+    "name": "火焰"
+  },
+  "rct2.ww.flamngo1": {
+    "reference-name": "Flamingo Feeding",
+    "name": "Flamingo Feeding"
+  },
+  "rct2.ww.flamngo2": {
+    "reference-name": "Flamingo Looking",
+    "name": "Flamingo Looking"
+  },
+  "rct2.ww.flamngo3": {
+    "reference-name": "Flamingo Preening",
+    "name": "Flamingo Preening"
+  },
+  "rct2.bmfl": {
+    "reference-name": "Floorless Twister Trains",
+    "name": "無地板式雲霄飛車",
+    "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
+    "description": "瘋狂的雲霄飛車列車沒有給乘客地板,在疾速經過旋轉軌道及多樣反轉刺激時感受在空中的感覺",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tjf": {
+    "reference-name": "Flower",
+    "name": "花"
+  },
+  "rct2.tt.flwrpowr": {
+    "reference-name": "Flower Power Ride",
+    "name": "花的魅力遊樂設施",
+    "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
+    "description": "由乘客操縱花朵外形,中央嵌有馬達的小艇",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "每輛車限乘1人"
+  },
+  "rct2.tt.1960tsrt": {
+    "reference-name": "Flower Power T-Shirts",
+    "name": "花的魅力T恤",
+    "reference-description": "Stall selling T-shirts with a flower motif",
+    "description": "販賣有花朵圖案的T恤"
+  },
+  "rct2.tt.flygboat": {
+    "reference-name": "Flying Boats",
+    "name": "飛行船遊樂設施",
+    "reference-description": "Roller coaster cars shaped like flying boats",
+    "description": "飛船外形的列車在雲霄飛車軌道上的曲線迴轉及陡坡急墜軌道上運行,將平靜的河面激起大量的水花。",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "每艘船限乘6人"
+  },
+  "rct2.bmair": {
+    "reference-name": "Flying Roller Coaster Trains",
+    "name": "飛行雲霄飛車",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
+    "description": "乘客被固定軌道下的舒適座位,途經穿過最終極瘋狂軌道的飛行體驗",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.fsauc": {
+    "reference-name": "Flying Saucers",
+    "name": "碰碰飛碟",
+    "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
+    "description": "自助駕駛的飛碟型車輛",
+    "reference-capacity": "1 person per car",
+    "capacity": "每飛碟1位乘客"
+  },
+  "rct2.ball3": {
+    "reference-name": "Football",
+    "name": "足球"
+  },
+  "rct2.ww.football": {
+    "reference-name": "Football Trains",
+    "name": "Football Trains",
+    "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.forbidft": {
+    "reference-name": "Forbidden Fruit Tree",
+    "name": "禁果樹"
+  },
+  "rct2.tt.shwdfrst": {
+    "reference-name": "Forest Trees",
+    "name": "森林樹木"
+  },
+  "rct2.wdiag": {
+    "reference-name": "Fountain",
+    "name": "噴水池"
+  },
+  "rct2.ttf": {
+    "reference-name": "Fountain",
+    "name": "噴泉"
+  },
+  "rct2.ivmc1": {
+    "reference-name": "Four-seater Cars",
+    "name": "反轉U型飛車",
+    "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
+    "description": "反轉飛車在U型迴轉及垂直向下急轉軌道上運行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.chcks": {
+    "reference-name": "Fried Chicken Stall",
+    "name": "炸雞店",
+    "reference-description": "A stall selling tubs of fried chicken",
+    "description": "一間賣整桶式炸雞的商店"
+  },
+  "rct2.frnood": {
+    "reference-name": "Fried Rice Noodles Stall",
+    "name": "炒米粉 店",
+    "reference-description": "A stall selling Chinese style fried rice noodles",
+    "description": "一家賣中式炒米粉的店"
+  },
+  "rct2.jeldrop1": {
+    "reference-name": "Fruit Drop",
+    "name": "成熟果實"
+  },
+  "rct2.jeldrop2": {
+    "reference-name": "Fruit Drop",
+    "name": "成熟果實"
+  },
+  "rct2.tf1": {
+    "reference-name": "Fruit Tree",
+    "name": "果樹"
+  },
+  "rct2.tf2": {
+    "reference-name": "Fruit Tree",
+    "name": "果樹"
+  },
+  "rct2.icecr1": {
+    "reference-name": "Fruity Ices Stall",
+    "name": "水果冰店",
+    "reference-description": "A themed stall selling fruity ice creams",
+    "description": "以水果冰淇淋為主題的商店"
+  },
+  "rct2.tt.funhouse": {
+    "reference-name": "Fun House",
+    "name": "歡樂屋",
+    "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
+    "description": "建築中的牆和地板會不斷移動,讓人迷失方向感",
+    "reference-capacity": "5 guests",
+    "capacity": "5位遊客"
+  },
+  "rct2.funcake": {
+    "reference-name": "Funnel Cake Shop",
+    "name": "糕餅店",
+    "reference-description": "A stall selling funnel cakes",
+    "description": "一家賣糕餅的店"
+  },
+  "rct2.tt.scgfutur": {
+    "reference-name": "Future Themeing",
+    "name": "未來主題區"
+  },
+  "rct2.tt.futurent": {
+    "reference-name": "Futuristic Park Entrance",
+    "name": "未來主題公園入口"
+  },
+  "rct2.hang1": {
+    "reference-name": "Gallows",
+    "name": "絞刑臺"
+  },
+  "rct2.tt.ganstrcr": {
+    "reference-name": "Gangster Cars",
+    "name": "盜匪車雲霄飛車",
+    "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
+    "description": "以1920年代為主題的盜匪車輛,被直線推進動力以加速推離車站並快速通過倒置旋轉軌道",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.tg2": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg12": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg20": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg9": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg15": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg5": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg10": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg21": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg11": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg4": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg8": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg14": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg3": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg18": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg6": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg17": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg19": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg1": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg13": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg7": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.tg16": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.scggardn": {
+    "reference-name": "Gardens",
+    "name": "花園"
+  },
+  "rct2.ww.geisha": {
+    "reference-name": "Geisha",
+    "name": "Geisha"
+  },
+  "rct2.genstore": {
+    "reference-name": "General Store",
+    "name": "普通商店"
+  },
+  "rct2.music.gentle": {
+    "reference-name": "Gentle style",
+    "name": "溫和風格"
+  },
+  "rct2.twf": {
+    "reference-name": "Geometric Fountain",
+    "name": "幾何狀的水池"
+  },
+  "rct2.tge2": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何狀的雕刻品"
+  },
+  "rct2.tge4": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何狀的雕刻品"
+  },
+  "rct2.tge1": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何狀的雕刻品"
+  },
+  "rct2.tge3": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何狀的雕刻品"
+  },
+  "rct2.tge5": {
+    "reference-name": "Geometric Sculpture",
+    "name": "幾何狀的雕刻品"
+  },
+  "rct2.ww.rgeorg11": {
+    "reference-name": "Georgian Flat Roof Corner",
+    "name": "Georgian Flat Roof Corner"
+  },
+  "rct2.ww.rgeorg09": {
+    "reference-name": "Georgian Flat Roof Edge 1",
+    "name": "Georgian Flat Roof Edge 1"
+  },
+  "rct2.ww.rgeorg10": {
+    "reference-name": "Georgian Flat Roof Edge 2",
+    "name": "Georgian Flat Roof Edge 2"
+  },
+  "rct2.ww.wgeorg02": {
+    "reference-name": "Georgian Ground Floor Wall Piece 1",
+    "name": "Georgian Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wgeorg04": {
+    "reference-name": "Georgian Ground Floor Wall Piece 2",
+    "name": "Georgian Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wgeorg06": {
+    "reference-name": "Georgian Ground Floor Wall Piece 3",
+    "name": "Georgian Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wgeorg07": {
+    "reference-name": "Georgian Ground Floor Wall Piece 4",
+    "name": "Georgian Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 5",
+    "name": "Georgian Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wgeorg09": {
+    "reference-name": "Georgian Ground Floor Wall Piece 6",
+    "name": "Georgian Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.rgeorg08": {
+    "reference-name": "Georgian Ground Floor Wall Piece 7",
+    "name": "Georgian Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.rgeorg01": {
+    "reference-name": "Georgian Roof End Piece 1",
+    "name": "Georgian Roof End Piece 1"
+  },
+  "rct2.ww.rgeorg02": {
+    "reference-name": "Georgian Roof End Piece 2",
+    "name": "Georgian Roof End Piece 2"
+  },
+  "rct2.ww.rgeorg03": {
+    "reference-name": "Georgian Roof Piece 1",
+    "name": "Georgian Roof Piece 1"
+  },
+  "rct2.ww.rgeorg04": {
+    "reference-name": "Georgian Roof Piece 2",
+    "name": "Georgian Roof Piece 2"
+  },
+  "rct2.ww.rgeorg05": {
+    "reference-name": "Georgian Roof Piece 3",
+    "name": "Georgian Roof Piece 3"
+  },
+  "rct2.ww.rgeorg06": {
+    "reference-name": "Georgian Roof Piece 4",
+    "name": "Georgian Roof Piece 4"
+  },
+  "rct2.ww.rgeorg07": {
+    "reference-name": "Georgian Roof Piece 5",
+    "name": "Georgian Roof Piece 5"
+  },
+  "rct2.ww.rgeorg12": {
+    "reference-name": "Georgian Roof Piece 7",
+    "name": "Georgian Roof Piece 7"
+  },
+  "rct2.ww.wgeorg01": {
+    "reference-name": "Georgian Wall Piece 1",
+    "name": "Georgian Wall Piece 1"
+  },
+  "rct2.ww.wgeorg03": {
+    "reference-name": "Georgian Wall Piece 2",
+    "name": "Georgian Wall Piece 2"
+  },
+  "rct2.ww.wgeorg05": {
+    "reference-name": "Georgian Wall Piece 3",
+    "name": "Georgian Wall Piece 3"
+  },
+  "rct2.ww.wgeorg10": {
+    "reference-name": "Georgian Wall Piece 4",
+    "name": "Georgian Wall Piece 4"
+  },
+  "rct2.ww.wgeorg11": {
+    "reference-name": "Georgian Wall Piece 5",
+    "name": "Georgian Wall Piece 5"
+  },
+  "rct2.ww.wgeorg12": {
+    "reference-name": "Georgian Wall Piece 6",
+    "name": "Georgian Wall Piece 6"
+  },
+  "rct2.tt.geyserxx": {
+    "reference-name": "Geysers",
+    "name": "間歇泉"
+  },
+  "rct2.gtc": {
+    "reference-name": "Ghost Train Cars",
+    "name": "幽靈列車",
+    "reference-description": "Powered monster-shaped cars that run on a ghost train track",
+    "description": "有機動裝置的怪物造型列車遊歷著多層次的軌道經過有幽靈式的景物及特殊特效",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2位乘客/每個車廂"
+  },
+  "rct2.tt.bigbassx": {
+    "reference-name": "Giant Bass Guitar",
+    "name": "巨型低音吉他"
+  },
+  "rct2.beanst2": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大的豆莖"
+  },
+  "rct2.beanst1": {
+    "reference-name": "Giant Beanstalk",
+    "name": "巨大的豆莖"
+  },
+  "rct2.scgcandy": {
+    "reference-name": "Giant Candy Themeing",
+    "name": "糖果屋主題"
+  },
+  "rct2.carrot": {
+    "reference-name": "Giant Carrot",
+    "name": "巨大的胡蘿蔔"
+  },
+  "rct2.tt.footprnt": {
+    "reference-name": "Giant Dinosaur Footprint",
+    "name": "大恐龍的腳印"
+  },
+  "rct2.tt.bigdrums": {
+    "reference-name": "Giant Drum Kit",
+    "name": "巨型鼓"
+  },
+  "rct2.fern1": {
+    "reference-name": "Giant Fern",
+    "name": "巨大的蕨"
+  },
+  "rct2.scggiant": {
+    "reference-name": "Giant Garden Themeing",
+    "name": "巨大花園主題區"
+  },
+  "rct2.ggrs1": {
+    "reference-name": "Giant Grass",
+    "name": "大型牧草"
+  },
+  "rct2.tt.biggutar": {
+    "reference-name": "Giant Guitar",
+    "name": "巨型吉他"
+  },
+  "rct2.tt.4x4gmant": {
+    "reference-name": "Giant Mangrove Tree",
+    "name": "熱帶雨林樹"
+  },
+  "rct2.dlc.bigpanda": {
+    "reference-name": "Giant Panda",
+    "name": "巨大的熊貓"
+  },
+  "rct2.sgp": {
+    "reference-name": "Giant Pumpkin",
+    "name": "巨大南瓜"
+  },
+  "rct2.tsf2": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.tsf1": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.tsf3": {
+    "reference-name": "Giant Snowflake",
+    "name": "巨大雪花"
+  },
+  "rct2.intst": {
+    "reference-name": "Giga Coaster Trains",
+    "name": "巨大雲霄飛車",
+    "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
+    "description": "一座巨大的鋼製雲霄飛車有能力可以緩慢的落下及爬坡達300英尺",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4位乘客/每個車廂"
+  },
+  "rct2.ww.giraffe1": {
+    "reference-name": "Giraffe 1",
+    "name": "Giraffe 1"
+  },
+  "rct2.ww.giraffe2": {
+    "reference-name": "Giraffe 2",
+    "name": "Giraffe 2"
+  },
+  "rct2.tgs": {
+    "reference-name": "Giraffe Statue",
+    "name": "長頸鹿雕像"
+  },
+  "rct2.georoof2": {
+    "reference-name": "Glass Roof",
+    "name": "玻璃屋頂"
+  },
+  "rct2.georoof1": {
+    "reference-name": "Glass Roof",
+    "name": "玻璃屋頂"
+  },
+  "rct2.wallgl16": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃牆"
+  },
+  "rct2.wallgl8": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃牆"
+  },
+  "rct2.wgw2": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃牆"
+  },
+  "rct2.wallgl32": {
+    "reference-name": "Glass Wall",
+    "name": "玻璃牆"
+  },
+  "rct2.kart1": {
+    "reference-name": "Go-Karts",
+    "name": "高卡賽車",
+    "reference-description": "Self-drive petrol-engined go-karts",
+    "description": "自己駕駛汽油引擎式的高卡賽車",
+    "reference-capacity": "single-seater",
+    "capacity": "單一乘客"
+  },
+  "rct2.ww.1x2glama": {
+    "reference-name": "Gold Llama",
+    "name": "Gold Llama"
+  },
+  "rct2.ww.gdstaue1": {
+    "reference-name": "Gold Statue 1",
+    "name": "Gold Statue 1"
+  },
+  "rct2.ww.gdstaue2": {
+    "reference-name": "Gold Statue 2",
+    "name": "Gold Statue 2"
+  },
+  "rct2.ww.goldbuda": {
+    "reference-name": "Golden Buddha",
+    "name": "Golden Buddha"
+  },
+  "rct2.tt.goldflec": {
+    "reference-name": "Golden Fleece",
+    "name": "黃金羊毛"
+  },
+  "rct2.tghc": {
+    "reference-name": "Golden Hinoki Cypress Tree",
+    "name": "黃金扁柏樹"
+  },
+  "rct2.tgg": {
+    "reference-name": "Gong",
+    "name": "銅鑼"
+  },
+  "rct2.ww.goodsam": {
+    "reference-name": "Good Samurai",
+    "name": "Good Samurai"
+  },
+  "rct2.ww.gorilla": {
+    "reference-name": "Gorilla Trains",
+    "name": "Gorilla Trains",
+    "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.surface.grass": {
+    "reference-name": "Grass",
+    "name": "Grass"
+  },
+  "rct2.surface.grassclumps": {
+    "reference-name": "Grass Clumps",
+    "name": "Grass Clumps"
+  },
+  "rct2.tgs3": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs1": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs2": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tgs4": {
+    "reference-name": "Grave Stone",
+    "name": "墓碑/墓石"
+  },
+  "rct2.tmm2": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓園遺蹟"
+  },
+  "rct2.tmm1": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓園遺蹟"
+  },
+  "rct2.tmm3": {
+    "reference-name": "Graveyard Monument",
+    "name": "墓園遺蹟"
+  },
+  "rct2.ww.wgwoc1": {
+    "reference-name": "Great Wall Of China Front Wall Section",
+    "name": "Great Wall Of China Front Wall Section"
+  },
+  "rct2.ww.wgwoc2": {
+    "reference-name": "Great Wall Of China Rear Wall Section",
+    "name": "Great Wall Of China Rear Wall Section"
+  },
+  "rct2.ww.wgwoc3": {
+    "reference-name": "Great Wall Of China Step up Wall Section",
+    "name": "Great Wall Of China Step up Wall Section"
+  },
+  "rct2.ww.gwoctur2": {
+    "reference-name": "Great Wall Of China Turret Corner",
+    "name": "Great Wall Of China Turret Corner"
+  },
+  "rct2.ww.gwoctur1": {
+    "reference-name": "Great Wall Of China Turret Straight",
+    "name": "Great Wall Of China Turret Straight"
+  },
+  "rct2.ww.gratwhte": {
+    "reference-name": "Great White Shark Trains",
+    "name": "Great White Shark Trains",
+    "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "description": "Trains with shoulder restraints, in the shape of a great white shark",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tarmacg": {
+    "reference-name": "Green Tarmac Footpath",
+    "name": "綠色柏油碎石步道"
+  },
+  "rct2.wtrgrn": {
+    "reference-name": "Green Water",
+    "name": "綠水"
+  },
+  "rct1.ll.pathtilg": {
+    "reference-name": "Green and Brown Tiled Footpath",
+    "name": "Green and Brown Tiled Footpath"
+  },
+  "rct1.aa.pathtils": {
+    "reference-name": "Grey Tiled Footpath",
+    "name": "Grey Tiled Footpath"
+  },
+  "rct2.surface.gridgreen": {
+    "reference-name": "Grid (Green)",
+    "name": "Grid (Green)"
+  },
+  "rct2.surface.gridpurple": {
+    "reference-name": "Grid (Purple)",
+    "name": "Grid (Purple)"
+  },
+  "rct2.surface.gridred": {
+    "reference-name": "Grid (Red)",
+    "name": "Grid (Red)"
+  },
+  "rct2.surface.gridyellow": {
+    "reference-name": "Grid (Yellow)",
+    "name": "Grid (Yellow)"
+  },
+  "rct2.tt.fwrprdc1": {
+    "reference-name": "Groovy Dancer",
+    "name": "時髦的舞者"
+  },
+  "rct2.ww.3x3hmsen": {
+    "reference-name": "HMS Endeavour",
+    "name": "HMS Endeavour"
+  },
+  "rct2.tt.hadesxxx": {
+    "reference-name": "Hades Statue",
+    "name": "冥王雕像"
+  },
+  "rct2.tt.halofmrs": {
+    "reference-name": "Hall of Mirrors",
+    "name": "鏡屋",
+    "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
+    "description": "建築物中有變形的鏡子,會將觀看鏡子的人的影響扭曲",
+    "reference-capacity": "5 guests",
+    "capacity": "5位遊客"
+  },
+  "rct2.tt.hrbwal11": {
+    "reference-name": "Harbour Dock",
+    "name": "港口船塢"
+  },
+  "rct2.tt.hrbwal01": {
+    "reference-name": "Harbour Wall",
+    "name": "港口牆面"
+  },
+  "rct2.tt.hrbwal08": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "港口牆牆角塊"
+  },
+  "rct2.tt.hrbwal07": {
+    "reference-name": "Harbour Wall Corner Piece",
+    "name": "港口牆牆角塊"
+  },
+  "rct2.tt.hrbwal09": {
+    "reference-name": "Harbour Wall with Dock",
+    "name": "港口牆面(含船塢)"
+  },
+  "rct2.tt.hrbwal02": {
+    "reference-name": "Harbour Wall with Fishing Gear",
+    "name": "港口牆面(含捕魚用具)"
+  },
+  "rct2.tt.hrbwal06": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "港口牆面(含固定樁)"
+  },
+  "rct2.tt.hrbwal04": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "港口牆面(含固定樁)"
+  },
+  "rct2.tt.hrbwal05": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "港口牆面(含固定樁)"
+  },
+  "rct2.tt.hrbwal03": {
+    "reference-name": "Harbour Wall with Moor",
+    "name": "港口牆面(含固定樁)"
+  },
+  "rct2.tt.harpiesx": {
+    "reference-name": "Harpies Trains",
+    "name": "鳥身女妖雲霄飛車",
+    "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "乘客被以橫臥姿勢固定在特殊挽具上,歷經疾速旋轉軌道及反轉,甚至以幾近貼地方式與地面接觸",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.hatst": {
+    "reference-name": "Hat Stall",
+    "name": "帽子店",
+    "reference-description": "A souvenir stall selling large foam hats",
+    "description": "紀念品店賣各式各樣的帽子"
+  },
+  "rct2.hhbuild": {
+    "reference-name": "Haunted House",
+    "name": "鬼屋",
+    "reference-description": "Large themed building containing scary corridors and spooky rooms",
+    "description": "大型的主題建築物包含可怕的長廊以及幽靈房間",
+    "reference-capacity": "15 guests",
+    "capacity": "15位遊客"
+  },
+  "rct2.tt.spokprsn": {
+    "reference-name": "Haunted Jail House",
+    "name": "監獄鬼屋",
+    "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
+    "description": "建築物內有地牢和犯人的人體模型,驚嚇走進鬼屋的人",
+    "reference-capacity": "16 guests",
+    "capacity": "限16人"
+  },
+  "rct2.hmcar": {
+    "reference-name": "Haunted Mansion Cars",
+    "name": "猛鬼屋",
+    "reference-description": "Small powered cars that run on a ghost train track",
+    "description": "動力式車輛延著多層次軌道通過一些特效及景物",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.tt.haybails": {
+    "reference-name": "Hay Bale",
+    "name": "乾草堆"
+  },
+  "rct2.tht": {
+    "reference-name": "Heart Shaped Tree",
+    "name": "心形的樹"
+  },
+  "rct2.tt.hevbth15": {
+    "reference-name": "Heavenly Bath Floor",
+    "name": "天國浴場地板"
+  },
+  "rct2.tt.hevbth01": {
+    "reference-name": "Heavenly Bath Pool",
+    "name": "天國浴場水池"
+  },
+  "rct2.tt.hevbth02": {
+    "reference-name": "Heavenly Bath Pool Corner",
+    "name": "天國浴場水池牆角"
+  },
+  "rct2.tt.hevbth17": {
+    "reference-name": "Heavenly Bath Pool Edge",
+    "name": "天國浴場水池邊緣"
+  },
+  "rct2.tt.hevbth16": {
+    "reference-name": "Heavenly Bath Pool Steps",
+    "name": "天國浴場水池台階"
+  },
+  "rct2.tt.hevrof01": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天國浴場天花板"
+  },
+  "rct2.tt.hevrof02": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天國浴場天花板"
+  },
+  "rct2.tt.hevrof04": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天國浴場天花板"
+  },
+  "rct2.tt.hevrof03": {
+    "reference-name": "Heavenly Bath Roof",
+    "name": "天國浴場天花板"
+  },
+  "rct2.tt.hevbth14": {
+    "reference-name": "Heavenly Bath Window",
+    "name": "天國浴場窗"
+  },
+  "rct2.tt.hevbth05": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天國浴場拱門"
+  },
+  "rct2.tt.hevbth06": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天國浴場拱門"
+  },
+  "rct2.tt.hevbth07": {
+    "reference-name": "Heavenly Baths Arch",
+    "name": "天國浴場拱門"
+  },
+  "rct2.tt.hevbth13": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天國浴場建築式樣"
+  },
+  "rct2.tt.hevbth10": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天國浴場建築式樣"
+  },
+  "rct2.tt.hevbth12": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天國浴場建築式樣"
+  },
+  "rct2.tt.hevbth11": {
+    "reference-name": "Heavenly Baths Architecture",
+    "name": "天國浴場建築式樣"
+  },
+  "rct2.tt.hevbth04": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "天國浴場噴泉"
+  },
+  "rct2.tt.hevbth03": {
+    "reference-name": "Heavenly Baths Fountain",
+    "name": "天國浴場噴泉"
+  },
+  "rct2.tt.hevbth08": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "天國浴場樓梯"
+  },
+  "rct2.tt.hevbth09": {
+    "reference-name": "Heavenly Baths Stairway",
+    "name": "天國浴場樓梯"
+  },
+  "rct2.whg": {
+    "reference-name": "Hedge",
+    "name": "圍籬"
+  },
+  "rct2.whgg": {
+    "reference-name": "Hedge",
+    "name": "圍籬"
+  },
+  "rct2.ww.helipad": {
+    "reference-name": "Helipad",
+    "name": "Helipad"
+  },
+  "rct2.tt.hurcluls": {
+    "reference-name": "Hercules",
+    "name": "大力士海克力斯"
+  },
+  "rct2.tghc2": {
+    "reference-name": "Hiba Tree",
+    "name": "桸柏樹"
+  },
+  "rct2.ww.hippo01": {
+    "reference-name": "Hippo 1",
+    "name": "Hippo 1"
+  },
+  "rct2.ww.hippo02": {
+    "reference-name": "Hippo 2",
+    "name": "Hippo 2"
+  },
+  "rct2.ww.hipporid": {
+    "reference-name": "Hippo Submarines",
+    "name": "Hippo Submarines",
+    "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.thl": {
+    "reference-name": "Honey Locust Tree",
+    "name": "黃金洋槐樹"
+  },
+  "rct2.music.horror": {
+    "reference-name": "Horror style",
+    "name": "恐怖風格"
+  },
+  "rct2.tt.horsecrt": {
+    "reference-name": "Horse",
+    "name": "馬"
+  },
+  "rct2.tsh": {
+    "reference-name": "Horse Statue",
+    "name": "馬雕像"
+  },
+  "rct2.thrs": {
+    "reference-name": "Horseman Statue",
+    "name": "騎馬者雕像"
+  },
+  "rct2.steep1": {
+    "reference-name": "Horses",
+    "name": "越野障礙賽馬",
+    "reference-description": "Single cars shaped like a horse",
+    "description": "乘客騎著馬形車輛循著單軌式雲霄飛車軌道",
+    "reference-capacity": "2 riders per horse",
+    "capacity": "2 位乘客/每輛馬"
+  },
+  "rct2.hchoc": {
+    "reference-name": "Hot Chocolate Stall",
+    "name": "熱巧克力店",
+    "reference-description": "A stall selling hot chocolate drinks",
+    "description": "一家賣熱巧克力飲料的店"
+  },
+  "rct2.hotds": {
+    "reference-name": "Hot Dog Stall",
+    "name": "熱狗店",
+    "reference-description": "A stall selling hot dogs in rolls",
+    "description": "一家在賣熱狗的店"
+  },
+  "rct2.tt.ghotrod2": {
+    "reference-name": "Hot Rod Car",
+    "name": "改裝車"
+  },
+  "rct2.tt.ghotrod1": {
+    "reference-name": "Hot Rod Car",
+    "name": "改裝車"
+  },
+  "rct2.tt.hotrodxx": {
+    "reference-name": "Hot Rod Trains",
+    "name": "改裝車雲霄飛車",
+    "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
+    "description": "在一陣令人興奮的高速氣壓式堆進器啟動,列車以高速衝向垂直頂端軌道,接著再垂直下墜到車站的另一端再回到車站",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.twh1": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.toh1": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.toh2": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.tsph": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.sah2": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.soh2": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.sah": {
+    "reference-name": "House",
+    "name": "房子"
+  },
+  "rct2.shs2": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.soh1": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.soh3": {
+    "reference-name": "House",
+    "name": "房屋"
+  },
+  "rct2.tt.hoverbke": {
+    "reference-name": "Hover Bikes",
+    "name": "飛行腳踏車遊樂設施",
+    "reference-description": "Futuristic bike-shaped single vehicles",
+    "description": "乘客乘坐在有未來感的腳踏車外形車輛上,沿著單軌軌道前進",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.tt.hovercar": {
+    "reference-name": "Hover Cars",
+    "name": "飛行車遊樂設施",
+    "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
+    "description": "使用磁浮運輸技術營造乘坐未來車的感覺",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.tt.hvrbike4": {
+    "reference-name": "Hoverbike Flying",
+    "name": "飛行中的飛行腳踏車"
+  },
+  "rct2.tt.hvrbike3": {
+    "reference-name": "Hoverbike Flying",
+    "name": "飛行中的飛行腳踏車"
+  },
+  "rct2.tt.hvrbike1": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "停車處的飛行腳踏車"
+  },
+  "rct2.tt.hvrbike2": {
+    "reference-name": "Hoverbike on Stand",
+    "name": "停車處的飛行腳踏車"
+  },
+  "rct2.tt.hovrbord": {
+    "reference-name": "Hoverboards",
+    "name": "滑板雲霄飛車",
+    "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
+    "description": "乘客乘坐在未來的滑板上,在角落間自由?盪",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.tt.hovrcar3": {
+    "reference-name": "Hovercar Flying",
+    "name": "飛行中的飛行車"
+  },
+  "rct2.tt.hovrcar4": {
+    "reference-name": "Hovercar Flying",
+    "name": "飛行中的飛行車"
+  },
+  "rct2.tt.hovrcar1": {
+    "reference-name": "Hovercar on Stand",
+    "name": "停車處的飛行車"
+  },
+  "rct2.tt.hovrcar2": {
+    "reference-name": "Hovercar on Stand",
+    "name": "停車處的飛行車"
+  },
+  "rct2.ww.huskie": {
+    "reference-name": "Huskie Car",
+    "name": "Huskie Car",
+    "reference-description": "Powered vehicles in the shape of Huskie sleds",
+    "description": "Powered vehicles in the shape of Huskie sleds",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.goltr": {
+    "reference-name": "Hyper-Twister Trains",
+    "name": "極度旋轉列車",
+    "reference-description": "Spacious trains with simple lap restraints",
+    "description": "寬敝的列車有著簡單的膝式安全裝置",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.bmrb": {
+    "reference-name": "Hyper-Twister Trains (wide cars)",
+    "name": "極速旋轉列車",
+    "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
+    "description": "寬闊的4 人座的浮雕式車輛及簡單式的安全裝置",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.arrt2": {
+    "reference-name": "Hypercoaster Trains",
+    "name": "超速飛車",
+    "reference-description": "Comfortable trains with only lap bar restraints",
+    "description": "一座超大的非倒吊式雲霄飛車只有一條壓制膝部的安全條以大規模方式高速落下",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.edge.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.surface.ice": {
+    "reference-name": "Ice",
+    "name": "Ice"
+  },
+  "rct2.icecr2": {
+    "reference-name": "Ice Cream Cone Stall",
+    "name": "冰淇淋店",
+    "reference-description": "A stall selling ice cream cones",
+    "description": "一間賣蛋角冰淇淋的店"
+  },
+  "rct2.icecube": {
+    "reference-name": "Ice Cube",
+    "name": "冰塊"
+  },
+  "rct2.ww.icefor02": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.ww.icefor01": {
+    "reference-name": "Ice Formation",
+    "name": "Ice Formation"
+  },
+  "rct2.sip": {
+    "reference-name": "Ice Palace",
+    "name": "冰殿"
+  },
+  "rct2.ww.iceent": {
+    "reference-name": "Ice Park Entrance",
+    "name": "Ice Park Entrance"
+  },
+  "rct2.ww.pipebase": {
+    "reference-name": "Ice Pipe Base",
+    "name": "Ice Pipe Base"
+  },
+  "rct2.ww.vertpipe": {
+    "reference-name": "Ice Pipe Section",
+    "name": "Ice Pipe Section"
+  },
+  "rct2.ww.pipevent": {
+    "reference-name": "Ice Pipe Vent",
+    "name": "Ice Pipe Vent"
+  },
+  "rct2.ww.roofice6": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice2": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice5": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice3": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice1": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.roofice4": {
+    "reference-name": "Ice Roof",
+    "name": "Ice Roof"
+  },
+  "rct2.ww.wallice9": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice8": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice4": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice1": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice5": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice2": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice7": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice3": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallic10": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.ww.wallice6": {
+    "reference-name": "Ice Wall",
+    "name": "Ice Wall"
+  },
+  "rct2.music.ice": {
+    "reference-name": "Ice style",
+    "name": "冰封風格"
+  },
+  "rct2.ww.icebarl2": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl3": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.ww.icebarl1": {
+    "reference-name": "Iced Barrels",
+    "name": "Iced Barrels"
+  },
+  "rct2.icetst": {
+    "reference-name": "Iced Tea Stall",
+    "name": "冰紅茶店",
+    "reference-description": "A stall selling iced tea drinks",
+    "description": "一家賣冰紅茶的店"
+  },
+  "rct2.tig": {
+    "reference-name": "Igloo",
+    "name": "圓頂小屋"
+  },
+  "rct2.igroof": {
+    "reference-name": "Igloo Roof",
+    "name": "圓屋頂"
+  },
+  "rct2.wallig24": {
+    "reference-name": "Igloo Wall",
+    "name": "圓頂牆"
+  },
+  "rct2.wallig16": {
+    "reference-name": "Igloo Wall",
+    "name": "圓頂牆"
+  },
+  "rct2.ww.roofig03": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig04": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig01": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig02": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.roofig06": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo1": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.ww.wigloo2": {
+    "reference-name": "Igloo Wall",
+    "name": "Igloo Wall"
+  },
+  "rct2.intinv": {
+    "reference-name": "Impulse Trains",
+    "name": "瞬間反轉飛車",
+    "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
+    "description": "反轉雲霄飛車是由車站加速射出如大釘子般垂直軌道上方,然後再倒退回到車站並衝向另一邊垂直軌道上",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tic": {
+    "reference-name": "Incense Cedar Tree",
+    "name": "檀香杉樹"
+  },
+  "rct2.ww.inflag05": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag01": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag02": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag03": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.ww.inflag04": {
+    "reference-name": "Indian Silk Flag",
+    "name": "Indian Silk Flag"
+  },
+  "rct2.tt.indwal05": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "工業屋頂轉角塊"
+  },
+  "rct2.tt.indwal06": {
+    "reference-name": "Industrial Roof Corner Piece",
+    "name": "工業屋頂轉角塊"
+  },
+  "rct2.tt.indwal21": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal22": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal24": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal23": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal25": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal29": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal20": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal27": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal28": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal26": {
+    "reference-name": "Industrial Roof Piece",
+    "name": "工業屋頂塊"
+  },
+  "rct2.tt.indwal15": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "工業牆牆角塊"
+  },
+  "rct2.tt.indwal14": {
+    "reference-name": "Industrial Wall Corner Piece",
+    "name": "工業牆牆角塊"
+  },
+  "rct2.tt.indwal03": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業牆面組"
+  },
+  "rct2.tt.indwal02": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業牆面組"
+  },
+  "rct2.tt.indwal04": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業牆面組"
+  },
+  "rct2.tt.indwal01": {
+    "reference-name": "Industrial Wall Set",
+    "name": "工業牆面組"
+  },
+  "rct2.tt.indwal13": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal07": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal11": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal12": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal09": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal08": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal10": {
+    "reference-name": "Industrial Wall with Doorway",
+    "name": "工業牆面(含門口)"
+  },
+  "rct2.tt.indwal31": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal30": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal32": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal18": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal17": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal16": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.tt.indwal19": {
+    "reference-name": "Industrial Wall with Window",
+    "name": "工業牆面(含窗戶)"
+  },
+  "rct2.infok": {
+    "reference-name": "Information Kiosk",
+    "name": "服務台",
+    "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
+    "description": "一處遊客可以取得遊樂園地圖及買到雨傘的地方"
+  },
+  "rct2.ww.inuit2": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct2.ww.inuit": {
+    "reference-name": "Inuit",
+    "name": "Inuit"
+  },
+  "rct1.edge.iron": {
+    "reference-name": "Iron",
+    "name": "Iron"
+  },
+  "rct2.titc": {
+    "reference-name": "Italian Cypress Tree",
+    "name": "義大利扁柏樹"
+  },
+  "rct2.ww.italypor": {
+    "reference-name": "Italian Police Ride",
+    "name": "Italian Police Ride",
+    "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 passengers"
+  },
+  "rct2.ww.jaguarrd": {
+    "reference-name": "Jaguar Cars",
+    "name": "Jaguar Cars",
+    "reference-description": "Roller coaster cars themed to look like jaguars",
+    "description": "Roller coaster cars themed to look like jaguars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.japchblo": {
+    "reference-name": "Japanese Cherry Blossom Tree",
+    "name": "Japanese Cherry Blossom Tree"
+  },
+  "rct2.ww.jachtree": {
+    "reference-name": "Japanese Cherry Tree",
+    "name": "Japanese Cherry Tree"
+  },
+  "rct2.ww.wshogi17": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi16": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.wshogi15": {
+    "reference-name": "Japanese Fence",
+    "name": "Japanese Fence"
+  },
+  "rct2.ww.japent": {
+    "reference-name": "Japanese Park Entrance",
+    "name": "Japanese Park Entrance"
+  },
+  "rct2.ww.jappintr": {
+    "reference-name": "Japanese Pine Tree",
+    "name": "Japanese Pine Tree"
+  },
+  "rct2.ww.rshogi2": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi3": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.rshogi1": {
+    "reference-name": "Japanese Roof",
+    "name": "Japanese Roof"
+  },
+  "rct2.ww.jpflag03": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag01": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag02": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag05": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag06": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.jpflag04": {
+    "reference-name": "Japanese Silk Flag",
+    "name": "Japanese Silk Flag"
+  },
+  "rct2.ww.japsnotr": {
+    "reference-name": "Japanese Snowball Tree",
+    "name": "Japanese Snowball Tree"
+  },
+  "rct2.tt.jazzmbr4": {
+    "reference-name": "Jazz Band Member",
+    "name": "爵士樂隊成員"
+  },
+  "rct2.tt.jazzmbr3": {
+    "reference-name": "Jazz Band Member",
+    "name": "爵士樂隊成員"
+  },
+  "rct2.tt.jazzmbr1": {
+    "reference-name": "Jazz Band Member",
+    "name": "爵士樂隊成員"
+  },
+  "rct2.tt.jazzmbr2": {
+    "reference-name": "Jazz Band Member",
+    "name": "爵士樂隊成員"
+  },
+  "rct2.jelbab1": {
+    "reference-name": "Jelly Baby",
+    "name": "娃娃軟糖"
+  },
+  "rct2.jbean1": {
+    "reference-name": "Jellybean",
+    "name": "軟豆糖"
+  },
+  "rct2.walljb16": {
+    "reference-name": "Jellybean Wall",
+    "name": "豆型糖果牆"
+  },
+  "rct2.tt.jetplan1": {
+    "reference-name": "Jet Aeroplane",
+    "name": "噴射機"
+  },
+  "rct2.tt.jetplan2": {
+    "reference-name": "Jet Aeroplane",
+    "name": "噴射機"
+  },
+  "rct2.tt.jetplan3": {
+    "reference-name": "Jet Aeroplane",
+    "name": "噴射機"
+  },
+  "rct2.tt.jetpackx": {
+    "reference-name": "Jet Pack Booster",
+    "name": "噴射背包推進器",
+    "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "乘客乘坐在朝軌道垂直段往上發射的交通工具上",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "每輛車限乘8人"
+  },
+  "rct2.tt.jetplane": {
+    "reference-name": "Jet Plane Cars",
+    "name": "噴射機雲霄飛車",
+    "reference-description": "Roller coaster cars in the shape of jet planes",
+    "description": "一座以個人列車在小巧型雲霄飛車設施上平緩地旋轉落下。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.jski": {
+    "reference-name": "Jet Skis",
+    "name": "噴射滑橇",
+    "reference-description": "Single-seater jet skis which riders can drive themselves",
+    "description": "每台單一乘客自行操縱它的運作",
+    "reference-capacity": "1 rider per vehicle",
+    "capacity": "1位乘客／每部機器"
+  },
+  "rct2.tt.jousting": {
+    "reference-name": "Jousting Knights",
+    "name": "騎士競技雲霄飛車",
+    "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
+    "description": "乘客坐在單軌軌道上戰馬外形的車輛後方",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.jumpfnt1": {
+    "reference-name": "Jumping Fountains",
+    "name": "跳躍噴泉"
+  },
+  "rct2.jumpsnw1": {
+    "reference-name": "Jumping Snowballs",
+    "name": "跳躍雪球"
+  },
+  "rct2.station.jungle": {
+    "reference-name": "Jungle",
+    "name": "Jungle"
+  },
+  "rct2.wjf": {
+    "reference-name": "Jungle Fence",
+    "name": "叢林式柵欄"
+  },
+  "rct2.bn2": {
+    "reference-name": "Jungle Style Sign",
+    "name": "叢林式風格 招牌"
+  },
+  "rct2.scgjungl": {
+    "reference-name": "Jungle Themeing",
+    "name": "叢林主題區"
+  },
+  "rct2.ww.3x3atre2": {
+    "reference-name": "Jungle Tree 1",
+    "name": "Jungle Tree 1"
+  },
+  "rct2.ww.3x3atre1": {
+    "reference-name": "Jungle Tree 2",
+    "name": "Jungle Tree 2"
+  },
+  "rct2.ww.3x3altre": {
+    "reference-name": "Jungle Tree with Leopards",
+    "name": "Jungle Tree with Leopards"
+  },
+  "rct2.ww.3x3atre3": {
+    "reference-name": "Jungle Tree with Vines",
+    "name": "Jungle Tree with Vines"
+  },
+  "rct2.music.jungle": {
+    "reference-name": "Jungle drums style",
+    "name": "叢林敲擊風格"
+  },
+  "rct2.tmj": {
+    "reference-name": "Junk",
+    "name": "廢棄物"
+  },
+  "rct2.bn6": {
+    "reference-name": "Jurassic Style Sign",
+    "name": "侏羅紀風格 招牌"
+  },
+  "rct2.scgjuras": {
+    "reference-name": "Jurassic Themeing",
+    "name": "侏羅紀主題區"
+  },
+  "rct2.music.jurassic": {
+    "reference-name": "Jurassic style",
+    "name": "侏儸紀風格"
+  },
+  "rct2.ww.1x1kanga": {
+    "reference-name": "Kangaroo",
+    "name": "Kangaroo"
+  },
+  "rct2.ww.killwhal": {
+    "reference-name": "Killer Whale Submarines",
+    "name": "Killer Whale Submarines",
+    "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
+    "reference-capacity": "5 passengers per submarine",
+    "capacity": "5 passengers per submarine"
+  },
+  "rct2.ww.kolaride": {
+    "reference-name": "Koala Car",
+    "name": "Koala Car",
+    "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "8 passengers per car"
+  },
+  "rct2.ww.rkreml08": {
+    "reference-name": "Kremlin Large Tower Base",
+    "name": "Kremlin Large Tower Base"
+  },
+  "rct2.ww.rkreml10": {
+    "reference-name": "Kremlin Large Tower Mid-Section",
+    "name": "Kremlin Large Tower Mid-Section"
+  },
+  "rct2.ww.rkreml09": {
+    "reference-name": "Kremlin Large Tower Top",
+    "name": "Kremlin Large Tower Top"
+  },
+  "rct2.ww.rkreml01": {
+    "reference-name": "Kremlin Minaret Piece 1",
+    "name": "Kremlin Minaret Piece 1"
+  },
+  "rct2.ww.rkreml02": {
+    "reference-name": "Kremlin Minaret Piece 2",
+    "name": "Kremlin Minaret Piece 2"
+  },
+  "rct2.ww.rkreml03": {
+    "reference-name": "Kremlin Minaret Piece 3",
+    "name": "Kremlin Minaret Piece 3"
+  },
+  "rct2.ww.rkreml04": {
+    "reference-name": "Kremlin Roof Piece 1",
+    "name": "Kremlin Roof Piece 1"
+  },
+  "rct2.ww.rkreml05": {
+    "reference-name": "Kremlin Roof Piece 2",
+    "name": "Kremlin Roof Piece 2"
+  },
+  "rct2.ww.rkreml07": {
+    "reference-name": "Kremlin Small Tower Base",
+    "name": "Kremlin Small Tower Base"
+  },
+  "rct2.ww.rkreml06": {
+    "reference-name": "Kremlin Small Tower Mid-Section",
+    "name": "Kremlin Small Tower Mid-Section"
+  },
+  "rct2.ww.rkreml11": {
+    "reference-name": "Kremlin Small Tower Minaret Base",
+    "name": "Kremlin Small Tower Minaret Base"
+  },
+  "rct2.ww.wkreml01": {
+    "reference-name": "Kremlin Step-up Wall Piece 1",
+    "name": "Kremlin Step-up Wall Piece 1"
+  },
+  "rct2.ww.wkreml02": {
+    "reference-name": "Kremlin Step-up Wall Piece 2",
+    "name": "Kremlin Step-up Wall Piece 2"
+  },
+  "rct2.ww.wkreml03": {
+    "reference-name": "Kremlin Wall Piece 1",
+    "name": "Kremlin Wall Piece 1"
+  },
+  "rct2.ww.wkreml04": {
+    "reference-name": "Kremlin Wall Piece 2",
+    "name": "Kremlin Wall Piece 2"
+  },
+  "rct2.ww.wkreml05": {
+    "reference-name": "Kremlin Wall Piece 3",
+    "name": "Kremlin Wall Piece 3"
+  },
+  "rct2.ww.wkreml06": {
+    "reference-name": "Kremlin Wall Piece 4",
+    "name": "Kremlin Wall Piece 4"
+  },
+  "rct2.ww.wkreml07": {
+    "reference-name": "Kremlin Wall Piece 5",
+    "name": "Kremlin Wall Piece 5"
+  },
+  "rct2.ww.wkreml08": {
+    "reference-name": "Kremlin Wall Piece 6",
+    "name": "Kremlin Wall Piece 6"
+  },
+  "rct2.ww.wkreml09": {
+    "reference-name": "Kremlin Wall Piece 7",
+    "name": "Kremlin Wall Piece 7"
+  },
+  "rct2.ww.wkreml10": {
+    "reference-name": "Kremlin Wall Piece 8",
+    "name": "Kremlin Wall Piece 8"
+  },
+  "rct2.premt1": {
+    "reference-name": "LIM Launched Roller Coaster Trains",
+    "name": "極限發射雲霄飛車",
+    "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
+    "description": "雲霄飛車列車由車站被直線加速機械射出到反轉式旋轉軌道",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.zldb": {
+    "reference-name": "Ladybird Trains",
+    "name": "瓢蟲列車",
+    "reference-description": "Roller coaster trains with small ladybird-shaped cars",
+    "description": "雲霄飛車列車是以瓢蟲外形的車輛",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.lamppir": {
+    "reference-name": "Lamp",
+    "name": "燈"
+  },
+  "rct2.lamp2": {
+    "reference-name": "Lamp",
+    "name": "燈"
+  },
+  "rct2.lamp1": {
+    "reference-name": "Lamp",
+    "name": "燈"
+  },
+  "rct2.lamp4": {
+    "reference-name": "Lamp",
+    "name": "燈"
+  },
+  "rct2.lamp3": {
+    "reference-name": "Lamp",
+    "name": "燈"
+  },
+  "rct2.tt.mamthw04": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "大型多方向長毛象柵欄"
+  },
+  "rct2.tt.mamthw03": {
+    "reference-name": "Large Angled Mammoth Fence",
+    "name": "大型多方向長毛象柵欄"
+  },
+  "rct2.tt.melmtree": {
+    "reference-name": "Large Elm Tree",
+    "name": "大榆樹"
+  },
+  "rct2.tt.mamthw01": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "大型長毛象柵欄"
+  },
+  "rct2.tt.mamthw02": {
+    "reference-name": "Large Mammoth Fence",
+    "name": "大型長毛象柵欄"
+  },
+  "rct2.tt.cratr4x4": {
+    "reference-name": "Large Meteor Crater",
+    "name": "大型隕石坑"
+  },
+  "rct2.tt.majoroak": {
+    "reference-name": "Large Oak",
+    "name": "大橡樹"
+  },
+  "rct2.ww.largeju1": {
+    "reference-name": "Large Rainforest Tree",
+    "name": "Large Rainforest Tree"
+  },
+  "rct2.tt.rdmet4x4": {
+    "reference-name": "Large Red Meteor Crater",
+    "name": "大型紅色隕石坑"
+  },
+  "rct2.tt.smoksk01": {
+    "reference-name": "Large Smoking Chimney",
+    "name": "冒煙的大煙囪"
+  },
+  "rct2.tt.speakr02": {
+    "reference-name": "Large Speaker",
+    "name": "大型擴音器"
+  },
+  "rct2.ww.sbh4totm": {
+    "reference-name": "Large Totem Pole",
+    "name": "Large Totem Pole"
+  },
+  "rct2.tt.laserx01": {
+    "reference-name": "Laser Fence",
+    "name": "雷射柵欄"
+  },
+  "rct2.tt.laserx02": {
+    "reference-name": "Laser Fence Corner",
+    "name": "雷射柵欄牆角"
+  },
+  "rct2.ssc1": {
+    "reference-name": "Launched Freefall Car",
+    "name": "發射自由落體",
+    "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
+    "description": "自由落體車輛以氣壓式發射朝高塔上方上升然後再自行自由落下",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.tlc": {
+    "reference-name": "Lawson Cypress Tree",
+    "name": "羅生扁柏樹"
+  },
+  "rct2.skytr": {
+    "reference-name": "Lay-down Cars",
+    "name": "迷你懸掛式飛行列車",
+    "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
+    "description": "乘客乘坐在橫臥向下的方向,懸掛在特殊設計的列車並在單軌軌道環行轉角處時自由搖晃",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 位乘客/每個車廂"
+  },
+  "rct2.vekst": {
+    "reference-name": "Lay-down Roller Coaster Trains",
+    "name": "橫臥式雲霄飛車",
+    "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
+    "description": "乘客被以橫臥姿勢固定在特殊挽具上,歷經疾迅旋轉軌道及反轉,甚至以幾近貼地方式與地面接觸",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.mktstal2": {
+    "reference-name": "Lemonade Market Stall",
+    "name": "檸檬水攤位",
+    "reference-description": "A themed stall selling old style, fresh lemonade.",
+    "description": "販賣老式新鮮檸檬水的主題攤位。"
+  },
+  "rct2.lemst": {
+    "reference-name": "Lemonade Stall",
+    "name": "檸檬水店",
+    "reference-description": "A stall selling refreshing lemonade drinks",
+    "description": "一家賣清涼的檸檬水飲料的商店"
+  },
+  "rct2.lift1": {
+    "reference-name": "Lift Cabin",
+    "name": "升降機",
+    "reference-description": "Steel lift cabin",
+    "description": "遊客乘搭升降機上下穿梭於垂直的管道中, 並借此訪問另一層",
+    "reference-capacity": "16 passengers",
+    "capacity": "16位乘客"
+  },
+  "rct2.tly": {
+    "reference-name": "Lily",
+    "name": "百合花"
+  },
+  "rct2.ww.caddilac": {
+    "reference-name": "Limousine Trains",
+    "name": "Limousine Trains",
+    "reference-description": "Limousine-themed roller coaster cars",
+    "description": "Limousine-themed roller coaster cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.afrclion": {
+    "reference-name": "Lion",
+    "name": "Lion"
+  },
+  "rct2.ww.lionride": {
+    "reference-name": "Lion Cars",
+    "name": "Lion Cars",
+    "reference-description": "Roller coaster cars themed to look like lions",
+    "description": "Roller coaster cars themed to look like lions",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.littermn": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.littersp": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.litterww": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.litter1": {
+    "reference-name": "Litter Bin",
+    "name": "垃圾桶"
+  },
+  "rct2.tsnc": {
+    "reference-name": "Log Cabin",
+    "name": "木造小屋"
+  },
+  "rct2.station.log": {
+    "reference-name": "Log Cabin",
+    "name": "Log Cabin"
+  },
+  "rct2.ww.rlog02": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog01": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.rlog05": {
+    "reference-name": "Log Cabin Roof Piece",
+    "name": "Log Cabin Roof Piece"
+  },
+  "rct2.ww.1x2lgchm": {
+    "reference-name": "Log Cabin Side Chimney",
+    "name": "Log Cabin Side Chimney"
+  },
+  "rct2.ww.rlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.rlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog04": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog02": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog01": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog05": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog03": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.ww.wlog06": {
+    "reference-name": "Log Cabin Wall Piece",
+    "name": "Log Cabin Wall Piece"
+  },
+  "rct2.zlog": {
+    "reference-name": "Log Trains",
+    "name": "原木列車",
+    "reference-description": "Roller coaster trains with small log-shaped cars",
+    "description": "雲霄飛車列車是以小型原木外形的",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.tml": {
+    "reference-name": "Logs",
+    "name": "原木"
+  },
+  "rct2.lfb1": {
+    "reference-name": "Logs",
+    "name": "原木溪谷",
+    "reference-description": "Log-shaped boats built for running in water channels",
+    "description": "原木風格的船延著水道在陡峭斜坡急速下滑水溢四濺噴灑到遊客",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 位乘客 /每艘船"
+  },
+  "rct2.lolly1": {
+    "reference-name": "Lollypop",
+    "name": "棒棒糖"
+  },
+  "rct2.tlp": {
+    "reference-name": "Lombardy Poplar Tree",
+    "name": "白楊樹"
+  },
+  "rct2.scht1": {
+    "reference-name": "Looping Roller Coaster Trains",
+    "name": "火車的雲霄飛車",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
+    "description": "火車的雲霄飛車在歷經垂直迴圈時有膝部安全設備",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ww.wmayan17": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan18": {
+    "reference-name": "Lost City Column Piece",
+    "name": "Lost City Column Piece"
+  },
+  "rct2.ww.wmayan02": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan22": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan21": {
+    "reference-name": "Lost City Flat Roof Piece",
+    "name": "Lost City Flat Roof Piece"
+  },
+  "rct2.ww.wmayan16": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan15": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan12": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan14": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan13": {
+    "reference-name": "Lost City Stairway Piece",
+    "name": "Lost City Stairway Piece"
+  },
+  "rct2.ww.wmayan24": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan25": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan26": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan23": {
+    "reference-name": "Lost City Wall Corner Piece",
+    "name": "Lost City Wall Corner Piece"
+  },
+  "rct2.ww.wmayan11": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan05": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan09": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan07": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan06": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan04": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan08": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan03": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan20": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan10": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.wmayan01": {
+    "reference-name": "Lost City Wall Piece",
+    "name": "Lost City Wall Piece"
+  },
+  "rct2.ww.1x1atree": {
+    "reference-name": "Low Bush",
+    "name": "Low Bush"
+  },
+  "rct2.tt.shipb4x4": {
+    "reference-name": "Luxury Liner Bow",
+    "name": "豪華郵輪船頭"
+  },
+  "rct2.tt.shipm4x4": {
+    "reference-name": "Luxury Liner Mid Section",
+    "name": "豪華郵輪中段"
+  },
+  "rct2.tt.ships4x4": {
+    "reference-name": "Luxury Liner Stern",
+    "name": "豪華郵輪船尾"
+  },
+  "rct2.tt.flalmace": {
+    "reference-name": "Mace Ride",
+    "name": "硬頭錘遊樂設施",
+    "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
+    "description": "乘客乘坐在此主題的座椅上，座椅連接至以發動機驅動的旋轉手臂上。",
+    "reference-capacity": "1 guest per chair",
+    "capacity": "每座限乘1人"
+  },
+  "rct2.mcarpet1": {
+    "reference-name": "Magic Carpet",
+    "name": "魔毯",
+    "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
+    "description": "一輛超大飛毯特色的車由底部四支支架循環式地上上下下移動",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 位乘客"
+  },
+  "rct2.tt.armrbody": {
+    "reference-name": "Magical Armour",
+    "name": "魔法鎧甲"
+  },
+  "rct2.tt.armrhelm": {
+    "reference-name": "Magical Helmet",
+    "name": "魔法頭盔"
+  },
+  "rct2.tt.armrshld": {
+    "reference-name": "Magical Shield",
+    "name": "魔法盾牌"
+  },
+  "rct2.tt.armrswrd": {
+    "reference-name": "Magical Sword",
+    "name": "魔法劍"
+  },
+  "rct2.tmg": {
+    "reference-name": "Magnolia Tree",
+    "name": "木蘭花樹"
+  },
+  "rct2.ww.tmarch1": {
+    "reference-name": "Maharaja Palace Arch 1",
+    "name": "Maharaja Palace Arch 1"
+  },
+  "rct2.ww.tmarch2": {
+    "reference-name": "Maharaja Palace Arch 2",
+    "name": "Maharaja Palace Arch 2"
+  },
+  "rct2.ww.tajmdome": {
+    "reference-name": "Maharaja Palace Dome",
+    "name": "Maharaja Palace Dome"
+  },
+  "rct2.ww.tjblock1": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock3": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tjblock2": {
+    "reference-name": "Maharaja Palace Piece",
+    "name": "Maharaja Palace Piece"
+  },
+  "rct2.ww.tajmcbse": {
+    "reference-name": "Maharaja Palace Tower Base",
+    "name": "Maharaja Palace Tower Base"
+  },
+  "rct2.ww.tajmcolm": {
+    "reference-name": "Maharaja Palace Tower Column",
+    "name": "Maharaja Palace Tower Column"
+  },
+  "rct2.ww.tajmctop": {
+    "reference-name": "Maharaja Palace Tower Top",
+    "name": "Maharaja Palace Tower Top"
+  },
+  "rct2.ww.steamtrn": {
+    "reference-name": "Maharaja Steam Trains",
+    "name": "Maharaja Steam Trains",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "6 passengers per carriage"
+  },
+  "rct2.ww.mandarin": {
+    "reference-name": "Mandarin Duck Boats",
+    "name": "Mandarin Duck Boats",
+    "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 passengers per boat"
+  },
+  "rct2.ww.3x3mantr": {
+    "reference-name": "Mangrove Tree",
+    "name": "Mangrove Tree"
+  },
+  "rct2.ww.mantaray": {
+    "reference-name": "Manta Ray Boats",
+    "name": "Manta Ray Boats",
+    "reference-description": "Coaster boats in the shape of a manta ray",
+    "description": "Coaster boats in the shape of a manta ray",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "6 passengers per boat"
+  },
+  "rct2.ww.rmarble1": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble2": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble4": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.rmarble3": {
+    "reference-name": "Marble Roof",
+    "name": "Marble Roof"
+  },
+  "rct2.ww.g2dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.ww.g1dancer": {
+    "reference-name": "Mardi Gras Dancer",
+    "name": "Mardi Gras Dancer"
+  },
+  "rct2.tt.schntent": {
+    "reference-name": "Marquee",
+    "name": "遮篷"
+  },
+  "rct2.mallow2": {
+    "reference-name": "Marshmallow",
+    "name": "藥用蜀葵"
+  },
+  "rct2.mallow1": {
+    "reference-name": "Marshmallow",
+    "name": "藥用蜀葵"
+  },
+  "rct2.surface.martian": {
+    "reference-name": "Martian",
+    "name": "Martian"
+  },
+  "rct2.smb": {
+    "reference-name": "Martian Building",
+    "name": "火星人的建築物"
+  },
+  "rct2.tmo4": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物體"
+  },
+  "rct2.tmo2": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物體"
+  },
+  "rct2.tmo5": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物體"
+  },
+  "rct2.tmo3": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物體"
+  },
+  "rct2.tmo1": {
+    "reference-name": "Martian Object",
+    "name": "火星人的物體"
+  },
+  "rct2.scgmart": {
+    "reference-name": "Martian Themeing",
+    "name": "火星人主題區"
+  },
+  "rct2.wmw": {
+    "reference-name": "Martian Wall",
+    "name": "火星人的牆"
+  },
+  "rct2.music.martian": {
+    "reference-name": "Martian style",
+    "name": "火星風格"
+  },
+  "rct2.hmaze": {
+    "reference-name": "Maze",
+    "name": "迷宮",
+    "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
+    "description": "迷宮是由六呎高的圍離所構成的。遊客會對迷宮的?設覺得疑惑，而只有當遊客找到出口時，他們才能夠離開這個迷宮。"
+  },
+  "rct2.mbsoup": {
+    "reference-name": "Meatball Soup Stall",
+    "name": "貢丸湯店",
+    "reference-description": "A stall selling Chinese style meatball soup",
+    "description": "一家賣中國式貢丸湯的店"
+  },
+  "rct2.scgindus": {
+    "reference-name": "Mechanical Themeing",
+    "name": "機械主題區"
+  },
+  "rct2.music.mechanical": {
+    "reference-name": "Mechanical style",
+    "name": "機械風格"
+  },
+  "rct2.scgmedie": {
+    "reference-name": "Medieval Themeing",
+    "name": "中古世紀主題區"
+  },
+  "rct2.music.medieval": {
+    "reference-name": "Medieval style",
+    "name": "中世紀風格"
+  },
+  "rct2.tt.stnesta4": {
+    "reference-name": "Men Turned to Stone",
+    "name": "被變成石頭的人"
+  },
+  "rct2.tt.stnesta2": {
+    "reference-name": "Men Turned to Stone",
+    "name": "被變成石頭的人"
+  },
+  "rct2.tt.stnesta1": {
+    "reference-name": "Men Turned to Stone",
+    "name": "被變成石頭的人"
+  },
+  "rct2.tt.stnesta3": {
+    "reference-name": "Men Turned to Stone",
+    "name": "被變成石頭的人"
+  },
+  "rct2.mgr1": {
+    "reference-name": "Merry-Go-Round",
+    "name": "旋轉木馬",
+    "reference-description": "Traditional rotating carousel with carved wooden horses",
+    "description": "有著雕刻木馬的傳統旋轉木馬 。",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 位乘客"
+  },
+  "rct2.wmf": {
+    "reference-name": "Mesh Fence",
+    "name": "網狀柵欄"
+  },
+  "rct2.wmfg": {
+    "reference-name": "Mesh Fence",
+    "name": "網狀柵欄"
+  },
+  "rct2.tt.meteorcr": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "隕石坑牆角"
+  },
+  "rct2.tt.metoan01": {
+    "reference-name": "Meteor Crater Corner",
+    "name": "隕石坑牆角"
+  },
+  "rct2.tt.metoan02": {
+    "reference-name": "Meteor Crater Inverted Corner",
+    "name": "反向隕石坑牆角"
+  },
+  "rct2.tt.meteorst": {
+    "reference-name": "Meteor Crater Wall",
+    "name": "隕石坑牆面"
+  },
+  "rct2.tt.metrcrs1": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "含有水晶的隕石坑牆面"
+  },
+  "rct2.tt.metrcrs2": {
+    "reference-name": "Meteor Crater Wall with Crystals",
+    "name": "含有水晶的隕石坑牆面"
+  },
+  "rct2.tmbj": {
+    "reference-name": "Meyer's Blue Juniper Tree",
+    "name": "梅格藍檜樹"
+  },
+  "rct2.tt.microbus": {
+    "reference-name": "MicroBus Ride",
+    "name": "小型巴士遊樂設施",
+    "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "遊客坐在摸擬天體運行艙內觀看影片利用水力學支臂使旋轉及移動",
+    "reference-capacity": "8 passengers",
+    "capacity": "限乘8人"
+  },
+  "rct2.tt.travlr02": {
+    "reference-name": "Microbus",
+    "name": "小型巴士"
+  },
+  "rct2.wmmine": {
+    "reference-name": "Mine Cars",
+    "name": "木製狂放礦坑列車",
+    "reference-description": "Cars shaped like an old mine cart",
+    "description": "極小的礦坑列車在急轉彎的木架軌道上運行,使它不安全的傾斜並U型回轉及瞬間墜下的恐怖感",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.smc2": {
+    "reference-name": "Mine Cars",
+    "name": "礦坑車輛",
+    "reference-description": "Individual cars shaped like wooden mine trucks",
+    "description": "像礦坑中載木貨車的獨特車形",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ww.minecart": {
+    "reference-name": "Mine Cart Trains",
+    "name": "Mine Cart Trains",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smh1": {
+    "reference-name": "Mine Hut",
+    "name": "壙坑小屋"
+  },
+  "rct2.smh2": {
+    "reference-name": "Mine Hut",
+    "name": "壙坑小屋"
+  },
+  "rct2.ww.minelift": {
+    "reference-name": "Mine Lift Cabin",
+    "name": "Mine Lift Cabin",
+    "reference-description": "A steel lift cabin commonly used in mines",
+    "description": "A steel lift cabin commonly used in mines",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 passengers"
+  },
+  "rct2.smn1": {
+    "reference-name": "Mine Shaft",
+    "name": "壙坑井狀通道"
+  },
+  "rct2.scgmine": {
+    "reference-name": "Mine Themeing",
+    "name": "小人國"
+  },
+  "rct2.amt1": {
+    "reference-name": "Mine Trains",
+    "name": "坑道衝鋒車",
+    "reference-description": "Mine train-themed roller coaster trains",
+    "description": "坑道衝鋒車是以雲霄飛車列車延著看起來像老舊鐵路軌道的鋼製雲霄飛車軌道全速前進",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 或 4 位乘客/每個車廂"
+  },
+  "rct2.golf1": {
+    "reference-name": "Mini Golf",
+    "name": "迷你高爾夫",
+    "reference-description": "A gentle game of miniature golf",
+    "description": "一個溫和的迷你高爾夫遊戲",
+    "reference-capacity": "",
+    "capacity": ""
+  },
+  "rct2.helicar": {
+    "reference-name": "Mini Helicopters",
+    "name": "礦坑升降機",
+    "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
+    "description": "具動力的升降機外形列車在鋼製軌道上運行由乘客的踏板控制速度",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.tt.minotaur": {
+    "reference-name": "Minotaur Statue",
+    "name": "人身牛頭怪雕像"
+  },
+  "rct2.mint1": {
+    "reference-name": "Mint",
+    "name": "薄荷"
+  },
+  "rct2.music.modern": {
+    "reference-name": "Modern style",
+    "name": "摩登風格"
+  },
+  "rct2.tmp": {
+    "reference-name": "Monkey-Puzzle Tree",
+    "name": "使猴子困惑的樹"
+  },
+  "rct2.4x4": {
+    "reference-name": "Monster Trucks",
+    "name": "怪獸卡車",
+    "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
+    "description": "能爬上陡斜坡道, 而且帶有動力的巨型4 x 4卡車",
+    "reference-capacity": "2 passengers per truck",
+    "capacity": "每卡車2位乘客"
+  },
+  "rct2.tmc": {
+    "reference-name": "Monterey Cypress Tree",
+    "name": "蒙特瑞柏樹"
+  },
+  "rct2.tmzp": {
+    "reference-name": "Montezuma Pine Tree",
+    "name": "西班牙松樹"
+  },
+  "rct2.ww.wcuzco28": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco18": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco02": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco10": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco04": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco12": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco14": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco08": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco16": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco06": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco15": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzco13": {
+    "reference-name": "Monumental Broken Wall Piece",
+    "name": "Monumental Broken Wall Piece"
+  },
+  "rct2.ww.wcuzfoun": {
+    "reference-name": "Monumental Fountain",
+    "name": "Monumental Fountain"
+  },
+  "rct2.ww.wcuzco25": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco19": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco20": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco26": {
+    "reference-name": "Monumental Stairway Piece",
+    "name": "Monumental Stairway Piece"
+  },
+  "rct2.ww.wcuzco23": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco21": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco24": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco22": {
+    "reference-name": "Monumental Wall Corner Piece",
+    "name": "Monumental Wall Corner Piece"
+  },
+  "rct2.ww.wcuzco03": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco01": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco11": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco07": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco09": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco27": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco17": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.ww.wcuzco05": {
+    "reference-name": "Monumental Wall Piece",
+    "name": "Monumental Wall Piece"
+  },
+  "rct2.tt.moonjuce": {
+    "reference-name": "Moon Juice",
+    "name": "月球果汁",
+    "reference-description": "A stall selling the latest soft drinks",
+    "description": "販賣最新的碳酸飲料的攤位"
+  },
+  "rct2.tt.mythpath": {
+    "reference-name": "Mosaic FootPath",
+    "name": "馬賽克道路"
+  },
+  "rct2.simpod": {
+    "reference-name": "Motion Simulator",
+    "name": "摸擬天體運行",
+    "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
+    "description": "遊客坐在摸擬天體運行艙內觀看影片利用水力學支臂使旋轉及移動",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.steep2": {
+    "reference-name": "Motorbikes",
+    "name": "摩托車競速賽",
+    "reference-description": "Single cars shaped like a motorbike",
+    "description": "乘客搭著摩托車形的雲霄飛車車輛延著單軌軌道前進",
+    "reference-capacity": "2 riders per bike",
+    "capacity": "2 位乘客/每輛摩托車"
+  },
+  "rct2.tt.chprbke2": {
+    "reference-name": "Motorcycle",
+    "name": "摩托車"
+  },
+  "rct2.tt.chprbke1": {
+    "reference-name": "Motorcycle",
+    "name": "摩托車"
+  },
+  "rct2.smc1": {
+    "reference-name": "Mouse Cars",
+    "name": "老鼠小車車",
+    "reference-description": "Individual cars shaped like mice",
+    "description": "像老鼠外形特色的車輛",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.wmouse": {
+    "reference-name": "Mouse Cars",
+    "name": "木製野地飛鼠",
+    "reference-description": "Individual cars shaped like a mouse",
+    "description": "小老鼠外形的車輛在木架軌道上運行,車子以傾斜穿越U型轉彎及陡峭墜下時有極大的不安全刺激感",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.ww.rmud05": {
+    "reference-name": "Mud Roof Piece",
+    "name": "Mud Roof Piece"
+  },
+  "rct2.ww.wmud08": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud04": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud02": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud06": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud03": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud07": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud05": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.ww.wmud01": {
+    "reference-name": "Mud Wall Piece",
+    "name": "Mud Wall Piece"
+  },
+  "rct2.arrx": {
+    "reference-name": "Multi-Dimension Coaster Trains",
+    "name": "多種尺寸衝鋒列車",
+    "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
+    "description": "車輛以高腳跟式投射乘客坐椅",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.mythentr": {
+    "reference-name": "Mythological Entrance",
+    "name": "神話主題入口"
+  },
+  "rct2.tt.scgmytho": {
+    "reference-name": "Mythological Themeing",
+    "name": "神話主題區"
+  },
+  "rct2.ww.indianst": {
+    "reference-name": "Native American",
+    "name": "Native American"
+  },
+  "rct2.wtrcyan": {
+    "reference-name": "Natural Water",
+    "name": "自然水源"
+  },
+  "rct2.ww.wropecor": {
+    "reference-name": "Nautical Corner Roof Railing",
+    "name": "Nautical Corner Roof Railing"
+  },
+  "rct2.ww.wnauti03": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti04": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti01": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti02": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wnauti05": {
+    "reference-name": "Nautical Roof Piece",
+    "name": "Nautical Roof Piece"
+  },
+  "rct2.ww.wropeswa": {
+    "reference-name": "Nautical Roof Railing",
+    "name": "Nautical Roof Railing"
+  },
+  "rct2.ww.wallna08": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna13": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna09": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna14": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna11": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna03": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna10": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna04": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna05": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna06": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna02": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna12": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna01": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.ww.wallna07": {
+    "reference-name": "Nautical Wall Piece",
+    "name": "Nautical Wall Piece"
+  },
+  "rct2.tt.dinsign4": {
+    "reference-name": "Neon Diner Sign",
+    "name": "?廳霓虹燈"
+  },
+  "rct2.tt.dinsign1": {
+    "reference-name": "Neon Diner Sign",
+    "name": "廳霓虹燈"
+  },
+  "rct2.tt.dinsign3": {
+    "reference-name": "Neon Diner Sign",
+    "name": "廳霓虹燈"
+  },
+  "rct2.tt.dinsign2": {
+    "reference-name": "Neon Diner Sign",
+    "name": "廳霓虹燈"
+  },
+  "rct2.tt.neptunex": {
+    "reference-name": "Neptune Ride",
+    "name": "海神遊樂設施",
+    "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "乘客兩人一組乘坐在各種主題的座位上，繞著栩栩如生的海神雕像旋轉。",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.tt.mythosea": {
+    "reference-name": "Neptune's Seafood Stall",
+    "name": "海神海鮮攤",
+    "reference-description": "A stall selling Neptune's salty treats",
+    "description": "販賣海神的海味點心的攤位"
+  },
+  "rct2.tt.oldnyk06": {
+    "reference-name": "New York Corner Filler",
+    "name": "紐約牆牆角填充塊"
+  },
+  "rct2.tt.oldnyk26": {
+    "reference-name": "New York Entrance",
+    "name": "紐約主題入口"
+  },
+  "rct2.tt.oldnyk10": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "反向紐約牆角塊"
+  },
+  "rct2.tt.oldnyk08": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "反向紐約牆角塊"
+  },
+  "rct2.tt.oldnyk07": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "反向紐約牆角塊"
+  },
+  "rct2.tt.oldnyk09": {
+    "reference-name": "New York Inverted Corner Piece",
+    "name": "反向紐約牆角塊"
+  },
+  "rct2.tt.oldnyk24": {
+    "reference-name": "New York Inverted Corner Roof",
+    "name": "反向紐約屋頂牆角"
+  },
+  "rct2.tt.oldnyk05": {
+    "reference-name": "New York Roof Piece",
+    "name": "紐約屋頂塊"
+  },
+  "rct2.tt.oldnyk35": {
+    "reference-name": "New York Roof Piece",
+    "name": "紐約屋頂塊"
+  },
+  "rct2.tt.oldnyk32": {
+    "reference-name": "New York Roof Piece",
+    "name": "紐約屋頂塊"
+  },
+  "rct2.tt.oldnyk25": {
+    "reference-name": "New York Roof Piece",
+    "name": "紐約屋頂塊"
+  },
+  "rct2.tt.oldnyk20": {
+    "reference-name": "New York Roof Piece",
+    "name": "紐約屋頂塊"
+  },
+  "rct2.tt.oldnyk33": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk19": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk17": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk04": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk15": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk01": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk18": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk02": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk03": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk31": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk16": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk34": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk30": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk29": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk28": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk27": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk22": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk21": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk23": {
+    "reference-name": "New York Wall Piece",
+    "name": "紐約牆面塊"
+  },
+  "rct2.tt.oldnyk11": {
+    "reference-name": "New York Wall with Line",
+    "name": "紐約牆面(含線條)"
+  },
+  "rct2.tt.oldnyk13": {
+    "reference-name": "New York Wall with Line",
+    "name": "紐約牆面(含線條)"
+  },
+  "rct2.tt.oldnyk14": {
+    "reference-name": "New York Washing Line",
+    "name": "紐約晾衣繩"
+  },
+  "rct2.tt.oldnyk12": {
+    "reference-name": "New York Washing Line",
+    "name": "紐約晾衣繩"
+  },
+  "openrct2.station.noentrance": {
+    "reference-name": "No entrance",
+    "name": "隱藏入口"
+  },
+  "openrct2.station.noplatformnoentrance": {
+    "reference-name": "No entrance, no platform",
+    "name": "No entrance, no platform"
+  },
+  "rct2.ww.naent": {
+    "reference-name": "North America Park Entrance",
+    "name": "North America Park Entrance"
+  },
+  "rct2.ww.scgnamrc": {
+    "reference-name": "North America Themeing",
+    "name": "North America Themeing"
+  },
+  "rct2.tns": {
+    "reference-name": "Norway Spruce Tree",
+    "name": "挪威杉木"
+  },
+  "rct2.tt.oakbarel": {
+    "reference-name": "Oak Barrels",
+    "name": "橡木桶遊樂設施",
+    "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
+    "description": "橡木桶沿著水道航道進行,穿過濺下的瀑布及令人興奮的急湍水流",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "每艘船限乘8人"
+  },
+  "rct2.tt.futsky36": {
+    "reference-name": "Obsidian SkyScraper Door Piece",
+    "name": "黑曜石摩天大樓門口塊"
+  },
+  "rct2.tt.futsky54": {
+    "reference-name": "Obsidian SkyScraper Roof Piece",
+    "name": "黑曜石摩天大樓屋頂塊"
+  },
+  "rct2.tt.futsky37": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "黑躍石摩天大樓緩斜坡牆角"
+  },
+  "rct2.tt.futsky39": {
+    "reference-name": "Obsidian SkyScraper Shallow Slope Corner",
+    "name": "黑躍石摩天大樓緩斜坡牆角"
+  },
+  "rct2.tt.futsky38": {
+    "reference-name": "Obsidian SkyScraper Shallow Sloped Wall",
+    "name": "黑躍石摩天大樓緩斜坡牆面"
+  },
+  "rct2.tt.futsky46": {
+    "reference-name": "Obsidian SkyScraper Steep Slope Corner",
+    "name": "黑躍石摩天大樓陡斜坡牆角"
+  },
+  "rct2.tt.futsky40": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黑躍石摩天大樓陡斜坡牆面"
+  },
+  "rct2.tt.futsky41": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黑躍石摩天大樓陡斜坡牆面"
+  },
+  "rct2.tt.futsky44": {
+    "reference-name": "Obsidian SkyScraper Steep Sloped Wall",
+    "name": "黑躍石摩天大樓陡斜坡牆面"
+  },
+  "rct2.tt.futsky47": {
+    "reference-name": "Obsidian SkyScraper Wall",
+    "name": "黑曜石摩天大樓牆面"
+  },
+  "rct2.tt.futsky48": {
+    "reference-name": "Obsidian SkyScraper Wall with Window",
+    "name": "黑曜石摩天大樓牆面(含窗戶)"
+  },
+  "rct2.sob": {
+    "reference-name": "Office Block",
+    "name": "辦公室區塊"
+  },
+  "rct2.tt.schndrum": {
+    "reference-name": "Oil Barrel",
+    "name": "油桶"
+  },
+  "rct2.ww.oilpump": {
+    "reference-name": "Oil Pump",
+    "name": "Oil Pump"
+  },
+  "rct2.ww.ovrgrwnt": {
+    "reference-name": "Old Overgrown Tree",
+    "name": "Old Overgrown Tree"
+  },
+  "rct2.wtrorng": {
+    "reference-name": "Orange Water",
+    "name": "柳橙水"
+  },
+  "rct2.music.organ": {
+    "reference-name": "Organ style",
+    "name": "風琴風格"
+  },
+  "rct2.music.oriental": {
+    "reference-name": "Oriental style",
+    "name": "東方風格"
+  },
+  "rct2.mment1": {
+    "reference-name": "Ornamental Structure",
+    "name": "裝飾用結構"
+  },
+  "rct2.mment3": {
+    "reference-name": "Ornamental Structure",
+    "name": "裝飾用的結構"
+  },
+  "rct2.mment2": {
+    "reference-name": "Ornamental Structure",
+    "name": "裝飾用的結構"
+  },
+  "rct2.torn2": {
+    "reference-name": "Ornamental Tree",
+    "name": "裝飾用的樹"
+  },
+  "rct2.ts6": {
+    "reference-name": "Ornamental Tree",
+    "name": "裝飾用的樹"
+  },
+  "rct2.ts5": {
+    "reference-name": "Ornamental Tree",
+    "name": "裝飾用的樹"
+  },
+  "rct2.ts4": {
+    "reference-name": "Ornamental Tree",
+    "name": "裝飾用的樹"
+  },
+  "rct2.torn1": {
+    "reference-name": "Ornamental Tree",
+    "name": "裝飾用的樹"
+  },
+  "rct2.ww.wmarble3": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble2": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble5": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble4": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble1": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.wmarble6": {
+    "reference-name": "Ornate Marble Wall",
+    "name": "Ornate Marble Wall"
+  },
+  "rct2.ww.ostrich": {
+    "reference-name": "Ostrich Trains",
+    "name": "Ostrich Trains",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.outriggr": {
+    "reference-name": "Outrigger Canoes",
+    "name": "Outrigger Canoes",
+    "reference-description": "Long canoes which the passengers paddle themselves",
+    "description": "Long canoes which the passengers paddle themselves",
+    "reference-capacity": "2 passengers per canoe",
+    "capacity": "2 passengers per canoe"
+  },
+  "rct2.station.pagoda": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.spg": {
+    "reference-name": "Pagoda",
+    "name": "涼亭"
+  },
+  "rct2.ww.pagodam": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pogodal": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.ww.pagodas": {
+    "reference-name": "Pagoda",
+    "name": "Pagoda"
+  },
+  "rct2.bn7": {
+    "reference-name": "Pagoda Style Sign",
+    "name": "塔/涼亭風格 招牌"
+  },
+  "rct2.scgorien": {
+    "reference-name": "Pagoda Themeing",
+    "name": "塔/涼亭主題區"
+  },
+  "rct2.ww.pagodatw": {
+    "reference-name": "Pagoda Tower",
+    "name": "Pagoda Tower"
+  },
+  "rct2.tpm": {
+    "reference-name": "Palm Tree",
+    "name": "棕櫚樹"
+  },
+  "rct2.th2": {
+    "reference-name": "Palm Tree",
+    "name": "棕櫚樹"
+  },
+  "rct2.ww.sbh3plm2": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm3": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.ww.sbh3plm1": {
+    "reference-name": "Palm Tree",
+    "name": "Palm Tree"
+  },
+  "rct2.dlc.litterpa": {
+    "reference-name": "Panda Litter Bin",
+    "name": "熊貓垃圾桶"
+  },
+  "rct2.dlc.scgpanda": {
+    "reference-name": "Panda Themeing",
+    "name": "熊貓主題區"
+  },
+  "rct2.dlc.zpanda": {
+    "reference-name": "Panda Trains",
+    "name": "熊貓列車",
+    "reference-description": "Roller coaster trains with cuddly panda cars",
+    "description": "雲霄飛車列車是逗人喜愛的熊貓車輛",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 位乘客/每個車廂"
+  },
+  "rct2.pkesfh": {
+    "reference-name": "Park Entrance Building",
+    "name": "遊樂園入口建造"
+  },
+  "rct2.pkemm": {
+    "reference-name": "Park Entrance Gates",
+    "name": "遊樂園入口柵門"
+  },
+  "rct2.tt.peasthut": {
+    "reference-name": "Peasant Hut",
+    "name": "農舍"
+  },
+  "rct2.tt.pegasusx": {
+    "reference-name": "Pegasus Cars",
+    "name": "飛馬遊樂設施",
+    "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
+    "description": "具動力裝置及飛馬外形的車輛沿著以軌道構成的路徑行進",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.ww.penguinb": {
+    "reference-name": "Penguin Trains",
+    "name": "Penguin Trains",
+    "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tt.peramob2": {
+    "reference-name": "Period Automobile",
+    "name": "區間摩托車"
+  },
+  "rct2.tt.peramob1": {
+    "reference-name": "Period Automobile",
+    "name": "區間摩托車"
+  },
+  "rct2.tt.4x4diner": {
+    "reference-name": "Period Diner",
+    "name": "區間?車"
+  },
+  "rct2.tt.pdflag15": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag03": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag14": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag05": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag16": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag04": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag02": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag06": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag08": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.pdflag13": {
+    "reference-name": "Period Flag",
+    "name": "區間旗標"
+  },
+  "rct2.tt.prdyacht": {
+    "reference-name": "Period Sailing Yacht",
+    "name": "區間快艇"
+  },
+  "rct2.tt.1920slmp": {
+    "reference-name": "Period Street Lamps",
+    "name": "區間路燈"
+  },
+  "rct2.tt.perdtk01": {
+    "reference-name": "Period Truck",
+    "name": "區間卡車"
+  },
+  "rct2.tt.perdtk02": {
+    "reference-name": "Period Truck",
+    "name": "區間卡車"
+  },
+  "rct2.sps": {
+    "reference-name": "Petrol station",
+    "name": "加油站"
+  },
+  "rct2.truck1": {
+    "reference-name": "Pickup Trucks",
+    "name": "載運貨車",
+    "reference-description": "Powered vehicles in the shape of pickup trucks",
+    "description": "載運貨車的外形具有動力機械的車輛",
+    "reference-capacity": "1 passenger per truck",
+    "capacity": "1 位乘客/每輛貨車"
+  },
+  "rct2.dlc.wtrpink": {
+    "reference-name": "Pink Water",
+    "name": "Pink Water"
+  },
+  "rct2.ww.pva": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptk": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pst": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pcg": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.ptj": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.ww.pco": {
+    "reference-name": "Pipe",
+    "name": "Pipe"
+  },
+  "rct2.pipe32j": {
+    "reference-name": "Pipe Section",
+    "name": "一段水管"
+  },
+  "rct2.pipe8": {
+    "reference-name": "Pipe Section",
+    "name": "一段水管"
+  },
+  "rct2.pipe32": {
+    "reference-name": "Pipe Section",
+    "name": "一段水管"
+  },
+  "rct2.pirflag": {
+    "reference-name": "Pirate Flag",
+    "name": "海盜旗"
+  },
+  "rct2.swsh1": {
+    "reference-name": "Pirate Ship",
+    "name": "海盜船",
+    "reference-description": "Large swinging pirate ship",
+    "description": "大規模?動的海盜船",
+    "reference-capacity": "16 passengers",
+    "capacity": "16 位乘客"
+  },
+  "rct2.prship": {
+    "reference-name": "Pirate Ship",
+    "name": "海盜船"
+  },
+  "rct2.scgpirat": {
+    "reference-name": "Pirates Themeing",
+    "name": "海盜主題館"
+  },
+  "rct2.music.pirate": {
+    "reference-name": "Pirates style",
+    "name": "海盜風格"
+  },
+  "rct2.pizzs": {
+    "reference-name": "Pizza Stall",
+    "name": "比薩店",
+    "reference-description": "A stall selling portions of pizza",
+    "description": "一間賣比薩的店"
+  },
+  "rct2.station.plain": {
+    "reference-name": "Plain",
+    "name": "Plain"
+  },
+  "rct2.ww.wmarbpl6": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl2": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl7": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl4": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl3": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl1": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.ww.wmarbpl5": {
+    "reference-name": "Plain Marble Wall",
+    "name": "Plain Marble Wall"
+  },
+  "rct2.tjp2": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.tjp1": {
+    "reference-name": "Plant",
+    "name": "植物"
+  },
+  "rct2.wcw2": {
+    "reference-name": "Playing Card Wall",
+    "name": "卜克牌牆"
+  },
+  "rct2.wcw1": {
+    "reference-name": "Playing Card Wall",
+    "name": "卜克牌牆"
+  },
+  "rct2.romroof2": {
+    "reference-name": "Plinth",
+    "name": "圓柱柱腳"
+  },
+  "rct2.tt.ploughxx": {
+    "reference-name": "Plough",
+    "name": "犁"
+  },
+  "rct2.ww.polarber": {
+    "reference-name": "Polar Bear Trains",
+    "name": "Polar Bear Trains",
+    "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.suppleg2": {
+    "reference-name": "Pole",
+    "name": "柱子"
+  },
+  "rct2.suppleg1": {
+    "reference-name": "Pole",
+    "name": "柱子"
+  },
+  "rct2.walltn32": {
+    "reference-name": "Poles",
+    "name": "柱子"
+  },
+  "rct2.tt.polchase": {
+    "reference-name": "Police Car Trains",
+    "name": "警匪追逐戰雲霄飛車",
+    "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
+    "description": "一座由乘客以站立姿態乘座的迴圈式雲霄飛車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.tt.policecr": {
+    "reference-name": "Police Cars",
+    "name": "警車雲霄飛車",
+    "reference-description": "1960s-themed police cars run on wooden tracks, turning around on special reversing sections",
+    "description": "以1960年代為主題的警車在木架軌道上奔馳,轉進特殊倒轉區域",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "每輛車限乘6人"
+  },
+  "rct2.popcs": {
+    "reference-name": "Popcorn Stall",
+    "name": "爆米花店",
+    "reference-description": "A stall selling giant buckets of popcorn",
+    "description": "賣大桶爆米花的店"
+  },
+  "rct2.wallcbpc": {
+    "reference-name": "Portcullis Door",
+    "name": "升降閘門"
+  },
+  "rct2.wallcfpc": {
+    "reference-name": "Portcullis Door",
+    "name": "升降閘門"
+  },
+  "rct2.wallpost": {
+    "reference-name": "Post",
+    "name": "柱子"
+  },
+  "rct2.pmt1": {
+    "reference-name": "Powered Mine Trains",
+    "name": "礦坑列車",
+    "reference-description": "Mine train-themed roller coaster trains that propel themselves",
+    "description": "具動力式礦坑列車衝向平滑旋轉式軌道上",
+    "reference-capacity": "2 or 4 passengers per car",
+    "capacity": "2 或 4 位乘客/每個車廂"
+  },
+  "rct2.tt.jurasent": {
+    "reference-name": "Prehistoric Entrance",
+    "name": "史前時代入口"
+  },
+  "rct2.tt.scgjurra": {
+    "reference-name": "Prehistoric Themeing",
+    "name": "史前時代主題區"
+  },
+  "rct2.pretst": {
+    "reference-name": "Pretzel Stall",
+    "name": "椒鹽脆餅店",
+    "reference-description": "A stall selling crispy pretzels",
+    "description": "一家賣酥脆的椒鹽脆餅的店"
+  },
+  "rct2.tt.soupcrnr": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.soupcrn2": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.souped01": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.souptl02": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.souptl01": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.souped02": {
+    "reference-name": "Primordial Soup",
+    "name": "太初渾湯"
+  },
+  "rct2.tt.jailxx17": {
+    "reference-name": "Prison Door",
+    "name": "監獄門"
+  },
+  "rct2.tt.jailxx19": {
+    "reference-name": "Prison Fence",
+    "name": "監獄柵欄"
+  },
+  "rct2.tt.jailxx10": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx13": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx09": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx11": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx08": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx12": {
+    "reference-name": "Prison Inverted Piece",
+    "name": "反向監獄塊"
+  },
+  "rct2.tt.jailxx21": {
+    "reference-name": "Prison Wall Corner",
+    "name": "監獄牆牆角"
+  },
+  "rct2.tt.jailxx20": {
+    "reference-name": "Prison Wall Corner",
+    "name": "監獄牆牆角"
+  },
+  "rct2.tt.jailxx06": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx02": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx01": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx05": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx04": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx03": {
+    "reference-name": "Prison Wall Piece",
+    "name": "監獄牆面塊"
+  },
+  "rct2.tt.jailxx07": {
+    "reference-name": "Prison Wall Roof",
+    "name": "監獄屋頂牆"
+  },
+  "rct2.tt.jailxx16": {
+    "reference-name": "Prison Watch Tower",
+    "name": "監獄監視塔"
+  },
+  "rct2.tt.jailxx14": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "監獄監視塔階梯"
+  },
+  "rct2.tt.jailxx15": {
+    "reference-name": "Prison Watch Tower Stairs",
+    "name": "監獄監視塔階梯"
+  },
+  "rct2.tt.jailxx18": {
+    "reference-name": "Prison Water Tower",
+    "name": "監獄水塔"
+  },
+  "rct2.tt.pterodac": {
+    "reference-name": "Pterodactyl Trains",
+    "name": "翼手龍雲霄飛車",
+    "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
+    "description": "乘客被固定軌道下的舒適座位,途經穿過最終極瘋狂軌道的史前飛行體驗",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.tsmp": {
+    "reference-name": "Pumpkin",
+    "name": "南瓜"
+  },
+  "rct2.twh2": {
+    "reference-name": "Pumpkin House",
+    "name": "南瓜屋"
+  },
+  "rct2.spyr": {
+    "reference-name": "Pyramid",
+    "name": "金字塔"
+  },
+  "rct2.qtv1": {
+    "reference-name": "Queue Line TV",
+    "name": "等待區電視"
+  },
+  "rct2.rcr": {
+    "reference-name": "Racing Cars",
+    "name": "賽車",
+    "reference-description": "Powered vehicles in the shape of racing cars",
+    "description": "賽車外形具動力機械的車輛",
+    "reference-capacity": "1 passenger per car",
+    "capacity": "1 位乘客/每個車廂"
+  },
+  "rct2.tt.raptorxx": {
+    "reference-name": "Racing Raptors",
+    "name": "迅猛龍雲霄飛車",
+    "reference-description": "Separate raptor-shaped vehicles",
+    "description": "乘客坐在單軌軌道上的迅猛龍外形的車輛後方",
+    "reference-capacity": "2 riders per vehicle",
+    "capacity": "每輛車限乘2人"
+  },
+  "rct2.tt.schntnny": {
+    "reference-name": "Racing Tannoy",
+    "name": "運轉中的擴音系統"
+  },
+  "rct2.ww.radar": {
+    "reference-name": "Radar Dish",
+    "name": "Radar Dish"
+  },
+  "rct2.rftboat": {
+    "reference-name": "Rafts",
+    "name": "水上橡皮艇",
+    "reference-description": "Raft-shaped boats built for flat river tracks",
+    "description": "橡皮艇外形的船在水道上溫和地曲折前進",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 位乘客 /每艘橡皮艇"
+  },
+  "rct2.music.ragtime": {
+    "reference-name": "Ragtime style",
+    "name": "雷格泰姆音樂風格"
+  },
+  "rct2.wsw2": {
+    "reference-name": "Railings",
+    "name": "欄杆"
+  },
+  "rct2.wsw1": {
+    "reference-name": "Railings",
+    "name": "欄杆"
+  },
+  "rct2.wswg": {
+    "reference-name": "Railings",
+    "name": "欄杆"
+  },
+  "rct2.wsw": {
+    "reference-name": "Railings",
+    "name": "欄杆"
+  },
+  "rct2.wallmm16": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.wallsc16": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.wallmm17": {
+    "reference-name": "Railings",
+    "name": "扶手"
+  },
+  "rct2.tt.ranbpath": {
+    "reference-name": "Rainbow FootPath",
+    "name": "彩虹道路"
+  },
+  "rct2.ww.rbrick02": {
+    "reference-name": "Red Brick Corner Roof Piece",
+    "name": "Red Brick Corner Roof Piece"
+  },
+  "rct2.ww.rbrick04": {
+    "reference-name": "Red Brick Flat Roof Corner",
+    "name": "Red Brick Flat Roof Corner"
+  },
+  "rct2.ww.rbrick03": {
+    "reference-name": "Red Brick Flat Roof Edge Piece",
+    "name": "Red Brick Flat Roof Edge Piece"
+  },
+  "rct2.ww.rbrick01": {
+    "reference-name": "Red Brick Inverted Roof Piece",
+    "name": "Red Brick Inverted Roof Piece"
+  },
+  "rct2.ww.rbrick08": {
+    "reference-name": "Red Brick Roof Piece 1",
+    "name": "Red Brick Roof Piece 1"
+  },
+  "rct2.ww.rbrick05": {
+    "reference-name": "Red Brick Roof Piece 2",
+    "name": "Red Brick Roof Piece 2"
+  },
+  "rct2.ww.rbrick07": {
+    "reference-name": "Red Brick Roof Piece 3",
+    "name": "Red Brick Roof Piece 3"
+  },
+  "rct2.ww.wbrick01": {
+    "reference-name": "Red Brick Wall Piece 1",
+    "name": "Red Brick Wall Piece 1"
+  },
+  "rct2.ww.wbrick11": {
+    "reference-name": "Red Brick Wall Piece 11",
+    "name": "Red Brick Wall Piece 11"
+  },
+  "rct2.ww.wbrick12": {
+    "reference-name": "Red Brick Wall Piece 12",
+    "name": "Red Brick Wall Piece 12"
+  },
+  "rct2.ww.wbrick13": {
+    "reference-name": "Red Brick Wall Piece 13",
+    "name": "Red Brick Wall Piece 13"
+  },
+  "rct2.ww.wbrick02": {
+    "reference-name": "Red Brick Wall Piece 2",
+    "name": "Red Brick Wall Piece 2"
+  },
+  "rct2.ww.wbrick03": {
+    "reference-name": "Red Brick Wall Piece 3",
+    "name": "Red Brick Wall Piece 3"
+  },
+  "rct2.ww.wbrick04": {
+    "reference-name": "Red Brick Wall Piece 4",
+    "name": "Red Brick Wall Piece 4"
+  },
+  "rct2.ww.wbrick05": {
+    "reference-name": "Red Brick Wall Piece 5",
+    "name": "Red Brick Wall Piece 5"
+  },
+  "rct2.ww.wbrick08": {
+    "reference-name": "Red Brick Wall Piece 8",
+    "name": "Red Brick Wall Piece 8"
+  },
+  "rct2.trf2": {
+    "reference-name": "Red Fir Tree",
+    "name": "紅杉木樹"
+  },
+  "rct2.trf": {
+    "reference-name": "Red Fir Tree",
+    "name": "紅杉木樹"
+  },
+  "rct2.tt.rdmeto01": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "紅色隕石坑牆角"
+  },
+  "rct2.tt.rdmeto02": {
+    "reference-name": "Red Meteor Crater Corner",
+    "name": "紅色隕石坑牆角"
+  },
+  "rct2.tt.rdmeto04": {
+    "reference-name": "Red Meteor Crater Inverted Corner",
+    "name": "反向紅色隕石坑牆角"
+  },
+  "rct2.tt.rdmeto03": {
+    "reference-name": "Red Meteor Crater Wall",
+    "name": "紅色隕石坑牆面"
+  },
+  "rct1.ll.pathtilr": {
+    "reference-name": "Red and Brown Tiled Footpath",
+    "name": "Red and Brown Tiled Footpath"
+  },
+  "rct2.ww.redwood": {
+    "reference-name": "Redwood Tree",
+    "name": "Redwood Tree"
+  },
+  "rct2.mono3": {
+    "reference-name": "Retro-style Monorail Trains",
+    "name": "懷舊風格單軌電車",
+    "reference-description": "Monorail trains with open cabins",
+    "description": "使用開放式設計車廂的單軌電車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每車卡4位乘客"
+  },
+  "rct2.revf1": {
+    "reference-name": "Reverse Freefall Car",
+    "name": "倒退式自由落體",
+    "reference-description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "大型的車輛是倒退式自由落體設施",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.revcar": {
+    "reference-name": "Reverser Cars",
+    "name": "倒退式雲霄飛車",
+    "reference-description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "妖怪列車在木架軌道上運行,轉進特殊倒轉區域",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.ww.afrrhino": {
+    "reference-name": "Rhino",
+    "name": "Rhino"
+  },
+  "rct2.ww.rhinorid": {
+    "reference-name": "Rhino Trains",
+    "name": "Rhino Trains",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 passengers per car"
+  },
+  "rct2.wallpr32": {
+    "reference-name": "Rigging",
+    "name": "索具"
+  },
+  "rct2.rapboat": {
+    "reference-name": "River Rapids Boats",
+    "name": "急流",
+    "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "圓形船體沿著水道航道進行,穿過濺下的瀑布及令人興奮的急湍水流",
+    "reference-capacity": "8 passengers per boat",
+    "capacity": "8 位乘客 /每艘船"
+  },
+  "rct2.tt.rivrstyx": {
+    "reference-name": "River Styx boats",
+    "name": "冥河",
+    "reference-description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "橡皮艇形的船在水道上曲折前進",
+    "reference-capacity": "4 passengers per raft",
+    "capacity": "4 位乘客 /每艘橡皮艇"
+  },
+  "rct2.road": {
+    "reference-name": "Road",
+    "name": "道路"
+  },
+  "rct2.tt.1920sent": {
+    "reference-name": "Roaring Twenties Park Entrance",
+    "name": "喧騰的20年代主題公園入口"
+  },
+  "rct2.tt.scg1920s": {
+    "reference-name": "Roaring Twenties Themeing",
+    "name": "喧騰的20年代主題區"
+  },
+  "rct2.tt.scg1920w": {
+    "reference-name": "Roaring Twenties Wall Sets",
+    "name": "喧騰的20年代牆面集"
+  },
+  "rct2.rsaus": {
+    "reference-name": "Roast Sausage Stall",
+    "name": "烤香腸店",
+    "reference-description": "A stall selling Chinese style roast sausage",
+    "description": "一家賣中國式烤香腸的店"
+  },
+  "rct2.tt.robncamp": {
+    "reference-name": "Robin Hood's Camp",
+    "name": "羅賓漢的營帳"
+  },
+  "rct2.tt.hodshut2": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "羅賓漢的小屋"
+  },
+  "rct2.tt.hodshut1": {
+    "reference-name": "Robin Hood's Hut",
+    "name": "羅賓漢的小屋"
+  },
+  "rct2.tt.furobot1": {
+    "reference-name": "Robot",
+    "name": "機械人"
+  },
+  "rct2.tt.furobot2": {
+    "reference-name": "Robot",
+    "name": "機械人"
+  },
+  "rct2.edge.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.surface.rock": {
+    "reference-name": "Rock",
+    "name": "Rock"
+  },
+  "rct2.tt.gldyrent": {
+    "reference-name": "Rock 'n' Roll Park Entrance",
+    "name": "搖滾主題公園入口"
+  },
+  "rct2.tt.scg1960s": {
+    "reference-name": "Rock 'n' Roll Themeing",
+    "name": "搖滾主題區"
+  },
+  "rct2.tt.bandbusx": {
+    "reference-name": "Rock Band Tour Bus",
+    "name": "搖滾樂團巡迴巴士"
+  },
+  "rct2.wallrk32": {
+    "reference-name": "Rock Wall",
+    "name": "岩石牆"
+  },
+  "rct2.music.rock1": {
+    "reference-name": "Rock style",
+    "name": "搖滾風格"
+  },
+  "rct2.music.rock2": {
+    "reference-name": "Rock style 2",
+    "name": "搖滾風格2"
+  },
+  "rct2.music.rock3": {
+    "reference-name": "Rock style 3",
+    "name": "搖滾風格3"
+  },
+  "rct2.rckc": {
+    "reference-name": "Rocket Cars",
+    "name": "火箭車",
+    "reference-description": "Roller coaster cars themed to look like rockets",
+    "description": "雲霄飛車列車的特色像火箭",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.jurrpath": {
+    "reference-name": "Rocky FootPath",
+    "name": "石頭道路"
+  },
+  "rct2.ww.sbh3oscr": {
+    "reference-name": "Rollercoaster Award Statue",
+    "name": "Rollercoaster Award Statue"
+  },
+  "rct2.tt.rswatres": {
+    "reference-name": "Rollerskating Waitress",
+    "name": "溜冰的女服務生"
+  },
+  "rct2.scol": {
+    "reference-name": "Roman Colosseum",
+    "name": "古羅馬圓形大競技場"
+  },
+  "rct2.trc": {
+    "reference-name": "Roman Column",
+    "name": "羅馬柱廊"
+  },
+  "rct2.wc3": {
+    "reference-name": "Roman Column Wall",
+    "name": "羅馬圓柱牆"
+  },
+  "rct2.tt.romvc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "羅馬皇宮牆角塊"
+  },
+  "rct2.tt.corvs2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "羅馬皇宮牆角塊"
+  },
+  "rct2.tt.romnc2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "羅馬皇宮牆角塊"
+  },
+  "rct2.tt.corns2x2": {
+    "reference-name": "Roman Palace Corner Piece",
+    "name": "羅馬皇宮牆角塊"
+  },
+  "rct2.tt.crsvs2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "羅馬皇宮交叉區塊"
+  },
+  "rct2.tt.romvm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "羅馬皇宮交叉區塊"
+  },
+  "rct2.tt.crsss2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "羅馬皇宮交叉區塊"
+  },
+  "rct2.tt.romnm2x2": {
+    "reference-name": "Roman Palace Cross Section",
+    "name": "羅馬皇宮交叉區塊"
+  },
+  "rct2.tt.romne2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "羅馬皇宮末端塊"
+  },
+  "rct2.tt.romve2x1": {
+    "reference-name": "Roman Palace End Piece",
+    "name": "羅馬皇宮末端塊"
+  },
+  "rct2.tt.romns2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "羅馬皇宮直線塊"
+  },
+  "rct2.tt.strvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "羅馬皇宮直線塊"
+  },
+  "rct2.tt.romvs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "羅馬皇宮直線塊"
+  },
+  "rct2.tt.strgs2x2": {
+    "reference-name": "Roman Palace Straight Piece",
+    "name": "羅馬皇宮直線塊"
+  },
+  "rct2.trms": {
+    "reference-name": "Roman Statue",
+    "name": "羅馬雕像"
+  },
+  "rct2.trws": {
+    "reference-name": "Roman Statue",
+    "name": "羅馬雕像"
+  },
+  "rct2.tt1": {
+    "reference-name": "Roman Temple",
+    "name": "古羅馬教堂"
+  },
+  "rct2.wrwa": {
+    "reference-name": "Roman Wall",
+    "name": "羅馬牆"
+  },
+  "rct2.wrw": {
+    "reference-name": "Roman Wall",
+    "name": "羅馬牆"
+  },
+  "rct2.music.roman": {
+    "reference-name": "Roman fanfare style",
+    "name": "羅馬號角風格"
+  },
+  "rct2.roof12": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof10": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof14": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof2": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof5": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.minroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof6": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof4": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof13": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.pirroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.spcroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.pagroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof7": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof9": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.jngroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.romroof1": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.pirroof2": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.sumrf": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof3": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof8": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct2.roof11": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "other.ttrftl04": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "other.ttrftl02": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "other.ttrftl08": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "other.ttrftl07": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "other.ttrftl03": {
+    "reference-name": "Roof",
+    "name": "屋頂"
+  },
+  "rct1.ll.surface.roofgrey": {
+    "reference-name": "Roof (Grey)",
+    "name": "Roof (Grey)"
+  },
+  "rct1.aa.surface.roofred": {
+    "reference-name": "Roof (Red)",
+    "name": "Roof (Red)"
+  },
+  "rct2.gdrop1": {
+    "reference-name": "Roto-Drop",
+    "name": "落下旋轉車",
+    "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "一個環狀坐位被拉到高塔頂端再溫和地旋轉及自由緩慢地落下利用底部的磁性煞車溫和地停止住",
+    "reference-capacity": "16 passengers",
+    "capacity": "16位客人"
+  },
+  "rct2.ww.sbh3rt66": {
+    "reference-name": "Route 66 Sign",
+    "name": "Route 66 Sign"
+  },
+  "rct2.ww.londonbs": {
+    "reference-name": "Routemaster Buses",
+    "name": "Routemaster Buses",
+    "reference-description": "Replicas of the famous London Routemaster bus",
+    "description": "Replicas of the famous London Routemaster bus",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.rboat": {
+    "reference-name": "Rowing Boats",
+    "name": "划船",
+    "reference-description": "Rowing boats which passengers row themselves",
+    "description": "由乘客靠自己划船",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 位乘客 /每艘船"
+  },
+  "rct2.ters": {
+    "reference-name": "Ruined Statue",
+    "name": "毀壞的雕像"
+  },
+  "rct2.tt.runway03": {
+    "reference-name": "Runway Corner Piece",
+    "name": "跑道牆角塊"
+  },
+  "rct2.tt.runway04": {
+    "reference-name": "Runway Edge Piece",
+    "name": "跑到邊緣塊"
+  },
+  "rct2.tt.runway06": {
+    "reference-name": "Runway Inverted Corner Piece",
+    "name": "反向跑道牆角塊"
+  },
+  "rct2.tt.runway05": {
+    "reference-name": "Runway Piece",
+    "name": "跑道塊"
+  },
+  "rct2.tt.runway02": {
+    "reference-name": "Runway Piece",
+    "name": "跑道塊"
+  },
+  "rct2.tt.runway01": {
+    "reference-name": "Runway Piece",
+    "name": "跑道塊"
+  },
+  "rct1.ll.surface.rust": {
+    "reference-name": "Rust",
+    "name": "Rust"
+  },
+  "rct2.saloon": {
+    "reference-name": "Saloon",
+    "name": "廳"
+  },
+  "rct2.ww.sanftram": {
+    "reference-name": "San Francisco Trams",
+    "name": "San Francisco Trams",
+    "reference-description": "Replicas of the San Francisco Trams",
+    "description": "Replicas of the San Francisco Trams",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "10 passengers per car"
+  },
+  "rct2.surface.sand": {
+    "reference-name": "Sand",
+    "name": "Sand"
+  },
+  "rct2.surface.sandbrown": {
+    "reference-name": "Sand (Brown)",
+    "name": "Sand (Brown)"
+  },
+  "rct2.surface.sandred": {
+    "reference-name": "Sand (Red)",
+    "name": "Sand (Red)"
+  },
+  "rct1.ll.edge.stonebrown": {
+    "reference-name": "Sandstone (Brown)",
+    "name": "Sandstone (Brown)"
+  },
+  "rct1.ll.edge.stonegrey": {
+    "reference-name": "Sandstone (Grey)",
+    "name": "Sandstone (Grey)"
+  },
+  "rct2.tt.futsky19": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky03": {
+    "reference-name": "Sandstone Skyscraper Bottom Corner",
+    "name": "沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky29": {
+    "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
+    "name": "沙岩製摩天大樓底部弧形斜坡"
+  },
+  "rct2.tt.futsky52": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky24": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky25": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky22": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky26": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky20": {
+    "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
+    "name": "反向沙岩製摩天大樓底部牆角"
+  },
+  "rct2.tt.futsky10": {
+    "reference-name": "Sandstone Skyscraper Bottom Slope Base",
+    "name": "沙岩製摩天大樓底部斜坡基座"
+  },
+  "rct2.tt.futsky05": {
+    "reference-name": "Sandstone Skyscraper Corner Top",
+    "name": "沙岩製摩天大樓頂部牆角"
+  },
+  "rct2.tt.futsky42": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "沙岩製摩天大樓弧形斜坡頂部"
+  },
+  "rct2.tt.futsky04": {
+    "reference-name": "Sandstone Skyscraper Curved Slope Top",
+    "name": "沙岩製摩天大樓弧形斜坡頂部"
+  },
+  "rct2.tt.futsky15": {
+    "reference-name": "Sandstone Skyscraper Docking Bay",
+    "name": "沙岩製摩天大樓停機坪"
+  },
+  "rct2.tt.futsky18": {
+    "reference-name": "Sandstone Skyscraper Doorway",
+    "name": "沙岩製摩天大樓門口"
+  },
+  "rct2.tt.futsky17": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "沙岩製摩天大樓填充塊"
+  },
+  "rct2.tt.futsky02": {
+    "reference-name": "Sandstone Skyscraper Filler",
+    "name": "沙岩製摩天大樓填充塊"
+  },
+  "rct2.tt.futsky23": {
+    "reference-name": "Sandstone Skyscraper Inverted Corner Top",
+    "name": "反向沙岩製摩天大樓頂部牆角"
+  },
+  "rct2.tt.futsky53": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "黑曜石摩天大樓牆角中段"
+  },
+  "rct2.tt.futsky11": {
+    "reference-name": "Sandstone Skyscraper Mid Corner",
+    "name": "黑曜石摩天大樓牆角中段"
+  },
+  "rct2.tt.futsky35": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "黑曜石摩天大樓弧形斜坡中段"
+  },
+  "rct2.tt.futsky06": {
+    "reference-name": "Sandstone Skyscraper Mid Curved Slope",
+    "name": "黑曜石摩天大樓弧形斜坡中段"
+  },
+  "rct2.tt.futsky16": {
+    "reference-name": "Sandstone Skyscraper Mid Slope Corner",
+    "name": "黑曜石摩天大樓斜坡牆角中段"
+  },
+  "rct2.tt.futsky07": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "黑曜石摩天大樓牆面區段中段"
+  },
+  "rct2.tt.futsky09": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "黑曜石摩天大樓牆面區段中段"
+  },
+  "rct2.tt.futsky21": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "黑曜石摩天大樓牆面區段中段"
+  },
+  "rct2.tt.futsky12": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "黑曜石摩天大樓牆面區段中段"
+  },
+  "rct2.tt.futsky08": {
+    "reference-name": "Sandstone Skyscraper Mid Wall Section",
+    "name": "黑曜石摩天大樓牆面區段中段"
+  },
+  "rct2.tt.futsky34": {
+    "reference-name": "Sandstone Skyscraper Roof",
+    "name": "沙岩製摩天大樓屋頂"
+  },
+  "rct2.tt.futsky14": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "沙岩製摩天大樓屋頂尖塔"
+  },
+  "rct2.tt.futsky13": {
+    "reference-name": "Sandstone Skyscraper Roof Spire",
+    "name": "沙岩製摩天大樓屋頂尖塔"
+  },
+  "rct2.tt.futsky33": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "沙岩製摩天大樓走道"
+  },
+  "rct2.tt.futsky01": {
+    "reference-name": "Sandstone Skyscraper Walkway",
+    "name": "沙岩製摩天大樓走道"
+  },
+  "rct2.tt.futsky30": {
+    "reference-name": "Sandstone Walkway Corner",
+    "name": "沙岩製走道牆角"
+  },
+  "rct2.tt.futsky31": {
+    "reference-name": "Sandstone Walkway Cross Section",
+    "name": "沙岩製走道交叉區段"
+  },
+  "rct2.tt.futsky32": {
+    "reference-name": "Sandstone Walkway End Section",
+    "name": "沙岩製走道結尾區段"
+  },
+  "rct2.tt.futsky28": {
+    "reference-name": "Sandstone Walkway T-Junction",
+    "name": "沙岩製走道T型交叉區"
+  },
+  "rct2.sst": {
+    "reference-name": "Satellite",
+    "name": "衛星"
+  },
+  "rct2.ww.bigdish": {
+    "reference-name": "Satellite Dish",
+    "name": "Satellite Dish"
+  },
+  "rct2.tt.gschlbus": {
+    "reference-name": "School Bus",
+    "name": "校車"
+  },
+  "rct2.tt.schoolbs": {
+    "reference-name": "School Bus Trams",
+    "name": "校車遊樂設施",
+    "reference-description": "Miniature trams themed to look like North American school buses",
+    "description": "仿黃巴士主題列車",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "每輛車限乘10人"
+  },
+  "rct2.tsp": {
+    "reference-name": "Scots Pine Tree",
+    "name": "蘇格蘭松樹"
+  },
+  "rct2.ssig1": {
+    "reference-name": "Scrolling Sign",
+    "name": "捲動式招牌"
+  },
+  "rct2.wallsign": {
+    "reference-name": "Scrolling Sign",
+    "name": "捲動招牌"
+  },
+  "rct2.tgc1": {
+    "reference-name": "Sculpture",
+    "name": "雕刻品"
+  },
+  "rct2.tgc2": {
+    "reference-name": "Sculpture",
+    "name": "雕刻品"
+  },
+  "rct2.sqdst": {
+    "reference-name": "Sea Food Stall",
+    "name": "海鮮店",
+    "reference-description": "A stall selling fried tentacles",
+    "description": "一家賣炸觸角的店"
+  },
+  "rct2.tt.schnpl04": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.tt.schnpl05": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.tt.schnpl02": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.tt.schnpl06": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.tt.schnpl01": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.tt.schnpl03": {
+    "reference-name": "Sea Plane",
+    "name": "海上小飛機"
+  },
+  "rct2.ww.seals": {
+    "reference-name": "Seal Trains",
+    "name": "Seal Trains",
+    "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "description": "Roller coaster trains with shoulder restraints themed to look like seals",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.schnpits": {
+    "reference-name": "Seaplane Pits",
+    "name": "海上飛機修理站"
+  },
+  "rct2.tt.schnpit2": {
+    "reference-name": "Seaplane Pits",
+    "name": "海上飛機修理站"
+  },
+  "rct2.ww.sbh2shlt": {
+    "reference-name": "Search Light",
+    "name": "Search Light"
+  },
+  "rct2.benchpl": {
+    "reference-name": "Seats",
+    "name": "座位"
+  },
+  "rct2.ww.shiva": {
+    "reference-name": "Shiva",
+    "name": "Shiva"
+  },
+  "rct2.tsh4": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.tsh1": {
+    "reference-name": "Shrub",
+    "name": "灌木"
+  },
+  "rct2.scgshrub": {
+    "reference-name": "Shrubs and Ornaments",
+    "name": "灌木及裝飾品"
+  },
+  "rct2.badshut": {
+    "reference-name": "Shuttlecock",
+    "name": "羽毛球"
+  },
+  "rct2.badshut2": {
+    "reference-name": "Shuttlecock",
+    "name": "羽毛球"
+  },
+  "rct2.ww.wshogi09": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi13": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi11": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi03": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi10": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi07": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi04": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi05": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi06": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi12": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi01": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi08": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi02": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.ww.wshogi14": {
+    "reference-name": "Shōji Wall",
+    "name": "Shōji Wall"
+  },
+  "rct2.tt.1920path": {
+    "reference-name": "Sidewalk FootPath",
+    "name": "人行道路"
+  },
+  "rct2.bn1": {
+    "reference-name": "Sign",
+    "name": "招牌"
+  },
+  "rct2.scgpathx": {
+    "reference-name": "Signs and Items for Footpaths",
+    "name": "道路標示與事物"
+  },
+  "rct2.tsb": {
+    "reference-name": "Silver Birch Tree",
+    "name": "銀樺樹"
+  },
+  "rct2.tt.guyqwifx": {
+    "reference-name": "Singer with Quiff",
+    "name": "捲髮歌者"
+  },
+  "rct2.obs1": {
+    "reference-name": "Single-deck Cabin",
+    "name": "瞭望台",
+    "reference-description": "Single-deck rotating observation cabin",
+    "description": "觀察艙旋轉移動到高塔上面。",
+    "reference-capacity": "20 passengers",
+    "capacity": "20 位乘客"
+  },
+  "rct2.scgsixfl": {
+    "reference-name": "Six Flags Themeing",
+    "name": "六旗主題區"
+  },
+  "rct2.bmvd": {
+    "reference-name": "Six-seater Twister Trains",
+    "name": "自由落體雲霄飛車",
+    "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "完全延著垂直斜度軌道落下的附加大型列車體驗由頂點自由落下的快感",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.ssk1": {
+    "reference-name": "Skeleton",
+    "name": "骨骼"
+  },
+  "rct2.clift2": {
+    "reference-name": "Ski-lift Chairs",
+    "name": "登頂滑雪纜車車椅",
+    "reference-description": "Open cars for chairlift",
+    "description": "供纜車使用的開放式車卡",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "每車卡2位乘客"
+  },
+  "rct2.ww.skidoo": {
+    "reference-name": "Skidoo Dodgems",
+    "name": "Skidoo Dodgems",
+    "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "description": "Guests slide around in skidoo-shaped vehicles that they freely control",
+    "reference-capacity": "1 person per car",
+    "capacity": "1 person per car"
+  },
+  "rct2.smskull": {
+    "reference-name": "Skull",
+    "name": "頭骨"
+  },
+  "rct2.tsk": {
+    "reference-name": "Skull",
+    "name": "頭骨"
+  },
+  "rct2.ww.sbskys17": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys14": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys18": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys16": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.sbskys15": {
+    "reference-name": "Sky Scraper Roof Piece",
+    "name": "Sky Scraper Roof Piece"
+  },
+  "rct2.ww.wskysc08": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc09": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.ww.wskysc06": {
+    "reference-name": "Sky Scraper Wall Piece",
+    "name": "Sky Scraper Wall Piece"
+  },
+  "rct2.tt.futrpat2": {
+    "reference-name": "Sky Walk FootPath",
+    "name": "天橋道路"
+  },
+  "rct1.ll.edge.skyscrapera": {
+    "reference-name": "Skyscraper (A)",
+    "name": "Skyscraper (A)"
+  },
+  "rct1.ll.edge.skyscraperb": {
+    "reference-name": "Skyscraper (B)",
+    "name": "Skyscraper (B)"
+  },
+  "rct2.ww.sbskys10": {
+    "reference-name": "Skyscraper Concave Piece",
+    "name": "Skyscraper Concave Piece"
+  },
+  "rct2.ww.sbskys11": {
+    "reference-name": "Skyscraper Concave Roof",
+    "name": "Skyscraper Concave Roof"
+  },
+  "rct2.ww.sbskys12": {
+    "reference-name": "Skyscraper Convex Piece",
+    "name": "Skyscraper Convex Piece"
+  },
+  "rct2.ww.sbskys13": {
+    "reference-name": "Skyscraper Convex Roof",
+    "name": "Skyscraper Convex Roof"
+  },
+  "rct2.ww.sbskys03": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.sbskys04": {
+    "reference-name": "Skyscraper Lift Piece",
+    "name": "Skyscraper Lift Piece"
+  },
+  "rct2.ww.wskysc05": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc07": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.wskysc04": {
+    "reference-name": "Skyscraper Lift Section Piece",
+    "name": "Skyscraper Lift Section Piece"
+  },
+  "rct2.ww.sbskys06": {
+    "reference-name": "Skyscraper Metal Set 1 Concave Piece",
+    "name": "Skyscraper Metal Set 1 Concave Piece"
+  },
+  "rct2.ww.sbskys05": {
+    "reference-name": "Skyscraper Metal Set 1 Convex Piece",
+    "name": "Skyscraper Metal Set 1 Convex Piece"
+  },
+  "rct2.ww.wskysc03": {
+    "reference-name": "Skyscraper Metal Set 1 Wall Piece",
+    "name": "Skyscraper Metal Set 1 Wall Piece"
+  },
+  "rct2.ww.sbskys09": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys08": {
+    "reference-name": "Skyscraper Metal Set 2 Concave Piece",
+    "name": "Skyscraper Metal Set 2 Concave Piece"
+  },
+  "rct2.ww.sbskys07": {
+    "reference-name": "Skyscraper Metal Set 2 Convex Piece",
+    "name": "Skyscraper Metal Set 2 Convex Piece"
+  },
+  "rct2.ww.wskysc02": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.wskysc01": {
+    "reference-name": "Skyscraper Metal Set 2 Wall Piece",
+    "name": "Skyscraper Metal Set 2 Wall Piece"
+  },
+  "rct2.ww.mbskyr01": {
+    "reference-name": "Skyscraper Roof Piece",
+    "name": "Skyscraper Roof Piece"
+  },
+  "rct2.ww.mbskyr02": {
+    "reference-name": "Skyscraper Tip",
+    "name": "Skyscraper Tip"
+  },
+  "rct2.ww.sloth": {
+    "reference-name": "Sloth Trains",
+    "name": "Sloth Trains",
+    "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.mamthw06": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "小型多方向長毛象柵欄"
+  },
+  "rct2.tt.mamthw05": {
+    "reference-name": "Small Angled Mammoth Fence",
+    "name": "小型多方向長毛象柵欄"
+  },
+  "rct2.cog2r": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齒鐵輪"
+  },
+  "rct2.cog2u": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齒鐵輪"
+  },
+  "rct2.cog2ur": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齒鐵輪"
+  },
+  "rct2.cog2": {
+    "reference-name": "Small Cogwheel",
+    "name": "小木齒鐵輪"
+  },
+  "rct2.ww.smallgeo": {
+    "reference-name": "Small Geosphere",
+    "name": "Small Geosphere"
+  },
+  "rct2.tt.cratr2x2": {
+    "reference-name": "Small Meteor Crater",
+    "name": "小型隕石坑"
+  },
+  "rct2.mono2": {
+    "reference-name": "Small Monorail Cars",
+    "name": "小型單軌電車",
+    "reference-description": "Small monorail cars with open sides",
+    "description": "附有開放式側邊的小型單軌電車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每車卡4位乘客"
+  },
+  "rct2.ww.1x1jugt2": {
+    "reference-name": "Small Rainforest Tree 1",
+    "name": "Small Rainforest Tree 1"
+  },
+  "rct2.ww.1x1jugt3": {
+    "reference-name": "Small Rainforest Tree 2",
+    "name": "Small Rainforest Tree 2"
+  },
+  "rct2.tt.rdmet2x2": {
+    "reference-name": "Small Red Meteor Crater",
+    "name": "小型紅色隕石坑"
+  },
+  "rct2.tt.speakr01": {
+    "reference-name": "Small Speaker",
+    "name": "小型擴音器"
+  },
+  "rct2.tt.smoksk03": {
+    "reference-name": "Smoke Stack Base",
+    "name": "冒煙的乾草堆底座"
+  },
+  "rct2.tt.smoksk02": {
+    "reference-name": "Smoke Stack Mid",
+    "name": "冒煙的乾草堆中段"
+  },
+  "rct2.snail": {
+    "reference-name": "Snail",
+    "name": "蝸牛"
+  },
+  "rct2.station.snow": {
+    "reference-name": "Snow / Ice",
+    "name": "Snow / Ice"
+  },
+  "rct2.bn8": {
+    "reference-name": "Snow Covered Sign",
+    "name": "覆雪式招牌"
+  },
+  "rct2.twist2": {
+    "reference-name": "Snow Cups",
+    "name": "雪杯",
+    "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "乘客乘坐在圍繞著中央雪人的成對坐位上",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 位乘客"
+  },
+  "rct2.scgsnow": {
+    "reference-name": "Snow and Ice Themeing",
+    "name": "冰雪主題區"
+  },
+  "rct2.music.snow": {
+    "reference-name": "Snow style",
+    "name": "雪地風格"
+  },
+  "rct2.tcfs": {
+    "reference-name": "Snow-covered Caucasian Fir Tree",
+    "name": "被雪覆?的高加索冷杉樹"
+  },
+  "rct2.tnss": {
+    "reference-name": "Snow-covered Norway Spruce Tree",
+    "name": "被雪覆?的挪威杉木"
+  },
+  "rct2.trfs": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "被雪覆?的紅杉木"
+  },
+  "rct2.trf3": {
+    "reference-name": "Snow-covered Red Fir Tree",
+    "name": "被雪覆?的紅杉木"
+  },
+  "rct2.tsnb": {
+    "reference-name": "Snowball",
+    "name": "雪球"
+  },
+  "rct2.tsm": {
+    "reference-name": "Snowman",
+    "name": "雪人"
+  },
+  "rct2.sbox": {
+    "reference-name": "Soap Boxes",
+    "name": "肥皂盒德貝賽車",
+    "reference-description": "Single cars shaped like a soap box",
+    "description": "乘客乘坐在肥皂盒外形的車輛延著單軌式的雲霄飛車",
+    "reference-capacity": "4 riders per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.softoyst": {
+    "reference-name": "Soft Toy Stall",
+    "name": "填充玩具攤位",
+    "reference-description": "A stall selling a cute soft toy dinosaur",
+    "description": "販賣可愛恐龍填充玩具的攤位"
+  },
+  "rct2.ww.scgsamer": {
+    "reference-name": "South America Themeing",
+    "name": "South America Themeing"
+  },
+  "rct2.ww.samerent": {
+    "reference-name": "South American Park Entrance",
+    "name": "South American Park Entrance"
+  },
+  "rct2.souvs": {
+    "reference-name": "Souvenir Stall",
+    "name": "紀念品店",
+    "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
+    "description": "一家在賣紀念品 酷迪玩具 和 雨傘的店"
+  },
+  "rct2.soybean": {
+    "reference-name": "Soybean Milk Stall",
+    "name": "豆漿店",
+    "reference-description": "A stall selling cartons of soybean milk",
+    "description": "一家賣盒裝豆漿的店"
+  },
+  "rct2.station.space": {
+    "reference-name": "Space",
+    "name": "Space"
+  },
+  "rct2.tscp": {
+    "reference-name": "Space Capsule",
+    "name": "太空囊"
+  },
+  "rct2.ssh": {
+    "reference-name": "Space Capsule",
+    "name": "太空船"
+  },
+  "rct2.ww.spaceorb": {
+    "reference-name": "Space Orbs",
+    "name": "Space Orbs"
+  },
+  "rct2.srings": {
+    "reference-name": "Space Rings",
+    "name": "環形空間",
+    "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
+    "description": "在中心樞軸上轉動,允?乘客自由轉動方向",
+    "reference-capacity": "1 guest per ring",
+    "capacity": "1 guest per ring"
+  },
+  "rct2.ssr": {
+    "reference-name": "Space Rocket",
+    "name": "太空火箭"
+  },
+  "rct2.tt.spcshp01": {
+    "reference-name": "Space Ship Cargo Section",
+    "name": "太空船貨物區"
+  },
+  "rct2.tt.spcshp02": {
+    "reference-name": "Space Ship Comms Section",
+    "name": "太空船通訊區"
+  },
+  "rct2.tt.spcshp07": {
+    "reference-name": "Space Ship Control Deck",
+    "name": "太空船駕駛艙"
+  },
+  "rct2.tt.spcshp06": {
+    "reference-name": "Space Ship Cross Section",
+    "name": "太空船交叉區段"
+  },
+  "rct2.tt.spcshp09": {
+    "reference-name": "Space Ship Docking Section",
+    "name": "太空船泊塢區"
+  },
+  "rct2.tt.spcshp10": {
+    "reference-name": "Space Ship Engine Section",
+    "name": "太空船引擎區"
+  },
+  "rct2.tt.spcshp08": {
+    "reference-name": "Space Ship Fuel Section",
+    "name": "太空船燃料區"
+  },
+  "rct2.tt.spcshp05": {
+    "reference-name": "Space Ship Gravity Section",
+    "name": "太空船重力區"
+  },
+  "rct2.tt.spcshp11": {
+    "reference-name": "Space Ship Living Section",
+    "name": "太空船居住區"
+  },
+  "rct2.tt.spcshp12": {
+    "reference-name": "Space Ship Science Section",
+    "name": "太空船科學研究區"
+  },
+  "rct2.tt.spcshp04": {
+    "reference-name": "Space Ship Solar Panels",
+    "name": "太空船太陽能面板"
+  },
+  "rct2.tt.spcshp03": {
+    "reference-name": "Space Ship Solar Section",
+    "name": "太空船太陽能區"
+  },
+  "rct2.pathspce": {
+    "reference-name": "Space Style Footpath",
+    "name": "太空風格步道"
+  },
+  "rct2.bn9": {
+    "reference-name": "Space Style Sign",
+    "name": "太空式風格 招牌"
+  },
+  "rct2.scgspace": {
+    "reference-name": "Space Themeing",
+    "name": "太空世界主題區"
+  },
+  "rct2.music.space": {
+    "reference-name": "Space style",
+    "name": "太空風格"
+  },
+  "rct2.tsd": {
+    "reference-name": "Spade Shaped Tree",
+    "name": "鏟子形狀的樹"
+  },
+  "rct2.sspx": {
+    "reference-name": "Sphinx",
+    "name": "斯芬克斯"
+  },
+  "rct2.spider1": {
+    "reference-name": "Spider",
+    "name": "蜘蛛"
+  },
+  "rct2.tt.mspkwa01": {
+    "reference-name": "Spiked Fence",
+    "name": "有尖刺的柵欄"
+  },
+  "rct2.wmspin": {
+    "reference-name": "Spinning Mouse Cars",
+    "name": "太空飛鼠",
+    "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
+    "description": "老鼠外形車輛疾迅穿過牢固轉角及短程下坡,再溫和地旋轉著使你迷失方向感",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.spdrcr": {
+    "reference-name": "Spiral Roller Coaster Trains",
+    "name": "螺旋式雲霄飛車",
+    "reference-description": "Compact roller coaster trains with cars with in-line seating",
+    "description": "一座緊密的鋼製軌道的雲霄飛車有著螺旋上升斜坡及同軸列車座椅",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.hskelt": {
+    "reference-name": "Spiral Slide",
+    "name": "螺旋滑道",
+    "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
+    "description": "木製結構，內部有一個樓梯，而外部則是有螺旋狀的坡道可以滑下來"
+  },
+  "rct2.spboat": {
+    "reference-name": "Splash Boats",
+    "name": "水花四濺",
+    "reference-description": "Large capacity boats, built for water tracks with very steep drops",
+    "description": "大型容量的船體延著水道利用傳輸帶送上斜坡,再加速向下滑落並濺起水花使乘客浸泡到水",
+    "reference-capacity": "16 passengers per boat",
+    "capacity": "16 位乘客 /每艘船"
+  },
+  "rct2.scgspook": {
+    "reference-name": "Spooky Themeing",
+    "name": "幽靈主題區"
+  },
+  "rct2.spcar": {
+    "reference-name": "Sports Cars",
+    "name": "運動車",
+    "reference-description": "Powered vehicles in the shape of sports cars",
+    "description": "運動車外形的動力機械車輛",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.scgsport": {
+    "reference-name": "Sports Themeing",
+    "name": "運動主題區"
+  },
+  "rct2.ww.sputnik": {
+    "reference-name": "Sputnik",
+    "name": "Sputnik"
+  },
+  "rct2.ww.sputnikr": {
+    "reference-name": "Sputnik Cars",
+    "name": "Sputnik Cars",
+    "reference-description": "Russian satellite-shaped cars which swing from the rail above",
+    "description": "Russian satellite-shaped cars which swing from the rail above",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.tsq": {
+    "reference-name": "Squirrel Shaped Tree",
+    "name": "松鼠形狀的樹"
+  },
+  "rct2.ww.stgccstr": {
+    "reference-name": "Stage Coaches",
+    "name": "Stage Coaches",
+    "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.stamphrd": {
+    "reference-name": "Stampeding Herd Trains",
+    "name": "獸群狂奔雲霄飛車",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
+    "description": "一座外形為狂奔恐龍群迴圈式雲霄飛車。",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.togst": {
+    "reference-name": "Stand-up Roller Coaster Trains",
+    "name": "站立式雲霄飛車",
+    "reference-description": "Roller coaster trains in which the riders ride in a standing position",
+    "description": "一座循環式雲霄飛車讓乘客以站立姿勢搭乘",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.bmsu": {
+    "reference-name": "Stand-up Twister Trains",
+    "name": "站立式旋轉飛車",
+    "reference-description": "A train with shoulder restraints, in which the riders stand up",
+    "description": "乘客搭乘在站立式的列車內以特殊設計的安全裝置以確保在疾迅下墜及穿過多樣式反轉軌道時的安全",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.starfrdr": {
+    "reference-name": "Star Fruit Drink Stall",
+    "name": "楊桃汁店",
+    "reference-description": "A stall selling star fruit drinks",
+    "description": "一家賣楊桃汁飲料的店"
+  },
+  "rct2.tgh1": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.tgh2": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.tos": {
+    "reference-name": "Statue",
+    "name": "雕像"
+  },
+  "rct2.ww.soflibrt": {
+    "reference-name": "Statue of Liberty",
+    "name": "Statue of Liberty"
+  },
+  "rct2.nrl": {
+    "reference-name": "Steam Trains",
+    "name": "蒸氣火車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+    "description": "配備著復刻蒸氣火車頭及煤水車的小型蒸氣火車, 拉著開放式的木製車廂",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "每車廂6位乘客"
+  },
+  "rct2.nrl2": {
+    "reference-name": "Steam Trains with Covered Cars",
+    "name": "有蓋蒸氣火車",
+    "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+    "description": "配備著復刻蒸氣火車頭及煤水車的小型蒸氣火車, 拉著帶有織布車頂的木製車廂",
+    "reference-capacity": "6 passengers per carriage",
+    "capacity": "每車廂6位乘客"
+  },
+  "rct2.tt.stmdran1": {
+    "reference-name": "Steaming Drains",
+    "name": "蒸汽管"
+  },
+  "rct2.stbase": {
+    "reference-name": "Steel Block",
+    "name": "鐵塊"
+  },
+  "rct2.stlbaset": {
+    "reference-name": "Steel Block",
+    "name": "鋼鐵牆"
+  },
+  "rct2.wallstfn": {
+    "reference-name": "Steel Fence",
+    "name": "鐵柵欄"
+  },
+  "rct2.walllt32": {
+    "reference-name": "Steel Latticework",
+    "name": "鐵格子"
+  },
+  "rct2.stldw2": {
+    "reference-name": "Steel Wall",
+    "name": "鋼鐵牆"
+  },
+  "rct2.stldw": {
+    "reference-name": "Steel Wall",
+    "name": "鋼鐵牆"
+  },
+  "rct2.wallst8": {
+    "reference-name": "Steel Wall",
+    "name": "鐵牆"
+  },
+  "rct2.wallst32": {
+    "reference-name": "Steel Wall",
+    "name": "鐵牆"
+  },
+  "rct2.wallstwn": {
+    "reference-name": "Steel Wall",
+    "name": "鐵牆"
+  },
+  "rct2.wallst16": {
+    "reference-name": "Steel Wall",
+    "name": "鐵牆"
+  },
+  "rct2.tt.4x4stnhn": {
+    "reference-name": "Stone Age Temple",
+    "name": "石器時代寺廟"
+  },
+  "rct2.benchstn": {
+    "reference-name": "Stone Bench",
+    "name": "石椅"
+  },
+  "rct2.terb": {
+    "reference-name": "Stone Block",
+    "name": "石塊"
+  },
+  "rct2.ww.sb2sky01": {
+    "reference-name": "Stone Skyscraper Stairway Base",
+    "name": "Stone Skyscraper Stairway Base"
+  },
+  "rct2.ww.sbskys02": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.sbskys01": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc12": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc10": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.ww.wskysc11": {
+    "reference-name": "Stone Skyscraper Wall Piece",
+    "name": "Stone Skyscraper Wall Piece"
+  },
+  "rct2.wbr2": {
+    "reference-name": "Stone Wall",
+    "name": "石牆"
+  },
+  "rct2.wbr3": {
+    "reference-name": "Stone Wall",
+    "name": "石牆"
+  },
+  "rct2.wallbb34": {
+    "reference-name": "Stone Wall",
+    "name": "石牆"
+  },
+  "rct2.wbr2a": {
+    "reference-name": "Stone Wall",
+    "name": "石牆"
+  },
+  "rct2.tt.medstool": {
+    "reference-name": "Stool",
+    "name": "凳子"
+  },
+  "rct2.tt.stoolset": {
+    "reference-name": "Stools",
+    "name": "凳子"
+  },
+  "rct2.mono1": {
+    "reference-name": "Streamlined Monorail Trains",
+    "name": "流線型單軌電車",
+    "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
+    "description": "大載客量的單軌電車, 車頭車尾都配備著流線型設計",
+    "reference-capacity": "5 or 10 passengers per car",
+    "capacity": "每車卡5或10位乘客"
+  },
+  "rct1.ll.edge.green": {
+    "reference-name": "Stucco (Green)",
+    "name": "Stucco (Green)"
+  },
+  "rct1.aa.edge.grey": {
+    "reference-name": "Stucco (Grey)",
+    "name": "Stucco (Grey)"
+  },
+  "rct1.ll.edge.purple": {
+    "reference-name": "Stucco (Purple)",
+    "name": "Stucco (Purple)"
+  },
+  "rct1.aa.edge.red": {
+    "reference-name": "Stucco (Red)",
+    "name": "Stucco (Red)"
+  },
+  "rct1.aa.edge.yellow": {
+    "reference-name": "Stucco (Yellow)",
+    "name": "Stucco (Yellow)"
+  },
+  "rct2.substl": {
+    "reference-name": "Sub Sandwich Stall",
+    "name": "潛水艇三明治店",
+    "reference-description": "A stall selling fresh sub sandwiches",
+    "description": "一家賣新鮮潛水艇三明治的店"
+  },
+  "rct2.submar": {
+    "reference-name": "Submarines",
+    "name": "海底旅行",
+    "reference-description": "Riders ride in a submerged submarine through an underwater course",
+    "description": "乘客坐在水中的潛艇在水面下游動參觀",
+    "reference-capacity": "4 passengers per submarine",
+    "capacity": "4 位乘客 /每艘潛艇"
+  },
+  "rct2.cindr": {
+    "reference-name": "Sujeonggwa Stall",
+    "name": "Sujeonggwa 店",
+    "reference-description": "A stall selling Korean style Sujeonggwa drinks",
+    "description": "一家賣韓式Sujeonggwa飲料的店"
+  },
+  "rct2.music.summer": {
+    "reference-name": "Summer style",
+    "name": "夏日風格"
+  },
+  "rct2.sungst": {
+    "reference-name": "Sunglasses Stall",
+    "name": "太陽眼鏡店",
+    "reference-description": "A stall selling all kinds of sunglasses",
+    "description": "一家賣各種款式的太陽眼鏡的店"
+  },
+  "rct2.ww.sunken": {
+    "reference-name": "Sunken Ship",
+    "name": "Sunken Ship"
+  },
+  "rct2.tt.largecpu": {
+    "reference-name": "Super Computer Large CPU",
+    "name": "超級電腦大CPU"
+  },
+  "rct2.tt.compeyex": {
+    "reference-name": "Super Computer Monitor",
+    "name": "超級電腦螢幕"
+  },
+  "rct2.tt.smallcpu": {
+    "reference-name": "Super Computer Small CPU",
+    "name": "超級電腦小CPU"
+  },
+  "rct2.suppw2": {
+    "reference-name": "Support Structure",
+    "name": "支架結構"
+  },
+  "rct2.suppw1": {
+    "reference-name": "Support Structure",
+    "name": "支架結構"
+  },
+  "rct2.suppw3": {
+    "reference-name": "Support Structure",
+    "name": "支架結構"
+  },
+  "rct2.ww.surfbrdc": {
+    "reference-name": "Surfing Trains",
+    "name": "Surfing Trains",
+    "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.smono": {
+    "reference-name": "Suspended Monorail Trains",
+    "name": "懸掛式單軌電車",
+    "reference-description": "Large capacity monorail train cars",
+    "description": "大載客量的單軌電車",
+    "reference-capacity": "8 passengers per car",
+    "capacity": "每車卡8位乘客"
+  },
+  "rct2.tt.seaplane": {
+    "reference-name": "Suspended Seaplane Cars",
+    "name": "水上飛機遊樂設施",
+    "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "是由當列車在轉角處轉彎時列車自由搖?晃動組成的懸掛式雲霄飛車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "每輛車限乘4人"
+  },
+  "rct2.arrsw2": {
+    "reference-name": "Suspended Swinging Aeroplane Cars",
+    "name": "懸晃式飛機列車",
+    "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
+    "description": "懸掛式雲霄飛車列車是由飛機外形的車輛所組成的,車輛在經過轉角處時會自由?動搖晃",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.arrsw1": {
+    "reference-name": "Suspended Swinging Cars",
+    "name": "懸晃列車",
+    "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
+    "description": "是由當列車在轉角處轉彎時列車自由搖?晃動組成的懸掛式雲霄飛車",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ww.sb1hspb1": {
+    "reference-name": "Suspension Bridge Base Piece",
+    "name": "Suspension Bridge Base Piece"
+  },
+  "rct2.ww.sb1hspb2": {
+    "reference-name": "Suspension Bridge Base Spacer Piece",
+    "name": "Suspension Bridge Base Spacer Piece"
+  },
+  "rct2.ww.1x4brg05": {
+    "reference-name": "Suspension Bridge Cable Section",
+    "name": "Suspension Bridge Cable Section"
+  },
+  "rct2.ww.sb1hspb3": {
+    "reference-name": "Suspension Bridge Mid Section Piece",
+    "name": "Suspension Bridge Mid Section Piece"
+  },
+  "rct2.ww.1x4brg01": {
+    "reference-name": "Suspension Bridge Start side 1",
+    "name": "Suspension Bridge Start side 1"
+  },
+  "rct2.ww.1x4brg02": {
+    "reference-name": "Suspension Bridge Start side 2",
+    "name": "Suspension Bridge Start side 2"
+  },
+  "rct2.ww.1x4brg03": {
+    "reference-name": "Suspension Bridge Tower side 1",
+    "name": "Suspension Bridge Tower side 1"
+  },
+  "rct2.ww.1x4brg04": {
+    "reference-name": "Suspension Bridge Tower side 2",
+    "name": "Suspension Bridge Tower side 2"
+  },
+  "rct2.tt.swamplt2": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tt.swamplt9": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tt.swamplt7": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tt.swamplt6": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tt.swamplt8": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tt.swamplt3": {
+    "reference-name": "Swamp Fern",
+    "name": "沼澤蕨類"
+  },
+  "rct2.tsg": {
+    "reference-name": "Swamp Goo",
+    "name": "天鵝"
+  },
+  "rct2.tt.swamplt5": {
+    "reference-name": "Swamp Plant",
+    "name": "沼澤植物"
+  },
+  "rct2.tt.swamplt4": {
+    "reference-name": "Swamp Plant",
+    "name": "沼澤植物"
+  },
+  "rct2.tt.swamplt1": {
+    "reference-name": "Swamp Plant",
+    "name": "沼澤植物"
+  },
+  "rct2.swans": {
+    "reference-name": "Swans",
+    "name": "天鵝",
+    "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
+    "description": "天鵝外形的船, 由前座的乘客腳踏前進",
+    "reference-capacity": "4 passengers per boat",
+    "capacity": "4 位乘客 /每艘船"
+  },
+  "rct2.batfl": {
+    "reference-name": "Swinging Cars",
+    "name": "搖?車",
+    "reference-description": "Small cars which swing from the rail above",
+    "description": "小型車輛在鐵道上振動搖?",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.vekvamp": {
+    "reference-name": "Swinging Floorless Cars",
+    "name": "搖?列車",
+    "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
+    "description": "懸掛式雲霄飛車列車的的組成是由升降機式坐椅可以在行進間經過轉角處時自由?動搖晃",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.swsh2": {
+    "reference-name": "Swinging Inverter Ship",
+    "name": "倒轉?動的船",
+    "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
+    "description": "船是依附在於對面基底上平衡力支架的,以360度?動方式運行",
+    "reference-capacity": "12 passengers",
+    "capacity": "12 位乘客"
+  },
+  "rct2.tt.swrdstne": {
+    "reference-name": "Sword in the Stone",
+    "name": "石中劍"
+  },
+  "rct2.tshrt": {
+    "reference-name": "T-Shirt Stall",
+    "name": "T恤店",
+    "reference-description": "A stall selling souvenir T-Shirts",
+    "description": "一家賣T恤紀念品的店"
+  },
+  "rct2.ww.tgvtrain": {
+    "reference-name": "TGV Trains",
+    "name": "TGV Trains",
+    "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.tnt2": {
+    "reference-name": "TNT Barrels",
+    "name": "TNT Barrels"
+  },
+  "rct2.ww.tnt4": {
+    "reference-name": "TNT Crates",
+    "name": "TNT Crates"
+  },
+  "rct2.ww.tnt3": {
+    "reference-name": "TNT Detonator",
+    "name": "TNT Detonator"
+  },
+  "rct2.ww.tnt1": {
+    "reference-name": "TNT Stack",
+    "name": "TNT Stack"
+  },
+  "rct2.ww.talllan2": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.ww.talllan1": {
+    "reference-name": "Tall Lantern",
+    "name": "Tall Lantern"
+  },
+  "rct2.wwtw": {
+    "reference-name": "Tall Wooden Fence",
+    "name": "高大的木式柵欄"
+  },
+  "rct2.ttg": {
+    "reference-name": "Target",
+    "name": "目標"
+  },
+  "rct2.tarmac": {
+    "reference-name": "Tarmac Footpath",
+    "name": "柏油碎石步道"
+  },
+  "rct2.tavern": {
+    "reference-name": "Tavern",
+    "name": "小酒館"
+  },
+  "rct2.music.techno": {
+    "reference-name": "Techno style",
+    "name": "電子風格"
+  },
+  "rct2.ww.sbh1tepe": {
+    "reference-name": "Tee Pee",
+    "name": "Tee Pee"
+  },
+  "rct2.tt.telepter": {
+    "reference-name": "Teleporter Cabin",
+    "name": "傳送點",
+    "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
+    "description": "將遊客由某一層傳送到另一層",
+    "reference-capacity": "16 passengers",
+    "capacity": "限乘16人"
+  },
+  "rct2.ww.1x2azt02": {
+    "reference-name": "Temple Broken Wall Piece with Head",
+    "name": "Temple Broken Wall Piece with Head"
+  },
+  "rct2.ww.waztec19": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec02": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec16": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec15": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec18": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec17": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec01": {
+    "reference-name": "Temple Roof Piece",
+    "name": "Temple Roof Piece"
+  },
+  "rct2.ww.waztec20": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec21": {
+    "reference-name": "Temple Stairway Piece",
+    "name": "Temple Stairway Piece"
+  },
+  "rct2.ww.waztec27": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec11": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec12": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec26": {
+    "reference-name": "Temple Wall Corner Piece",
+    "name": "Temple Wall Corner Piece"
+  },
+  "rct2.ww.waztec09": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec04": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec10": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec24": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec22": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec14": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec25": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec13": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec05": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec23": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec03": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec08": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec07": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.waztec06": {
+    "reference-name": "Temple Wall Piece",
+    "name": "Temple Wall Piece"
+  },
+  "rct2.ww.1x2azt01": {
+    "reference-name": "Temple Wall Piece with Head",
+    "name": "Temple Wall Piece with Head"
+  },
+  "rct2.sah3": {
+    "reference-name": "Tenement",
+    "name": "租屋"
+  },
+  "rct2.ball4": {
+    "reference-name": "Tennis Ball",
+    "name": "網球"
+  },
+  "rct2.wallnt33": {
+    "reference-name": "Tennis Net Wall",
+    "name": "網球網牆"
+  },
+  "rct2.wallnt32": {
+    "reference-name": "Tennis Net Wall",
+    "name": "網球網牆"
+  },
+  "rct2.sct": {
+    "reference-name": "Tent",
+    "name": "帳蓬"
+  },
+  "rct2.teepee1": {
+    "reference-name": "Tepee",
+    "name": "圓錐帳篷"
+  },
+  "rct2.ww.1x1termm": {
+    "reference-name": "Termite Mound",
+    "name": "Termite Mound"
+  },
+  "rct2.shs1": {
+    "reference-name": "Terraced House",
+    "name": "連棟房屋"
+  },
+  "rct2.ww.terrarmy": {
+    "reference-name": "Terracotta Army",
+    "name": "Terracotta Army"
+  },
+  "rct2.tt.timemach": {
+    "reference-name": "Time Machine",
+    "name": "時光機",
+    "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
+    "description": "乘客坐在特殊設計的球體中,體驗時光旅行的感覺",
+    "reference-capacity": "1 guest per time machine",
+    "capacity": "限乘一人"
+  },
+  "rct2.tst5": {
+    "reference-name": "Toadstool",
+    "name": "傘菌"
+  },
+  "rct2.tst3": {
+    "reference-name": "Toadstool",
+    "name": "傘菌"
+  },
+  "rct2.tst2": {
+    "reference-name": "Toadstool",
+    "name": "傘菌"
+  },
+  "rct2.tms1": {
+    "reference-name": "Toadstool",
+    "name": "傘菌;毒菌"
+  },
+  "rct2.tst4": {
+    "reference-name": "Toadstool",
+    "name": "傘菌"
+  },
+  "rct2.tst1": {
+    "reference-name": "Toadstool",
+    "name": "傘菌"
+  },
+  "rct2.jstar1": {
+    "reference-name": "Toboggan Cars",
+    "name": "平底雪橇",
+    "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
+    "description": "平底雪橇外形的雲霄飛車與同軸座位",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.mktstal1": {
+    "reference-name": "Toffee Apple Market Stall",
+    "name": "太妃糖店",
+    "reference-description": "A themed stall selling sticky toffee apples",
+    "description": "販賣太妃糖的主題攤位"
+  },
+  "rct2.toffs": {
+    "reference-name": "Toffee Apple Stall",
+    "name": "太妃糖蘋果店",
+    "reference-description": "An apple-shaped stall selling toffee apples on a stick",
+    "description": "一間太妃糖蘋果店在賣太妃糖蘋果棒"
+  },
+  "rct2.tlt1": {
+    "reference-name": "Toilets",
+    "name": "廁所",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "一座基本廁所建築物"
+  },
+  "rct2.tlt2": {
+    "reference-name": "Toilets",
+    "name": "廁所",
+    "reference-description": "Toilets housed in a log cabin style building",
+    "description": "廁所房子是一座原木小屋風格的建築物"
+  },
+  "rct1.toilets": {
+    "reference-name": "Toilets",
+    "name": "廁所",
+    "reference-description": "Basic toilets housed in a prefabricated concrete building",
+    "description": "一座基本廁所建築物"
+  },
+  "rct2.tt.tommygun": {
+    "reference-name": "Tommy Gun Ride",
+    "name": "機關槍遊樂設施",
+    "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "乘客兩人一組乘坐在主題座椅上，繞著一挺大型的仿製機關槍旋轉",
+    "reference-capacity": "18 passengers",
+    "capacity": "限乘18人"
+  },
+  "rct2.topsp1": {
+    "reference-name": "Top Spin",
+    "name": "上空旋轉",
+    "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
+    "description": "乘客搭乘著懸掛式小船由大型旋臂,旋轉向前及向後運作",
+    "reference-capacity": "8 passengers",
+    "capacity": "8 位乘客"
+  },
+  "rct2.totem1": {
+    "reference-name": "Totem Pole",
+    "name": "圖騰柱"
+  },
+  "rct2.sth": {
+    "reference-name": "Town Hall",
+    "name": "市政府"
+  },
+  "rct2.music.toyland": {
+    "reference-name": "Toyland style",
+    "name": "童真風格"
+  },
+  "rct2.ww.rssncrrd": {
+    "reference-name": "Trabant Cars",
+    "name": "Trabant Cars",
+    "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
+    "description": "Roller coaster cars in the shape of replica Trabant cars",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.ww.trckprt5": {
+    "reference-name": "Track Bend",
+    "name": "Track Bend"
+  },
+  "rct2.ww.trckprt6": {
+    "reference-name": "Track Broke",
+    "name": "Track Broke"
+  },
+  "rct2.ww.trckprt7": {
+    "reference-name": "Track End",
+    "name": "Track End"
+  },
+  "rct2.ww.trckprt8": {
+    "reference-name": "Track Split",
+    "name": "Track Split"
+  },
+  "rct2.ww.trckprt9": {
+    "reference-name": "Track Straight",
+    "name": "Track Straight"
+  },
+  "rct2.ww.atractor": {
+    "reference-name": "Tractor",
+    "name": "Tractor"
+  },
+  "rct2.pkent1": {
+    "reference-name": "Traditional Park Entrance",
+    "name": "傳統遊樂園入口"
+  },
+  "rct2.tram1": {
+    "reference-name": "Trams",
+    "name": "電車",
+    "reference-description": "Old-timer replica trams",
+    "description": "復刻的懷舊電車",
+    "reference-capacity": "10 passengers per car",
+    "capacity": "每車卡10位乘客"
+  },
+  "rct2.tt.travlr01": {
+    "reference-name": "Traveller Van",
+    "name": "旅行車"
+  },
+  "rct2.chest2": {
+    "reference-name": "Treasure Chest",
+    "name": "珠寶盒"
+  },
+  "rct2.chest1": {
+    "reference-name": "Treasure Chest",
+    "name": "珠寶盒"
+  },
+  "rct2.tt.gldchest": {
+    "reference-name": "Treasure Chest",
+    "name": "珠寶盒"
+  },
+  "rct2.tt.trebucht": {
+    "reference-name": "Trebuchet Ride",
+    "name": "拋石機遊樂設施",
+    "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
+    "description": "乘客乘坐在依照黑暗時代圍城武器設計，以兩隻手臂懸吊的車廂中",
+    "reference-capacity": "8 passengers",
+    "capacity": "限乘8人"
+  },
+  "rct2.tl1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt5": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tl0": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.ts3": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt6": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt4": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tot2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tot3": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tm1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tm2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tot1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tsp1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tsp2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tl3": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tjt3": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tm0": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.ts2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tot4": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tl2": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.ts1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.ts0": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tm3": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.tropt1": {
+    "reference-name": "Tree",
+    "name": "樹"
+  },
+  "rct2.scgtrees": {
+    "reference-name": "Trees",
+    "name": "樹"
+  },
+  "rct2.tt.tricatop": {
+    "reference-name": "Triceratops Dodgems",
+    "name": "三角龍碰碰車",
+    "reference-description": "Riders lock horns with each other in triceratops dodgems",
+    "description": "三角龍形碰碰車乘客以角彼此纏鬥",
+    "reference-capacity": "1 person per car",
+    "capacity": "每輛車限乘1人"
+  },
+  "rct2.tt.trilobte": {
+    "reference-name": "Trilobite Boats",
+    "name": "三葉蟲小船",
+    "reference-description": "Trilobite-shaped roller coaster cars",
+    "description": "三葉蟲外形的列車在雲霄飛車的曲線迴轉及陡坡急墜軌道上運行,將平靜的河面激起大量的水花。",
+    "reference-capacity": "6 passengers per boat",
+    "capacity": "每艘船限乘6人"
+  },
+  "rct2.ww.wtudor13": {
+    "reference-name": "Tudor Ground Bay Wall Piece",
+    "name": "Tudor Ground Bay Wall Piece"
+  },
+  "rct2.ww.wtudor14": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor01": {
+    "reference-name": "Tudor Ground Floor Wall Piece 1",
+    "name": "Tudor Ground Floor Wall Piece 1"
+  },
+  "rct2.ww.wtudor15": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor02": {
+    "reference-name": "Tudor Ground Floor Wall Piece 2",
+    "name": "Tudor Ground Floor Wall Piece 2"
+  },
+  "rct2.ww.wtudor16": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor03": {
+    "reference-name": "Tudor Ground Floor Wall Piece 3",
+    "name": "Tudor Ground Floor Wall Piece 3"
+  },
+  "rct2.ww.wtudor17": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor04": {
+    "reference-name": "Tudor Ground Floor Wall Piece 4",
+    "name": "Tudor Ground Floor Wall Piece 4"
+  },
+  "rct2.ww.wtudor18": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor05": {
+    "reference-name": "Tudor Ground Floor Wall Piece 5",
+    "name": "Tudor Ground Floor Wall Piece 5"
+  },
+  "rct2.ww.wtudor06": {
+    "reference-name": "Tudor Ground Floor Wall Piece 6",
+    "name": "Tudor Ground Floor Wall Piece 6"
+  },
+  "rct2.ww.wtudor07": {
+    "reference-name": "Tudor Ground Floor Wall Piece 7",
+    "name": "Tudor Ground Floor Wall Piece 7"
+  },
+  "rct2.ww.wtudor08": {
+    "reference-name": "Tudor Ground Floor Wall Piece 8",
+    "name": "Tudor Ground Floor Wall Piece 8"
+  },
+  "rct2.ww.rtudor01": {
+    "reference-name": "Tudor Roof Piece 1",
+    "name": "Tudor Roof Piece 1"
+  },
+  "rct2.ww.rtudor02": {
+    "reference-name": "Tudor Roof Piece 1 Extender Piece",
+    "name": "Tudor Roof Piece 1 Extender Piece"
+  },
+  "rct2.ww.rtudor03": {
+    "reference-name": "Tudor Roof Piece 2",
+    "name": "Tudor Roof Piece 2"
+  },
+  "rct2.ww.rtudor05": {
+    "reference-name": "Tudor Roof Piece 3",
+    "name": "Tudor Roof Piece 3"
+  },
+  "rct2.ww.rtudor06": {
+    "reference-name": "Tudor Roof Piece 4",
+    "name": "Tudor Roof Piece 4"
+  },
+  "rct2.ww.wtudor09": {
+    "reference-name": "Tudor Wall Piece 1",
+    "name": "Tudor Wall Piece 1"
+  },
+  "rct2.ww.wtudor10": {
+    "reference-name": "Tudor Wall Piece 2",
+    "name": "Tudor Wall Piece 2"
+  },
+  "rct2.ww.wtudor11": {
+    "reference-name": "Tudor Wall Piece 3",
+    "name": "Tudor Wall Piece 3"
+  },
+  "rct2.ww.wtudor12": {
+    "reference-name": "Tudor Wall Piece 4",
+    "name": "Tudor Wall Piece 4"
+  },
+  "rct2.ww.tutlboat": {
+    "reference-name": "Turtle Boats",
+    "name": "Turtle Boats",
+    "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
+    "reference-capacity": "2 passengers per boat",
+    "capacity": "2 passengers per boat"
+  },
+  "rct2.twist1": {
+    "reference-name": "Twist",
+    "name": "龍捲風",
+    "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "乘客坐在成對的座位上,由底部三支旋轉臂旋轉環繞運行",
+    "reference-capacity": "18 passengers",
+    "capacity": "18 位乘客"
+  },
+  "rct2.utcar": {
+    "reference-name": "Twister Cars",
+    "name": "旋轉列車",
+    "reference-description": "Roller coaster cars capable of heartline twists",
+    "description": "雲霄飛車車輛可以中心旋轉運行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.utcarr": {
+    "reference-name": "Twister Cars (starting reversed)",
+    "name": "旋轉列車(反轉出發)",
+    "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
+    "description": "雲霄飛車車輛可以中心旋轉運行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.bmsd": {
+    "reference-name": "Twister Trains",
+    "name": "旋風式雲霄飛車",
+    "reference-description": "Spacious trains with shoulder restraints",
+    "description": "雲霄飛車列車延著平滑的軌道上一起穿過多變反轉式的鋼製軌道滑行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.tt.alencrsh": {
+    "reference-name": "UFO Crash Site",
+    "name": "UFO墜落處"
+  },
+  "rct2.tus": {
+    "reference-name": "Unicorn Statue",
+    "name": "獨角獸雕像"
+  },
+  "rct2.scgurban": {
+    "reference-name": "Urban Themeing",
+    "name": "都市化主題"
+  },
+  "rct2.music.urban": {
+    "reference-name": "Urban style",
+    "name": "都市風格"
+  },
+  "rct2.tt.valkri01": {
+    "reference-name": "Valkyrie",
+    "name": "女武神"
+  },
+  "rct2.tt.valkri02": {
+    "reference-name": "Valkyrie",
+    "name": "女武神"
+  },
+  "rct2.tt.valkyrie": {
+    "reference-name": "Valkyries Trains",
+    "name": "女武神雲霄飛車",
+    "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
+    "description": "完全延著垂直斜度軌道落下的附加大型列車體驗由頂點自由落下的快感",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "每輛車限乘6人"
+  },
+  "rct2.ssig3": {
+    "reference-name": "Vertical 3D Sign",
+    "name": "直立式3D立體招牌"
+  },
+  "rct2.vekdv": {
+    "reference-name": "Vertical Shuttle Cars",
+    "name": "短程垂直反轉穿梭",
+    "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
+    "description": "乘客坐在車輛內懸掛在軌道下方,被向後垂直方向向上拉然後再快速墜下到旋轉迴圈緊接反轉運行",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ww.1x1atre2": {
+    "reference-name": "Vine Tree",
+    "name": "Vine Tree"
+  },
+  "rct2.vcr": {
+    "reference-name": "Vintage Cars",
+    "name": "葡萄酒列車",
+    "reference-description": "Powered vehicles in the shape of vintage cars",
+    "description": "具動力裝置及葡萄酒外型的車輛在即定航線軌道上運行",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 位乘客/每個車廂"
+  },
+  "rct2.vreel": {
+    "reference-name": "Virginia Reel Tubs",
+    "name": "維吉尼亞式旋轉",
+    "reference-description": "Circular cars that spin around as they travel along the track",
+    "description": "圓形車輛延著急彎的木架軌道自旋",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "openrct2.terrain.void": {
+    "reference-name": "Void",
+    "name": "Void"
+  },
+  "rct2.svlc": {
+    "reference-name": "Volcano",
+    "name": "火山"
+  },
+  "rct2.tt.4x4volca": {
+    "reference-name": "Volcano with small trees",
+    "name": "火山與小型樹木"
+  },
+  "rct2.tvl": {
+    "reference-name": "Voss's Laburnam Tree",
+    "name": "金鏈花樹"
+  },
+  "rct2.wag2": {
+    "reference-name": "Wagon",
+    "name": "馬車"
+  },
+  "rct2.wag1": {
+    "reference-name": "Wagon",
+    "name": "馬車"
+  },
+  "rct2.ww.sbh1wgwh": {
+    "reference-name": "Wagon Wheel",
+    "name": "Wagon Wheel"
+  },
+  "rct2.sktdw": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.sktdw2": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallpr33": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcw32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcb16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcf32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallmn32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallu132": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallpg32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcb32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcf8": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbb32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallsp32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbr16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallrh32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallpr34": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallrs32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbb33": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wc14": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcy32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcz32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wc15": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallrs8": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallsk32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcb8": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallpr35": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallu232": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallsk16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbr32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcf16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.walljn32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbb8": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbb16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcx32": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallbr8": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallrs16": {
+    "reference-name": "Wall",
+    "name": "牆"
+  },
+  "rct2.wallcfar": {
+    "reference-name": "Wall Arch",
+    "name": "拱門"
+  },
+  "official.mg-prar": {
+    "reference-name": "Wall with Passageway",
+    "name": "Wall with Passageway"
+  },
+  "rct2.scgwalls": {
+    "reference-name": "Walls and Roofs",
+    "name": "牆和 屋頂"
+  },
+  "rct2.twn": {
+    "reference-name": "Walnut Tree",
+    "name": "胡桃樹"
+  },
+  "rct2.ww.lincolns": {
+    "reference-name": "Washington Statue",
+    "name": "Washington Statue"
+  },
+  "rct2.wasp": {
+    "reference-name": "Wasp",
+    "name": "黃蜂"
+  },
+  "rct2.scgwater": {
+    "reference-name": "Water Feature Themeing",
+    "name": "水世界"
+  },
+  "rct2.whoriz": {
+    "reference-name": "Water Jet",
+    "name": "水上摩托車"
+  },
+  "rct2.wspout": {
+    "reference-name": "Water Spout",
+    "name": "噴水"
+  },
+  "rct2.trike": {
+    "reference-name": "Water Tricycles",
+    "name": "水上三輪車",
+    "reference-description": "Pedal-tricycle with large buoyant wheels",
+    "description": "有大型浮力輪子的腳踏-三輪車",
+    "reference-capacity": "2 passengers per tricycle",
+    "capacity": "2 位乘客 /每輛三輪車"
+  },
+  "rct2.music.water": {
+    "reference-name": "Water style",
+    "name": "水文風格"
+  },
+  "rct2.wallwf32": {
+    "reference-name": "Waterfall",
+    "name": "瀑布"
+  },
+  "rct2.ww.rwdaub02": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub03": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.rwdaub01": {
+    "reference-name": "Wattle & Daub Roof",
+    "name": "Wattle & Daub Roof"
+  },
+  "rct2.ww.wwdaub05": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub01": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub03": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub04": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub02": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub06": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.ww.wwdaub07": {
+    "reference-name": "Wattle & Daub Wall",
+    "name": "Wattle & Daub Wall"
+  },
+  "rct2.tt.wepnrack": {
+    "reference-name": "Weapon Set",
+    "name": "武器組"
+  },
+  "rct2.tww": {
+    "reference-name": "Weeping Willow Tree",
+    "name": "柳葉樹"
+  },
+  "rct2.tmw": {
+    "reference-name": "Wheels",
+    "name": "車子"
+  },
+  "rct2.tt.wiskybl1": {
+    "reference-name": "Whisky Barrel",
+    "name": "威士忌桶"
+  },
+  "rct2.tt.wiskybl2": {
+    "reference-name": "Whisky Barrels",
+    "name": "威士忌桶"
+  },
+  "rct2.tb1": {
+    "reference-name": "White Bishop",
+    "name": "白主教"
+  },
+  "rct2.tk3": {
+    "reference-name": "White King",
+    "name": "白棋國王"
+  },
+  "rct2.tk1": {
+    "reference-name": "White Knight",
+    "name": "白棋騎士"
+  },
+  "rct2.tp1": {
+    "reference-name": "White Pawn",
+    "name": "白棋兵"
+  },
+  "rct2.twp": {
+    "reference-name": "White Poplar Tree",
+    "name": "白楊樹"
+  },
+  "rct2.tq1": {
+    "reference-name": "White Queen",
+    "name": "白棋皇合"
+  },
+  "rct2.tr1": {
+    "reference-name": "White Rook",
+    "name": "白棋車"
+  },
+  "rct2.scgwwest": {
+    "reference-name": "Wild West Themeing",
+    "name": "西部荒野主題區"
+  },
+  "rct2.music.wildwest": {
+    "reference-name": "Wild west style",
+    "name": "美國西部風格"
+  },
+  "rct2.ww.sbwind02": {
+    "reference-name": "Wind Sculpted Concave Roof Corner",
+    "name": "Wind Sculpted Concave Roof Corner"
+  },
+  "rct2.ww.sbwind03": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind01": {
+    "reference-name": "Wind Sculpted Concave Wall Corner",
+    "name": "Wind Sculpted Concave Wall Corner"
+  },
+  "rct2.ww.sbwind05": {
+    "reference-name": "Wind Sculpted Convex Roof Corner",
+    "name": "Wind Sculpted Convex Roof Corner"
+  },
+  "rct2.ww.sbwind06": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind04": {
+    "reference-name": "Wind Sculpted Convex Wall Corner",
+    "name": "Wind Sculpted Convex Wall Corner"
+  },
+  "rct2.ww.sbwind19": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind18": {
+    "reference-name": "Wind Sculpted Floor Piece",
+    "name": "Wind Sculpted Floor Piece"
+  },
+  "rct2.ww.sbwind07": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind08": {
+    "reference-name": "Wind Sculpted Rock Formation Base",
+    "name": "Wind Sculpted Rock Formation Base"
+  },
+  "rct2.ww.sbwind11": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind10": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind12": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind09": {
+    "reference-name": "Wind Sculpted Rock Formation Mid Section",
+    "name": "Wind Sculpted Rock Formation Mid Section"
+  },
+  "rct2.ww.sbwind13": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind14": {
+    "reference-name": "Wind Sculpted Rock Formation Top",
+    "name": "Wind Sculpted Rock Formation Top"
+  },
+  "rct2.ww.sbwind16": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind17": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind15": {
+    "reference-name": "Wind Sculpted Roof Flat Roof Piece",
+    "name": "Wind Sculpted Roof Flat Roof Piece"
+  },
+  "rct2.ww.sbwind20": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.sbwind21": {
+    "reference-name": "Wind Sculpted Wall Base",
+    "name": "Wind Sculpted Wall Base"
+  },
+  "rct2.ww.wwind05": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind03": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind06": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.wwind04": {
+    "reference-name": "Wind Sculpted Wall Piece",
+    "name": "Wind Sculpted Wall Piece"
+  },
+  "rct2.ww.windmill": {
+    "reference-name": "Windmill",
+    "name": "Windmill"
+  },
+  "rct2.wallcbwn": {
+    "reference-name": "Window",
+    "name": "窗戶"
+  },
+  "rct2.wallbrwn": {
+    "reference-name": "Window",
+    "name": "窗戶"
+  },
+  "rct2.wallcfwn": {
+    "reference-name": "Window",
+    "name": "窗戶"
+  },
+  "rct2.tt.medisoup": {
+    "reference-name": "Witches Brew Soup",
+    "name": "巫婆湯",
+    "reference-description": "A stall selling a thick broth-style soup",
+    "description": "販賣濃湯類的攤位"
+  },
+  "rct2.tt.whccolds": {
+    "reference-name": "Witches around Cauldron",
+    "name": "圍繞大汽鍋的巫師"
+  },
+  "rct2.ww.whicgrub": {
+    "reference-name": "Witchetty Grub Trains",
+    "name": "Witchetty Grub Trains",
+    "reference-description": "Roller coaster trains with small grub-shaped cars",
+    "description": "Roller coaster trains with small grub-shaped cars",
+    "reference-capacity": "2 passengers per car",
+    "capacity": "2 passengers per car"
+  },
+  "rct2.scgwond": {
+    "reference-name": "Wonderland Themeing",
+    "name": "仙境主題區"
+  },
+  "rct2.wonton": {
+    "reference-name": "Wonton Soup Stall",
+    "name": "餛飩湯 店",
+    "reference-description": "A stall selling Wonton Soup",
+    "description": "一家賣餛飩湯的店"
+  },
+  "rct1.ll.surface.wood": {
+    "reference-name": "Wood",
+    "name": "Wood"
+  },
+  "rct2.edge.woodblack": {
+    "reference-name": "Wood (black)",
+    "name": "Wood (black)"
+  },
+  "rct2.edge.woodred": {
+    "reference-name": "Wood (red)",
+    "name": "Wood (red)"
+  },
+  "rct2.tt.primroor": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "有爬藤的木頭柵欄"
+  },
+  "rct2.tt.primroot": {
+    "reference-name": "Wood Fence with Climbing Vines",
+    "name": "有爬藤的木頭柵欄"
+  },
+  "rct2.tt.primwal2": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "有?樹藤的木頭柵欄"
+  },
+  "rct2.tt.primwal1": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "有?樹藤的木頭柵欄"
+  },
+  "rct2.tt.primwal3": {
+    "reference-name": "Wood Fence with Dead Vines",
+    "name": "有?樹藤的木頭柵欄"
+  },
+  "rct2.tt.primscrn": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primhead": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primst03": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primhear": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primst01": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primst02": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.tt.primtall": {
+    "reference-name": "Wood Fence with Man Eating Plant",
+    "name": "有食人植物的木頭柵欄"
+  },
+  "rct2.station.wooden": {
+    "reference-name": "Wooden",
+    "name": "Wooden"
+  },
+  "rct2.wdbase": {
+    "reference-name": "Wooden Block",
+    "name": "木塊"
+  },
+  "rct2.tt.wdncart2": {
+    "reference-name": "Wooden Cart",
+    "name": "木製推車"
+  },
+  "rct2.wfwg": {
+    "reference-name": "Wooden Fence",
+    "name": "木式柵欄"
+  },
+  "rct2.wmww": {
+    "reference-name": "Wooden Fence",
+    "name": "木式柵欄"
+  },
+  "rct2.wc17": {
+    "reference-name": "Wooden Fence",
+    "name": "木式柵欄"
+  },
+  "rct2.wpw3": {
+    "reference-name": "Wooden Fence",
+    "name": "木樁柵欄"
+  },
+  "rct2.wfw1": {
+    "reference-name": "Wooden Fence",
+    "name": "木式柵欄"
+  },
+  "rct1.wfw0": {
+    "reference-name": "Wooden Fence",
+    "name": "木式柵欄"
+  },
+  "rct2.wwtwa": {
+    "reference-name": "Wooden Fence Wall",
+    "name": "木式圍牆"
+  },
+  "rct2.tt.medipath": {
+    "reference-name": "Wooden FootPath",
+    "name": "木頭道路"
+  },
+  "rct2.wallwdps": {
+    "reference-name": "Wooden Post Fence",
+    "name": "木樁柵欄"
+  },
+  "rct2.wpw2": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木樁牆"
+  },
+  "rct2.wc18": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木樁牆"
+  },
+  "rct2.wpw1": {
+    "reference-name": "Wooden Post Wall",
+    "name": "木樁牆"
+  },
+  "rct2.ptct1": {
+    "reference-name": "Wooden Roller Coaster Trains",
+    "name": "木架雲霄飛車列車",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "木架雲霄飛車列車是裝填墊料座椅及膝部有安全護條裝置",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.ptct2": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater)",
+    "name": "木製式雲霄飛車列車(6 個座位)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+    "description": "木製式雲霄飛車是有安全裝置護具的列車",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.ptct2r": {
+    "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
+    "name": "木製式雲霄飛車列車(6 個座位)",
+    "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
+    "description": "木製式雲霄飛車是有安全裝置護具的列車是採向後運行方式",
+    "reference-capacity": "6 passengers per car",
+    "capacity": "6 位乘客/每個車廂"
+  },
+  "rct2.sfric1": {
+    "reference-name": "Wooden Side-Friction Cars",
+    "name": "木架的摩擦側邊列車",
+    "reference-description": "Basic cars for the Side-Friction Roller Coaster",
+    "description": "摩擦側邊的雲霄飛車的基本車輛",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 位乘客/每個車廂"
+  },
+  "rct2.bn5": {
+    "reference-name": "Wooden Sign",
+    "name": "森林招牌"
+  },
+  "rct2.wallwd16": {
+    "reference-name": "Wooden Wall",
+    "name": "木式牆"
+  },
+  "rct2.wallwd33": {
+    "reference-name": "Wooden Wall",
+    "name": "木式牆"
+  },
+  "rct2.wallwd8": {
+    "reference-name": "Wooden Wall",
+    "name": "木式牆"
+  },
+  "rct2.wallwd32": {
+    "reference-name": "Wooden Wall",
+    "name": "木式牆"
+  },
+  "rct2.tt.schncrsh": {
+    "reference-name": "Wrecked Seaplane",
+    "name": "失事的海上飛機"
+  },
+  "rct2.ww.taxicstr": {
+    "reference-name": "Yellow Taxi Trains",
+    "name": "Yellow Taxi Trains",
+    "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+    "reference-capacity": "4 passengers per car",
+    "capacity": "4 passengers per car"
+  },
+  "rct2.tt.yewtreex": {
+    "reference-name": "Yew Tree",
+    "name": "紫衫樹"
+  },
+  "rct2.ww.afrzebra": {
+    "reference-name": "Zebra",
+    "name": "Zebra"
+  },
+  "rct2.tt.zeusstat": {
+    "reference-name": "Zeus Statue",
+    "name": "宙斯雕像"
+  }
+}


### PR DESCRIPTION
This PR introduces object dumps for all supported languages to the Localisation repository. These dumps are intended to become the primary means for translators to translate the strings in OpenRCT2's official JSON objects.

Consider the following snippet from `nl-NL.json`:

```json
  "rct2.tt.1920racr": {
    "reference-name": "1920s Racing Cars",
    "name": "Jarentwintig-raceauto's",
    "reference-description": "1920s race car themed go-karts",
    "description": "Passagiers racen in go-karts die er uitzien als raceauto's uit de jaren '20.",
    "reference-capacity": "Single-seater",
    "capacity": "1 persoon per kart"
  },
```

The `rct2.tt.1920racr` object contains three strings: `name`, `description` and `capacity`. All three translations are printed in the dump file, as well as their equivalents from the `en-GB` locale. These *reference strings* are not imported back into the objects file.

To give another concrete example, here is what the same object looks like in `ja-JP.json`:
```json
  "rct2.tt.1920racr": {
    "reference-name": "1920s Racing Cars",
    "name": "1920年代のレースカー",
    "reference-description": "1920s race car themed go-karts",
    "description": "自分で操縦する、1920年代のレースカーです",
    "reference-capacity": "Single-seater",
    "capacity": "各車両1名"
  },
```

I am hopeful and confident that this will make object translation much easier for all translators. With these files in the Localisation repository, you will no longer need to do anything with the objects repository in order to submit translations!

For completeness, the object translation completion rates as of this PR are as follows:

Locale | Completion rate
------ | ---------------
 ar-EG | 4.85%
 ca-ES | 1.48%
 cs-CZ | 97.61%
 da-DK | 1.25%
 de-DE | 98.48%
 en-GB | 100.0%
 en-US | 3.03%
 eo-OO | 0.0%
 es-ES | 96.89%
 fi-FI | 0.99%
 fr-FR | 99.81%
 hu-HU | 2.28%
 it-IT | 96.81%
 ja-JP | 99.96%
 ko-KR | 98.45%
 nb-NO | 1.63%
 nl-NL | 98.33%
 pl-PL | 99.96%
 pt-BR | 99.96%
 ru-RU | 97.54%
 sv-SE | 96.32%
 tr-TR | 1.78%
 zh-CN | 60.52%
 zh-TW | 67.46%

Notification when new strings arrive:
@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @JasperGray @Wirlie @JoelTroch @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @renansimoes @tupaschoal @Nubbie @izhangfei @daihakken @marcinkunert