### PR TITLE
eo-OO: Translate objs starting with R + fixups

### DIFF
--- a/objects/eo-OO.json
+++ b/objects/eo-OO.json
@@ -39,7 +39,7 @@
     "reference-name": "1950s Rockets",
     "name": "Raketoj de la 1950-aj",
     "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-    "description": "Penditaj raketoformaj trajnoj de onda fervojo, kiu enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkau anguloj",
+    "description": "Penditaj raketoformaj trajnoj de onda fervojo, kiu enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -589,7 +589,7 @@
     "reference-name": "Articulated Roller Coaster Trains",
     "name": "Artika Trajnoj de Onda Fervojo",
     "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-    "description": "Trajnoj de Onda Fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj malfermitajn frontajn",
+    "description": "Trajnoj de Onda Fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj subĉielajn frontojn",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -787,7 +787,7 @@
     "reference-name": "Barnstorming Trains",
     "name": "Trajnoj de Barnstorming",
     "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
-    "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo formitaj kiel duobla-ferdekaj aeroplanoj",
+    "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo formitaj kiel duetaĝaj aeroplanoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -827,7 +827,7 @@
     "reference-name": "Battering Ram Trains",
     "name": "Ramilego-Trajnoj",
     "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
-    "description": "Kompaktaj trajnoj de onda fervojo, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
+    "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
     "reference-capacity": "6 passengers per car",
     "capacity": "Po 6 pasaĝeroj por aŭto"
   },
@@ -1543,7 +1543,7 @@
     "reference-name": "Chairlift Cars",
     "name": "Ĉaroj de Seĝlifto",
     "reference-description": "Open cars for chairlift",
-    "description": "Malfermitaj ĉaroj por seĝlifto",
+    "description": "Subĉielaj ĉaroj por seĝlifto",
     "reference-capacity": "2 passengers per car",
     "capacity": "Po 2 pasaĝeroj por aŭto"
   },
@@ -2319,17 +2319,17 @@
   },
   "rct2.tt.mgr2": {
     "reference-name": "Double Deck Carousel",
-    "name": "Duobla-Ferdeka Karuselo",
+    "name": "Duetaĝa Karuselo",
     "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
-    "description": "Tradicia enfermita duobla-ferdeka karuselo kun skulptitaj lignaj ĉevaloj",
+    "description": "Tradicia nesubĉiela duetaĝa karuselo kun skulptitaj lignaj ĉevaloj",
     "reference-capacity": "32 passengers",
     "capacity": "32 pasaĝeroj"
   },
   "rct2.obs2": {
     "reference-name": "Double-deck Cabin",
-    "name": "Duobla-Ferdeka Kajuto",
+    "name": "Duetaĝa Kajuto",
     "reference-description": "Twin-deck rotating observation cabin",
-    "description": "Duobla-ferdeka turniĝanta kajuto por observi",
+    "description": "Duetaĝa turniĝanta kajuto por observi",
     "reference-capacity": "32 passengers",
     "capacity": "32 pasaĝeroj"
   },
@@ -2621,7 +2621,7 @@
     "reference-name": "Ferris Wheel",
     "name": "Spektoradego",
     "reference-description": "Rotating big wheel with open chairs",
-    "description": "Turniĝanta granda rado kun malfermitaj seĝoj",
+    "description": "Turniĝanta granda rado kun subĉielaj seĝoj",
     "reference-capacity": "32 passengers",
     "capacity": "32 pasaĝeroj"
   },
