### PR TITLE
eo-OO: Some corrections and object TLs

### DIFF
--- a/data/language/eo-OO.txt
+++ b/data/language/eo-OO.txt
@@ -25,7 +25,7 @@ STR_0020    :Seĝlifto
 STR_0021    :Korktirila Onda Fervojo
 STR_0022    :Labirinto
 STR_0023    :Spirala Tobagano
-STR_0024    :Vetkurantaj Aŭtetoj
+STR_0024    :Gokartoj
 STR_0025    :Ŝtiprajdo
 STR_0026    :Rapidfluorajdo
 STR_0027    :Albatiĝantaj Aŭtetoj
@@ -117,7 +117,7 @@ STR_0530    :Ĉaroj pendas de ŝtala kablo, kiu etendiĝas de unu flanko de la a
 STR_0531    :Onda fervojo kompakta kun ŝtala trako, sur kie la trajno veturas tra korktiriloj kaj lopoj
 STR_0532    :Labirinto konstruita de 6-futaj altaj heĝoj aŭ muroj. La gastoj vagas en tiu labirinto, kaj eliras nur kiam ili trovas la elirejon
 STR_0533    :Ligna konstruaĵo kun interna ŝtuparo kaj ekstera spirala tobogano, kiun oni uzas kun toboganomatoj
-STR_0534    :Gastoj vetkuras unu la alian en vetkurantaj aŭtetoj sur asfalta trako
+STR_0534    :Gastoj vetkuras unu la alian en gokartoj sur asfalta trako
 STR_0535    :Boatoj veturas laŭ akvokanalo, kaj plaŭde malsupreniras krutajn deklivojn por trempi la rajdantojn
 STR_0536    :Rondaj boatoj vagas laŭ larĝa akvokanalo, plaŭdas tra akvofaloj, kaj ekscitas rajdantojn per ŝaŭmantaj rapidfluoj
 STR_0537    :Gastoj albatiĝas al unu la alian per elektraj albatiĝantaj aŭtetoj, kiujn ili stiras
@@ -138,7 +138,7 @@ STR_0554    :Linearaj induktaj motoroj plirapidigas la ĉaron el la stacio laŭ 
 STR_0555    :Gastoj rajdas en lifto supren aŭ malsupren, por iri de unu nivelo al alia
 STR_0556    :Pliaj larĝaj veturiloj malsupreniras ekzaktajn vertikalajn trakojn por la pleja sperto de libera-fala onda fervojo
 STR_0557    :Monaŭtomato por gastoj, kiuj ne havas sufiĉe da mono
-STR_0558    :Rajdantoj rajdas en duopaj da seĝoj, kiuj turniĝas ĉirkaŭ la finoj de tri longaj turniĝantaj brakoj
+STR_0558    :Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ la finoj de tri longaj turniĝantaj brakoj
 STR_0559    :Granda konstruaĵo, kiu enhavas timigajn koridorojn kaj timigajn ĉambrojn
 STR_0560    :Ejo por malsanaj gastoj, por ke ili bonsanas pli rapide
 STR_0561    :Cirkospektaklo de bestoj en granda cirkotendo
@@ -162,7 +162,7 @@ STR_0581    :Ringo da seĝoj, milde turniĝante, estas tirata al la supro de alt
 STR_0582    :Gastoj rajdas en kusenveturiloj, kiujn ili stiras libere
 STR_0583    :Konstruaĵo, kiu enhavas ĉambrojn torditajn kaj koridorojn angulajn por malorienti homojn tie
 STR_0584    :Specialaj bicikloj, kiujn la rajdantoj stiras per pedalado, veturas sur ŝtala monorelotrako
-STR_0585    :Rajdantoj, kiuj sidas en duopoj da seĝoj penditaj sub la trako, lopas kaj tordiĝas tra malgrandspacaj inversigoj
+STR_0585    :Rajdantoj, kiuj sidas en paroj da seĝoj penditaj sub la trako, lopas kaj tordiĝas tra krutaj inversigoj
 STR_0586    :Boatoformaj ĉaroj rapidas sur onda fervoja trako por ebligi kurboplenajn kurbiĝojn kaj krutajn malleviĝojn, foje plaŭdas en akvo dum mildaj riveropartoj
 STR_0587    :Post vigliga lanĉo povigita de aero, la trajno rapide supreniras vertikalan trakon, iras super la supro, kaj malsupreniras vertikale sur la alia flanko por reveni al la stacio
 STR_0588    :Unuopaj ĉaroj rapidas sub zigzaga trako kun harpingloformaj kurbiĝoj kaj subitaj malleviĝoj
@@ -3715,7 +3715,7 @@ STR_DTLS    :Konvertu grandan forlasitan minon, de vidindaĵo al amuzparko
 <Karts & Coasters>
 STR_SCNR    :Aŭtetoj k Ondaj Fervojoj
 STR_PARK    :Aŭtetoj k Ondaj Fervojoj
-STR_DTLS    :Granda parko kaŝita en la arbaro, kiu enhavas nur trakojn de vetkurantaj aŭtetoj kaj lignajn ondajn fervojojn
+STR_DTLS    :Granda parko kaŝita en la arbaro, kiu enhavas nur trakojn de gokartoj kaj lignajn ondajn fervojojn
 
 <Mel's World>
 STR_SCNR    :Melmondo
@@ -3781,7 +3781,7 @@ STR_DTLS    :La ĉefa atrakcio de ĉi tiu granda disvolvanta parko estas giganta
 <Canary Mines>
 STR_SCNR    :Kanario-Minoj
 STR_PARK    :Kanario-Minoj
-STR_DTLS    :Ĉi tiu forlasita mino jam havas la potencialon de vidindaĵo, kun sia miniatura fervojo kaj duopo de ondaj fervojoj kun vertikalaj malleviĝoj
+STR_DTLS    :Ĉi tiu forlasita mino jam havas la potencialon de vidindaĵo, kun sia miniatura fervojo kaj paro da ondaj fervojoj kun vertikalaj malleviĝoj
 
 <Barony Bridge>
 STR_SCNR    :Baronlando-Ponto
@@ -3866,7 +3866,7 @@ STR_DTLS    :Disvolvu ĉi tiu parkon kun romana temo, per aldoni atrakciojn kaj 
 <Swamp Cove>
 STR_SCNR    :Marĉejo-Golfeto
 STR_PARK    :Marĉejo-Golfeto
-STR_DTLS    :Konstruita parte sur serio de malgrandaj insuloj, ĉi tiu parko jam havas duopon de grandaj ondaj fervojoj por siaj ĉefaj atrakcioj
+STR_DTLS    :Konstruita parte sur serio de malgrandaj insuloj, ĉi tiu parko jam havas paron da grandaj ondaj fervojoj por siaj ĉefaj atrakcioj
 
 <Adrenaline Heights>
 STR_SCNR    :Adrenalino-Altaĵoj
@@ -3963,7 +3963,7 @@ STR_DTLS    :Apudmara golfeto estas la okazejo por ĉi tiu defio de la konstruad
 <Good Knight Park>
 STR_SCNR    :Bona-Kavaliro-Parko
 STR_PARK    :Bona-Kavaliro-Parko
-STR_DTLS    :Vi devas disvolvi kastelon, kun duopo de ondaj fervojoj, al pli granda amuzparko
+STR_DTLS    :Vi devas disvolvi kastelon, kun paro da ondaj fervojoj, al pli granda amuzparko
 
 <Wacky Warren>
 STR_SCNR    :Komika Kuniklejo

--- a/objects/eo-OO.json
+++ b/objects/eo-OO.json
@@ -163,7 +163,7 @@
     "reference-name": "Airship Themed Monorail Trains",
     "name": "Monorelaj Trajnoj kun Aeroŝipo-Temo",
     "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
-    "description": "Grandaj dekoraciitaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
+    "description": "Grandaj temitaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
     "reference-capacity": "8 passengers per car",
     "capacity": "Po 8 pasaĝeroj por aŭto"
   },