@@ -2809,7 +2809,7 @@
   },
   "rct2.tt.funhouse": {
     "reference-name": "Fun House",
-    "name": "Fun House",
+    "name": "Konstruaĵo de Amuzo",
     "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
     "description": "Konstruaĵo, kiu enhavas movantajn murojn kaj plankojn por malorienti homojn irante tie",
     "reference-capacity": "5 guests",
@@ -5345,7 +5345,7 @@
   },
   "rct2.wmouse": {
     "reference-name": "Mouse Cars",
-    "name": "Mouse Cars",
+    "name": "Musoĉaroj",
     "reference-description": "Individual cars shaped like a mouse",
     "description": "Individualaj ĉaroj formitaj kiel muso",
     "reference-capacity": "2 passengers per car",
@@ -6349,33 +6349,33 @@
   },
   "rct2.rcr": {
     "reference-name": "Racing Cars",
-    "name": "Racing Cars",
+    "name": "Vetkurantaj Aŭtoj",
     "reference-description": "Powered vehicles in the shape of racing cars",
-    "description": "Powered vehicles in the shape of racing cars",
+    "description": "Ŝaltitaj veturiloj formitaj kiel vetkurantaj aŭtoj",
     "reference-capacity": "1 passenger per car",
     "capacity": "Po 1 pasaĝero por aŭto"
   },
   "rct2.tt.raptorxx": {
     "reference-name": "Racing Raptors",
-    "name": "Racing Raptors",
+    "name": "Vetkurantaj Raptoroj",
     "reference-description": "Separate raptor-shaped vehicles",
-    "description": "Separate raptor-shaped vehicles",
+    "description": "Individuaj raptorformaj veturiloj",
     "reference-capacity": "2 riders per vehicle",
     "capacity": "Po 2 rajdantoj por veturilo"
   },
   "rct2.tt.schntnny": {
     "reference-name": "Racing Tannoy",
-    "name": "Racing Tannoy"
+    "name": "Vetkuranta Laŭtparolilo"
   },
   "rct2.ww.radar": {
     "reference-name": "Radar Dish",
-    "name": "Radar Dish"
+    "name": "Radara Anteno"
   },
   "rct2.rftboat": {
     "reference-name": "Rafts",
-    "name": "Rafts",
+    "name": "Flosoj",
     "reference-description": "Raft-shaped boats built for flat river tracks",
-    "description": "Raft-shaped boats built for flat river tracks",
+    "description": "Flosoformaj boatoj konstruitaj por plataj rivertrakoj",
     "reference-capacity": "4 passengers per raft",
     "capacity": "Po 4 pasaĝeroj por floso"
   },