@@ -495,11 +495,11 @@
   },
   "rct2.tt.artdec29": {
     "reference-name": "Art Deco Inverted Corner Section",
-    "name": "Artdekora Renversita Anguloparto"
+    "name": "Artdekora Inversigita Anguloparto"
   },
   "rct2.tt.artdec02": {
     "reference-name": "Art Deco Inverted Corner Section",
-    "name": "Artdekora Renversita Anguloparto"
+    "name": "Artdekora Inversigita Anguloparto"
   },
   "rct2.tt.artdec28": {
     "reference-name": "Art Deco Roof Section",
@@ -641,7 +641,7 @@
     "reference-name": "Automobile Cars",
     "name": "Aŭto-Ĉaroj",
     "reference-description": "Roller coaster cars in the shape of automobiles",
-    "description": "Ĉaroj de onda fervojo, kiuj havas la formon de aŭtoj",
+    "description": "Ĉaroj de onda fervojo formitaj kiel aŭtoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -657,7 +657,7 @@
     "reference-name": "B-Movie Giant Spider Ride",
     "name": "Atrakcio de B-Filmo Giganta Araneo",
     "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
-    "description": "Rajdantoj rajdas en dekoraciigitaj seĝoj, kiuj turniĝas ĉirkaŭ giganta B-Filmo araneo",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ giganta B-Filmo araneo",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -709,7 +709,7 @@
   },
   "rct2.ww.bamborf3": {
     "reference-name": "Bamboo Roof Inverted Corner",
-    "name": "Renversita Angulo de Bambua Tegmento"
+    "name": "Inversigita Angulo de Bambua Tegmento"
   },
   "official.pandagr": {
     "reference-name": "Bamboo Shoots",
@@ -787,7 +787,7 @@
     "reference-name": "Barnstorming Trains",
     "name": "Trajnoj de Barnstorming",
     "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
-    "description": "Renversitaj trajnoj de onda fervojo por la Onda Fervojo kun Renversita Puŝo formitaj kiel duoble-ferdekaj aeroplanoj",
+    "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo formitaj kiel duobla-ferdekaj aeroplanoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -827,7 +827,7 @@
     "reference-name": "Battering Ram Trains",
     "name": "Ramilego-Trajnoj",
     "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
-    "description": "Kompakta trajnoj de onda fervojo, dekoraciigita por aspekti kiel ramilegoj de la Malluma Epoko",
+    "description": "Kompaktaj trajnoj de onda fervojo, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
     "reference-capacity": "6 passengers per car",
     "capacity": "Po 6 pasaĝeroj por aŭto"
   },
@@ -857,7 +857,7 @@
     "reference-name": "Bengal Tiger Cars",
     "name": "Bengala Tigro-Ĉaroj",
     "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
-    "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, dekoraciigita por aspekti kiel Bengalaj Tigroj",
+    "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, temitaj por aspekti kiel Bengalaj Tigroj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -889,7 +889,7 @@
     "reference-name": "Black Cabs",
     "name": "Nigraj Taksioj",
     "reference-description": "Powered vehicles in the shape of London Taxis",
-    "description": "Ŝaltitaj veturiloj, kiuj havas la formon de Taksioj de Londono",
+    "description": "Ŝaltitaj veturiloj formitaj kiel Taksioj de Londono",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -929,7 +929,7 @@
     "reference-name": "Blob from Outer Space",
     "name": "Aĵo de Kosmospaco",
     "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
-    "description": "Dekoraciigita turniĝanta kajuto formita kiel iu aĵo de sciencofiksia B-filmo",
+    "description": "Temita turniĝanta kajuto formita kiel iu aĵo de sciencofiksia B-filmo",
     "reference-capacity": "20 passengers",
     "capacity": "20 pasaĝeroj"
   },
@@ -1093,7 +1093,7 @@
     "reference-name": "Bullet Trains",
     "name": "Ŝinkansenoj",
     "reference-description": "Japanese Bullet Train themed roller coaster cars",
-    "description": "Ĉaroj de onda fervojo, dekoraciigita per temo de Japana Ŝinkanseno",
+    "description": "Ĉaroj de onda fervojo kun temo de Japana Ŝinkanseno",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -1317,7 +1317,7 @@
     "reference-name": "Carnival Butterfly Cars",
     "name": "Karnavalaj Papilio-Ĉaroj",
     "reference-description": "Cars in the shape of butterfly carnival floats",
-    "description": "Ĉaroj, kiuj havas la formon de papilio-paradiloj",
+    "description": "Ĉaroj formitaj kiel papilio-paradiloj",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -1325,7 +1325,7 @@
     "reference-name": "Carnival Frog Cars",
     "name": "Karnavalaj Rano-Ĉaroj",
     "reference-description": "Cars in the shape of frog carnival floats",
-    "description": "Ĉaroj, kiuj havas la formon de rano-paradiloj",
+    "description": "Ĉaroj formitaj kiel rano-paradiloj",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -1333,7 +1333,7 @@
     "reference-name": "Carnival Lizard Cars",
     "name": "Karnavalaj Lacerto-Ĉaroj",
     "reference-description": "Cars in the shape of lizard carnival floats",
-    "description": "Ĉaroj, kiuj havas la formon de lacerto-paradiloj",
+    "description": "Ĉaroj formitaj kiel lacerto-paradiloj",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -1369,7 +1369,7 @@
   },
   "rct2.tt.mcastl01": {
     "reference-name": "Castle Inverted Corner",
-    "name": "Renversita Angulo de Kastelo"
+    "name": "Inversigita Angulo de Kastelo"
   },
   "rct2.tt.mcastl11": {
     "reference-name": "Castle Portcullis",
@@ -1393,7 +1393,7 @@
   },
   "rct2.tt.mcastl08": {
     "reference-name": "Castle Ramparts Inverted Corner",
-    "name": "Renversita Angulo de Murego de Kastelo"
+    "name": "Inversigita Angulo de Murego de Kastelo"
   },
   "rct2.tct1": {
     "reference-name": "Castle Tower",
@@ -1663,9 +1663,9 @@
   },
   "rct2.ww.coffeecu": {
     "reference-name": "Coffee Cup Ride",
-    "name": "Kafotaso Atrakcio",
+    "name": "Kafotaso-Atrakcio",
     "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
-    "description": "Rajdantoj rajdas en duopaj da seĝoj, kiuj turniĝas ĉirkaŭ granda animita kafmuelilo",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda animita kafmuelilo",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -1713,9 +1713,9 @@
   },
   "rct2.slct": {
     "reference-name": "Compact Inverted Coaster Trains",
-    "name": "Trajnoj de Kompakta Renversita Onda Fervojo",
+    "name": "Trajnoj de Kompakta Inversigita Onda Fervojo",
     "reference-description": "Riders sit in pairs of seats suspended beneath the track",
-    "description": "Rajdantoj sidas en duopoj da seĝoj penditaj sub la trako",
+    "description": "Rajdantoj sidas en paroj da seĝoj penditaj sub la trako",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -1731,7 +1731,7 @@
     "reference-name": "Conger Eel Trains",
     "name": "Kongro-Trajnoj",
     "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
-    "description": "Trajnoj kun ŝultrobridoj, kiu havas la formon de kongroj",
+    "description": "Trajnoj kun ŝultrobridoj formitaj kiel kongroj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -2083,11 +2083,11 @@
   },
   "rct2.tt.psntwl15": {
     "reference-name": "Dark Age Village Inverted Roof Piece",
-    "name": "Renversita Tegmento de Vilaĝo de Malluma Epoko"
+    "name": "Inversigita Tegmento de Vilaĝo de Malluma Epoko"
   },
   "rct2.tt.psntwl28": {
     "reference-name": "Dark Age Village Inverted Roof Piece",
-    "name": "Renversita Tegmento de Vilaĝo de Malluma Epoko"
+    "name": "Inversigita Tegmento de Vilaĝo de Malluma Epoko"
   },
   "rct2.tt.psntwl08": {
     "reference-name": "Dark Age Village Lower Corner Piece",
@@ -2217,7 +2217,7 @@
     "reference-name": "Diamond Ride",
     "name": "Diamanto-Atrakcio",
     "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
-    "description": "Rajdantoj rajdas duope en dekoraciigitaj seĝoj, kiuj turniĝas ĉirkaŭ granda diamanto",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda diamanto",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -2265,7 +2265,7 @@
     "reference-name": "Dinosaur Egg Ride",
     "name": "Dinosaŭra-Ovo-Atrakcio",
     "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
-    "description": "Rajdantoj rajdas duope en dekoraciigitaj seĝoj, kiuj turniĝas ĉirkaŭ animita patrino-dinosaŭro",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ animita patrino-dinosaŭro",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -2519,7 +2519,7 @@
   },
   "rct2.tt.elecfen5": {
     "reference-name": "Electric Fence Inverted Corner Piece",
-    "name": "Renversita Angulo de Elektra Barilo"
+    "name": "Inversigita Angulo de Elektra Barilo"
   },
   "rct2.tt.elecfen3": {
     "reference-name": "Electric Fence with Light",
@@ -2567,17 +2567,17 @@
   },
   "rct2.ww.faberge": {
     "reference-name": "Fabergé Egg Ride",
-    "name": "Fabergé Egg Ride",
+    "name": "Atrakcio de Ovo de Fabergé",
     "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
-    "description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda replikaĵo de ovo de Fabergé",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
   "rct2.slcfo": {
     "reference-name": "Face-off Cars",
-    "name": "Face-off Cars",
+    "name": "Alfrontantaj Aŭtoj",
     "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
-    "description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
+    "description": "Rapidirante tra krutaj inversigoj, rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -2631,9 +2631,9 @@
   },
   "rct2.ww.fightkit": {
     "reference-name": "Fighting Kite Ride",
-    "name": "Fighting Kite Ride",
+    "name": "Atrakcio de Batalantaj Flugludiloj",
     "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ la finoj de tri longaj turniĝantaj brakoj",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -2805,7 +2805,7 @@
     "reference-name": "Fruity Ices Stall",
     "name": "Frukto-Glaciaĵbudo",
     "reference-description": "A themed stall selling fruity ice creams",
-    "description": "Dekoraciigita budo vendanta frukto-glaciaĵojn"
+    "description": "Temita budo vendanta frukto-glaciaĵojn"
   },
   "rct2.tt.funhouse": {
     "reference-name": "Fun House",
@@ -3293,7 +3293,7 @@
     "reference-name": "Great White Shark Trains",
     "name": "Trajnoj de Granda Blanka Ŝarko",
     "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
-    "description": "Trajnoj kun ŝultrobridoj, kiuj havas la formon de granda blanka ŝarko",
+    "description": "Trajnoj kun ŝultrobridoj formitaj kiel granda blanka ŝarko",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -3407,7 +3407,7 @@
     "reference-name": "Haunted House",
     "name": "Fantomita Domo",
     "reference-description": "Large themed building containing scary corridors and spooky rooms",
-    "description": "Granda dekoraciigita konstruaĵo, kiu enhavas timigajn koridorojn, kaj timigetajn ĉambrojn",
+    "description": "Granda temita konstruaĵo, kiu enhavas timigajn koridorojn, kaj timigetajn ĉambrojn",
     "reference-capacity": "15 guests",
     "capacity": "15 gastoj"
   },
@@ -4099,9 +4099,9 @@
   },
   "rct2.ww.italypor": {
     "reference-name": "Italian Police Ride",
-    "name": "Italian Police Ride",
+    "name": "Itala Polico-Atrakcio",
     "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
-    "description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
+    "description": "Rajdantoj rajdas pare en replikaĵoj de italaj policaj aŭtoj, kaj turniĝas cirkle",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -4109,7 +4109,7 @@
     "reference-name": "Jaguar Cars",
     "name": "Jaguaro-Aŭtoj",
     "reference-description": "Roller coaster cars themed to look like jaguars",
-    "description": "Ĉaroj de onda fervojo dekoraciigita por aspekti kiel jaguaroj",
+    "description": "Ĉaroj de onda fervojo temitaj por aspekti kiel jaguaroj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -4233,7 +4233,7 @@
     "reference-name": "Jet Plane Cars",
     "name": "Aeroplano-Ĉaroj",
     "reference-description": "Roller coaster cars in the shape of jet planes",
-    "description": "Ĉaroj de onda fervojo, kiuj havas la formon de aeroplanoj",
+    "description": "Ĉaroj de onda fervojo formitaj kiel aeroplanoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -4901,7 +4901,7 @@
     "reference-name": "Manta Ray Boats",
     "name": "Mantarajo-Boatoj",
     "reference-description": "Coaster boats in the shape of a manta ray",
-    "description": "Boatoj de onda fervojo, kiu havas la formon de mantarajo",
+    "description": "Boatoj de onda fervojo formitaj kiel mantarajo",
     "reference-capacity": "6 passengers per boat",
     "capacity": "Po 6 pasaĝeroj por boato"
   },