@@ -6385,203 +6385,203 @@
   },
   "rct2.wsw2": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wsw1": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wswg": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wsw": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wallmm16": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wallsc16": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.wallmm17": {
     "reference-name": "Railings",
-    "name": "Railings"
+    "name": "Balkono"
   },
   "rct2.tt.ranbpath": {
     "reference-name": "Rainbow FootPath",
-    "name": "Rainbow FootPath"
+    "name": "Ĉiellarka Trotuaro"
   },
   "rct2.ww.rbrick02": {
     "reference-name": "Red Brick Corner Roof Piece",
-    "name": "Red Brick Corner Roof Piece"
+    "name": "Anguloparto de Ruĝa Brika Tegmento"
   },
   "rct2.ww.rbrick04": {
     "reference-name": "Red Brick Flat Roof Corner",
-    "name": "Red Brick Flat Roof Corner"
+    "name": "Angulo de Ruĝa Brika Plata Tegmento"
   },
   "rct2.ww.rbrick03": {
     "reference-name": "Red Brick Flat Roof Edge Piece",
-    "name": "Red Brick Flat Roof Edge Piece"
+    "name": "Bordoparto de Ruĝa Brika Plata Tegmento"
   },
   "rct2.ww.rbrick01": {
     "reference-name": "Red Brick Inverted Roof Piece",
-    "name": "Red Brick Inverted Roof Piece"
+    "name": "Inverisigita Ruĝa Brika Tegmentoparto"
   },
   "rct2.ww.rbrick08": {
     "reference-name": "Red Brick Roof Piece 1",
-    "name": "Red Brick Roof Piece 1"
+    "name": "Ruĝa Brika Tegmentoparto 1"
   },
   "rct2.ww.rbrick05": {
     "reference-name": "Red Brick Roof Piece 2",
-    "name": "Red Brick Roof Piece 2"
+    "name": "Ruĝa Brika Tegmentoparto 2"
   },
   "rct2.ww.rbrick07": {
     "reference-name": "Red Brick Roof Piece 3",
-    "name": "Red Brick Roof Piece 3"
+    "name": "Ruĝa Brika Tegmentoparto 3"
   },
   "rct2.ww.wbrick01": {
     "reference-name": "Red Brick Wall Piece 1",
-    "name": "Red Brick Wall Piece 1"
+    "name": "Ruĝa Brika Muroparto 1"
   },
   "rct2.ww.wbrick11": {
     "reference-name": "Red Brick Wall Piece 11",
-    "name": "Red Brick Wall Piece 11"
+    "name": "Ruĝa Brika Muroparto 11"
   },
   "rct2.ww.wbrick12": {
     "reference-name": "Red Brick Wall Piece 12",
-    "name": "Red Brick Wall Piece 12"
+    "name": "Ruĝa Brika Muroparto 12"
   },
   "rct2.ww.wbrick13": {
     "reference-name": "Red Brick Wall Piece 13",
-    "name": "Red Brick Wall Piece 13"
+    "name": "Ruĝa Brika Muroparto 13"
   },
   "rct2.ww.wbrick02": {
     "reference-name": "Red Brick Wall Piece 2",
-    "name": "Red Brick Wall Piece 2"
+    "name": "Ruĝa Brika Muroparto 2"
   },
   "rct2.ww.wbrick03": {
     "reference-name": "Red Brick Wall Piece 3",
-    "name": "Red Brick Wall Piece 3"
+    "name": "Ruĝa Brika Muroparto 3"
   },
   "rct2.ww.wbrick04": {
     "reference-name": "Red Brick Wall Piece 4",
-    "name": "Red Brick Wall Piece 4"
+    "name": "Ruĝa Brika Muroparto 4"
   },
   "rct2.ww.wbrick05": {
     "reference-name": "Red Brick Wall Piece 5",
-    "name": "Red Brick Wall Piece 5"
+    "name": "Ruĝa Brika Muroparto 5"
   },
   "rct2.ww.wbrick08": {
     "reference-name": "Red Brick Wall Piece 8",
-    "name": "Red Brick Wall Piece 8"
+    "name": "Ruĝa Brika Muroparto 8"
   },
   "rct2.trf2": {
     "reference-name": "Red Fir Tree",
-    "name": "Red Fir Tree"
+    "name": "Ruĝa Abioarbo"
   },
   "rct2.trf": {
     "reference-name": "Red Fir Tree",
-    "name": "Red Fir Tree"
+    "name": "Ruĝa Abioarbo"
   },
   "rct2.tt.rdmeto01": {
     "reference-name": "Red Meteor Crater Corner",
-    "name": "Red Meteor Crater Corner"
+    "name": "Angulo de Ruĝa Bolido-Kratero"
   },
   "rct2.tt.rdmeto02": {
     "reference-name": "Red Meteor Crater Corner",
-    "name": "Red Meteor Crater Corner"
+    "name": "Angulo de Ruĝa Bolido-Kratero"
   },
   "rct2.tt.rdmeto04": {
     "reference-name": "Red Meteor Crater Inverted Corner",
-    "name": "Red Meteor Crater Inverted Corner"
+    "name": "Inversigita Angulo de Ruĝa Bolido-Kratero"
   },
   "rct2.tt.rdmeto03": {
     "reference-name": "Red Meteor Crater Wall",
-    "name": "Red Meteor Crater Wall"
+    "name": "Muro de Ruĝa Bolido-Kratero"
   },
   "rct1.ll.pathtilr": {
     "reference-name": "Red and Brown Tiled Footpath",
-    "name": "Red and Brown Tiled Footpath"
+    "name": "Ruĝa kaj Bruna Kahelita Trotuaro"
   },
   "rct2.ww.redwood": {
     "reference-name": "Redwood Tree",
-    "name": "Redwood Tree"
+    "name": "Arbo de Sequoioideae"
   },
   "rct2.mono3": {
     "reference-name": "Retro-style Monorail Trains",
-    "name": "Retro-style Monorail Trains",
+    "name": "Retrostilaj Monorelaj Trajnoj",
     "reference-description": "Monorail trains with open cabins",
-    "description": "Monorail trains with open cabins",
+    "description": "Monorelaj trajnoj kun subĉielaj kajutoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
   "rct2.revf1": {
     "reference-name": "Reverse Freefall Car",
-    "name": "Reverse Freefall Car",
+    "name": "Ĉaro de Onda Fervojo kun Dorsantaŭa Libera Falo",
     "reference-description": "Large coaster car for the Reverse Freefall Coaster",
-    "description": "Large coaster car for the Reverse Freefall Coaster",
+    "description": "Granda ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
     "reference-capacity": "8 passengers",
     "capacity": "8 pasaĝeroj"
   },
   "rct2.revcar": {
     "reference-name": "Reverser Cars",
-    "name": "Reverser Cars",
+    "name": "Inversigantaj Ĉaroj",
     "reference-description": "Bogied cars capable of turning around on special reversing sections",
-    "description": "Bogied cars capable of turning around on special reversing sections",
+    "description": "Boĝiĉaroj kapablas je turniĝi ĉirkaŭ specialaj inversigantaj partoj",
     "reference-capacity": "6 passengers per car",
     "capacity": "Po 6 pasaĝeroj por aŭto"
   },
   "rct2.ww.afrrhino": {
     "reference-name": "Rhino",
-    "name": "Rhino"
+    "name": "Rinocero"
   },
   "rct2.ww.rhinorid": {
     "reference-name": "Rhino Trains",
-    "name": "Rhino Trains",
+    "name": "Rinocero-Trajnoj",
     "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
-    "description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
+    "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj, temitaj por aspekti kiel rinoceroj",
     "reference-capacity": "6 passengers per car",
     "capacity": "Po 6 pasaĝeroj por aŭto"
   },
   "rct2.wallpr32": {
     "reference-name": "Rigging",
-    "name": "Rigging"
+    "name": "Rigo"
   },
   "rct2.rapboat": {
     "reference-name": "River Rapids Boats",
-    "name": "River Rapids Boats",
+    "name": "Boatoj de Rapidfluorajdo",
     "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
-    "description": "Circular boats that turn and splash around as they meander along the river rapids",
+    "description": "Rondaj boatoj, kiuj turniĝas kaj plaŭdas vagante laŭ la rapidfluoj",
     "reference-capacity": "8 passengers per boat",
     "capacity": "Po 8 pasaĝeroj por boato"
   },
   "rct2.tt.rivrstyx": {
     "reference-name": "River Styx boats",
-    "name": "River Styx boats",
+    "name": "Boatoj de Stikso",
     "reference-description": "Boats with an Underworld theme, built for flat river tracks",
-    "description": "Boats with an Underworld theme, built for flat river tracks",
+    "description": "Boatoj kun infera temo, konstruitaj por plataj riverotrakoj",
     "reference-capacity": "4 passengers per raft",
     "capacity": "Po 4 pasaĝeroj por floso"
   },
   "rct2.road": {
     "reference-name": "Road",
-    "name": "Road"
+    "name": "Strato"
   },
   "rct2.tt.1920sent": {
     "reference-name": "Roaring Twenties Park Entrance",
-    "name": "Roaring Twenties Park Entrance"
+    "name": "Parkenirejo de Muĝadaj Dudekaj Jaroj"
   },
   "rct2.tt.scg1920s": {
     "reference-name": "Roaring Twenties Themeing",
-    "name": "Roaring Twenties Themeing"
+    "name": "Temo de Muĝadaj Dudekaj Jaroj"
   },
   "rct2.tt.scg1920w": {
     "reference-name": "Roaring Twenties Wall Sets",
-    "name": "Roaring Twenties Wall Sets"
+    "name": "Muroaroj de Muĝadaj Dudekaj Jaroj"
   },
   "rct2.rsaus": {
     "reference-name": "Roast Sausage Stall",
@@ -6591,47 +6591,47 @@
   },
   "rct2.tt.robncamp": {
     "reference-name": "Robin Hood's Camp",
-    "name": "Robin Hood's Camp"
+    "name": "Tendokampo de Robin Hood"
   },
   "rct2.tt.hodshut2": {
     "reference-name": "Robin Hood's Hut",
-    "name": "Robin Hood's Hut"
+    "name": "Budo de Robin Hood"
   },
   "rct2.tt.hodshut1": {
     "reference-name": "Robin Hood's Hut",
-    "name": "Robin Hood's Hut"
+    "name": "Budo de Robin Hood"
   },
   "rct2.tt.furobot1": {
     "reference-name": "Robot",
-    "name": "Robot"
+    "name": "Roboto"
   },
   "rct2.tt.furobot2": {
     "reference-name": "Robot",
-    "name": "Robot"
+    "name": "Roboto"
   },
   "rct2.edge.rock": {
     "reference-name": "Rock",
-    "name": "Rock"
+    "name": "Ŝtono"
   },
   "rct2.surface.rock": {
     "reference-name": "Rock",
-    "name": "Rock"
+    "name": "Ŝtono"
   },
   "rct2.tt.gldyrent": {
     "reference-name": "Rock 'n' Roll Park Entrance",
-    "name": "Rock 'n' Roll Park Entrance"
+    "name": "Parkenirejo de Rokenrolo"
   },
   "rct2.tt.scg1960s": {
     "reference-name": "Rock 'n' Roll Themeing",
-    "name": "Rock 'n' Roll Themeing"
+    "name": "Temo de Rokenrolo"
   },
   "rct2.tt.bandbusx": {
     "reference-name": "Rock Band Tour Bus",
-    "name": "Rock Band Tour Bus"
+    "name": "Rondvojaĝo-Buso de Rokgrupo"
   },
   "rct2.wallrk32": {
     "reference-name": "Rock Wall",
-    "name": "Rock Wall"
+    "name": "Ŝtonmuro"
   },
   "rct2.music.rock1": {
     "reference-name": "Rock style",
@@ -6647,111 +6647,111 @@
   },
   "rct2.rckc": {
     "reference-name": "Rocket Cars",
-    "name": "Rocket Cars",
+    "name": "Raketo-Ĉaroj",
     "reference-description": "Roller coaster cars themed to look like rockets",
-    "description": "Roller coaster cars themed to look like rockets",
+    "description": "Ĉaroj de onda fervojo, temitaj por aspekti kiel raketoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
   "rct2.tt.jurrpath": {
     "reference-name": "Rocky FootPath",
-    "name": "Rocky FootPath"
+    "name": "Roka Trotuaro"
   },
   "rct2.ww.sbh3oscr": {
     "reference-name": "Rollercoaster Award Statue",
-    "name": "Rollercoaster Award Statue"
+    "name": "Statuo de Onda-Fervojo-Premio"
   },
   "rct2.tt.rswatres": {
     "reference-name": "Rollerskating Waitress",
-    "name": "Rollerskating Waitress"
+    "name": "Radŝuanta Kelnerino"
   },
   "rct2.scol": {
     "reference-name": "Roman Colosseum",
-    "name": "Roman Colosseum"
+    "name": "Roma Koloseo"
   },
   "rct2.trc": {
     "reference-name": "Roman Column",
-    "name": "Roman Column"
+    "name": "Roma Kolono"
   },
   "rct2.wc3": {
     "reference-name": "Roman Column Wall",
-    "name": "Roman Column Wall"
+    "name": "Muro de Roma Kolono"
   },
   "rct2.tt.romvc2x2": {
     "reference-name": "Roman Palace Corner Piece",
-    "name": "Roman Palace Corner Piece"
+    "name": "Anguloparto de Roma Palaco"
   },
   "rct2.tt.corvs2x2": {
     "reference-name": "Roman Palace Corner Piece",
-    "name": "Roman Palace Corner Piece"
+    "name": "Anguloparto de Roma Palaco"
   },
   "rct2.tt.romnc2x2": {
     "reference-name": "Roman Palace Corner Piece",
-    "name": "Roman Palace Corner Piece"
+    "name": "Anguloparto de Roma Palaco"
   },
   "rct2.tt.corns2x2": {
     "reference-name": "Roman Palace Corner Piece",
-    "name": "Roman Palace Corner Piece"
+    "name": "Anguloparto de Roma Palaco"
   },
   "rct2.tt.crsvs2x2": {
     "reference-name": "Roman Palace Cross Section",
-    "name": "Roman Palace Cross Section"
+    "name": "Sekco de Roma Palaco"
   },
   "rct2.tt.romvm2x2": {
     "reference-name": "Roman Palace Cross Section",
-    "name": "Roman Palace Cross Section"
+    "name": "Sekco de Roma Palaco"
   },
   "rct2.tt.crsss2x2": {
     "reference-name": "Roman Palace Cross Section",
-    "name": "Roman Palace Cross Section"
+    "name": "Sekco de Roma Palaco"
   },
   "rct2.tt.romnm2x2": {
     "reference-name": "Roman Palace Cross Section",
-    "name": "Roman Palace Cross Section"
+    "name": "Sekco de Roma Palaco"
   },
   "rct2.tt.romne2x1": {
     "reference-name": "Roman Palace End Piece",
-    "name": "Roman Palace End Piece"
+    "name": "Finoparto de Roma Palaco"
   },
   "rct2.tt.romve2x1": {
     "reference-name": "Roman Palace End Piece",
-    "name": "Roman Palace End Piece"
+    "name": "Finoparto de Roma Palaco"
   },
   "rct2.tt.romns2x2": {
     "reference-name": "Roman Palace Straight Piece",
-    "name": "Roman Palace Straight Piece"
+    "name": "Rektoparto de Roma Palaco"
   },
   "rct2.tt.strvs2x2": {
     "reference-name": "Roman Palace Straight Piece",
-    "name": "Roman Palace Straight Piece"
+    "name": "Rektoparto de Roma Palaco"
   },
   "rct2.tt.romvs2x2": {
     "reference-name": "Roman Palace Straight Piece",
-    "name": "Roman Palace Straight Piece"
+    "name": "Rektoparto de Roma Palaco"
   },
   "rct2.tt.strgs2x2": {
     "reference-name": "Roman Palace Straight Piece",
-    "name": "Roman Palace Straight Piece"
+    "name": "Rektoparto de Roma Palaco"
   },
   "rct2.trms": {
     "reference-name": "Roman Statue",
-    "name": "Roman Statue"
+    "name": "Roma Statuo"
   },
   "rct2.trws": {
     "reference-name": "Roman Statue",
-    "name": "Roman Statue"
+    "name": "Roma Statuo"
   },
   "rct2.tt1": {
     "reference-name": "Roman Temple",
-    "name": "Roman Temple"
+    "name": "Roma Templo"
   },
   "rct2.wrwa": {
     "reference-name": "Roman Wall",
-    "name": "Roman Wall"
+    "name": "Roma Muro"
   },
   "rct2.wrw": {
     "reference-name": "Roman Wall",
-    "name": "Roman Wall"
+    "name": "Roma Muro"
   },
   "rct2.music.roman": {
     "reference-name": "Roman fanfare style",
@@ -6875,63 +6875,63 @@
   },
   "rct2.gdrop1": {
     "reference-name": "Roto-Drop",
-    "name": "Roto-Drop",
+    "name": "Turno-Falo",
     "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
-    "description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
+    "description": "Ringo da seĝoj, milde turniĝante, estas tirata al la supro de alta turo. Tiam, la ringo falas libere, kaj haltas milde al la malsupro per magnetaj bremsoj",
     "reference-capacity": "16 passengers",
     "capacity": "16 pasaĝeroj"
   },
   "rct2.ww.sbh3rt66": {
     "reference-name": "Route 66 Sign",
-    "name": "Route 66 Sign"
+    "name": "Afiŝo de Vojo 66"
   },
   "rct2.ww.londonbs": {
     "reference-name": "Routemaster Buses",
-    "name": "Routemaster Buses",
+    "name": "Londonaj Etaĝaj Busoj",
     "reference-description": "Replicas of the famous London Routemaster bus",
-    "description": "Replicas of the famous London Routemaster bus",
+    "description": "Replikaĵoj de la fama Londona Etaĝa Buso",
     "reference-capacity": "10 passengers per car",
     "capacity": "Po 10 pasaĝeroj por aŭto"
   },
   "rct2.rboat": {
     "reference-name": "Rowing Boats",
-    "name": "Rowing Boats",
+    "name": "Remado-Boatoj",
     "reference-description": "Rowing boats which passengers row themselves",
-    "description": "Rowing boats which passengers row themselves",
+    "description": "Remado-boatoj, kiujn pasaĝeroj remas per si mem",
     "reference-capacity": "2 passengers per boat",
     "capacity": "Po 2 pasaĝeroj por boato"
   },
   "rct2.ters": {
     "reference-name": "Ruined Statue",
-    "name": "Ruined Statue"
+    "name": "Rompita Statuo"
   },
   "rct2.tt.runway03": {
     "reference-name": "Runway Corner Piece",
-    "name": "Runway Corner Piece"
+    "name": "Anguloparto de Aviokurejo"
   },
   "rct2.tt.runway04": {
     "reference-name": "Runway Edge Piece",
-    "name": "Runway Edge Piece"
+    "name": "Bordoparto de Aviokurejo"
   },
   "rct2.tt.runway06": {
     "reference-name": "Runway Inverted Corner Piece",
-    "name": "Runway Inverted Corner Piece"
+    "name": "Inversigita Anguloparto de Aviokurejo"
   },
   "rct2.tt.runway05": {
     "reference-name": "Runway Piece",
-    "name": "Runway Piece"
+    "name": "Parto de Aviokurejo"
   },
   "rct2.tt.runway02": {
     "reference-name": "Runway Piece",
-    "name": "Runway Piece"
+    "name": "Parto de Aviokurejo"
   },
   "rct2.tt.runway01": {
     "reference-name": "Runway Piece",
-    "name": "Runway Piece"
+    "name": "Parto de Aviokurejo"
   },
   "rct1.ll.surface.rust": {
     "reference-name": "Rust",
-    "name": "Rust"
+    "name": "Rusto"
   },
   "rct2.saloon": {
     "reference-name": "Saloon",
@@ -8083,7 +8083,7 @@
     "reference-name": "Suspended Seaplane Cars",
     "name": "Penditaj Hidroplano-Ĉaroj",
     "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
-    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el hidroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
+    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el hidroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -8091,7 +8091,7 @@
     "reference-name": "Suspended Swinging Aeroplane Cars",
     "name": "Penditaj Svingiĝantaj Aeroplano-Ĉaroj",
     "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
-    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el aeroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
+    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el aeroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -8099,7 +8099,7 @@
     "reference-name": "Suspended Swinging Cars",
     "name": "Penditaj Svingiĝantaj Ĉaroj",
     "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
+    "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -8469,7 +8469,7 @@
     "reference-name": "Toboggan Cars",
     "name": "Sledo-Ĉaroj",
     "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
-    "description": "Sledformaj ĉaroj de onda fervojo with in-line seating",
+    "description": "Sledformaj ĉaroj de onda fervojo kun kolono da seĝoj",
     "reference-capacity": "4 passengers per car",
     "capacity": "Po 4 pasaĝeroj por aŭto"
   },
@@ -9359,7 +9359,7 @@
   },
   "rct2.tt.whccolds": {
     "reference-name": "Witches around Cauldron",
-    "name": "Sorĉistinoj ĉirkau Kaldrono"
+    "name": "Sorĉistinoj ĉirkaŭ Kaldrono"
   },
   "rct2.ww.whicgrub": {
     "reference-name": "Witchetty Grub Trains",


### PR DESCRIPTION
Fixups:
- Subĉiela instead of fermita
- Duetaĝa instead of duobla-ferdeka
- "Kun kolono da seĝoj" for in-line
- Translate two words starting with M and F that I forgot to translate earlier
- Correct spelling of ĉirkau to ĉirkaŭ