@@ -5093,7 +5093,7 @@
     "reference-name": "Mine Cars",
     "name": "Minĉaroj",
     "reference-description": "Individual cars shaped like wooden mine trucks",
-    "description": "Individuaj ĉaroj, kiu havas la formon de lignaj minkamionoj",
+    "description": "Individuaj ĉaroj formitaj kiel lignaj minkamionoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -5513,9 +5513,9 @@
   },
   "rct2.tt.neptunex": {
     "reference-name": "Neptune Ride",
-    "name": "Neptune Ride",
+    "name": "Neptuno-Atrackio",
     "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
-    "description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
+    "description": "Rajdantoj rajdas pare, en temitaj seĝoj, kiuj turniĝas ĉirkaŭ animita statuo de Neptuno",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -5921,7 +5921,7 @@
     "reference-name": "Pegasus Cars",
     "name": "Pegaso-Ĉaroj",
     "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
-    "description": "Ŝaltitaj veturiloj, kiuj havas la formon de Pegaso tiranta ĉaron",
+    "description": "Ŝaltitaj veturiloj formitaj kiel Pegaso tiranta ĉaron",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -6009,7 +6009,7 @@
     "reference-name": "Pickup Trucks",
     "name": "Kamionetoj",
     "reference-description": "Powered vehicles in the shape of pickup trucks",
-    "description": "Ŝaltitaj veturiloj, kiuj havas la formon de kamionetoj",
+    "description": "Ŝaltitaj veturiloj formitaj kiel kamionetoj",
     "reference-capacity": "1 passenger per truck",
     "capacity": "Por 1 pasaĝero por kamiono"
   },
@@ -6143,7 +6143,7 @@
     "reference-name": "Polar Bear Trains",
     "name": "Blanka Urso-Trajnoj",
     "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
-    "description": "Penditaj trajnoj kun formo de blankaj ursoj, en kiuj rajdantoj sidas duope kaj frontas aŭ antaŭe aŭ malantaŭe",
+    "description": "Penditaj trajnoj kun formo de blankaj ursoj, en kiuj rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -7561,9 +7561,9 @@
   },
   "rct2.twist2": {
     "reference-name": "Snow Cups",
-    "name": "Snow Cups",
+    "name": "Neĝo-Tasoj",
     "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
-    "description": "Riders ride in pairs of seats rotating around a central snowman",
+    "description": "Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ centra neĝhomo",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -8505,9 +8505,9 @@
   },
   "rct2.tt.tommygun": {
     "reference-name": "Tommy Gun Ride",
-    "name": "Tommy Gun Ride",
+    "name": "Tommy-Pafilo-Atrakcio",
     "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
-    "description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
+    "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda replikaĵo de Tommy-Pafilo",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -8821,9 +8821,9 @@
   },
   "rct2.twist1": {
     "reference-name": "Twist",
-    "name": "Twist",
+    "name": "Tvisto",
     "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-    "description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
+    "description": "Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ la finoj de tri longaj turniĝantaj brakoj",
     "reference-capacity": "18 passengers",
     "capacity": "18 pasaĝeroj"
   },
@@ -9559,7 +9559,7 @@
     "reference-name": "Yellow Taxi Trains",
     "name": "Flavaj Taksio-Trajnoj",
     "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
-    "description": "Trajnoj por la Altega Onda Fervojo, kiuj estis dekoraciitaj por aspekti kiel longaj flavaj taksioj",
+    "description": "Trajnoj por la Altega Onda Fervojo, kiuj estis temitaj por aspekti kiel longaj flavaj taksioj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },


### PR DESCRIPTION
- Use the term gokart directly instead of vetkurantaj aŭtetoj (racing minicars)
- Duobla-ferdeka (double-decker) instead of duoble-ferdeka (doubly decked)
- Some objects have inversigitaj (inverted) elements, not renversitaj (overturned) ones
- Pair can be translated more precisely as paro, not duopo (ordered pair)
- Translated some similar object descriptions having to do with riders sitting in pairs of seats,
  to give them consistent translations

