### PR TITLE
eo-OO: Several fixups for objects

### DIFF
--- a/objects/eo-OO.json
+++ b/objects/eo-OO.json
@@ -5,7 +5,7 @@
   },
   "rct2.mdsaent": {
     "reference-name": "'Medusa' Sign",
-    "name": "'Meduso' Afiŝo"
+    "name": "'Meduzo' Afiŝo"
   },
   "rct2.nitroent": {
     "reference-name": "'Nitro' Sign",
@@ -17,9 +17,9 @@
   },
   "rct2.tt.1920racr": {
     "reference-name": "1920s Racing Cars",
-    "name": "Vetkurantaj aŭtoj de la 1920-aj",
+    "name": "Vetkuraŭtoj de la 1920-aj",
     "reference-description": "1920s race car themed go-karts",
-    "description": "Vetkurantaj aŭtetoj kun temo de 1920-aj vetkuraŭtoj",
+    "description": "Gokartoj kun temo de 1920-aj vetkuraŭtoj",
     "reference-capacity": "Single-seater",
     "capacity": "Po 1 pasaĝero por aŭto"
   },
@@ -39,15 +39,15 @@
     "reference-name": "1950s Rockets",
     "name": "Raketoj de la 1950-aj",
     "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-    "description": "Penditaj raketoformaj trajnoj de onda fervojo, kiu enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
+    "description": "Penditaj raketoformaj trajnoj de onda fervojo, kiuj enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.c3d": {
     "reference-name": "3D Cinema",
     "name": "3D Kinejo",
     "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
-    "description": "Kinejo, kiu montras 3D filmojn en geodezikoforma konstruaĵo",
+    "description": "Kinejo, kiu montras 3D-ajn filmojn en geodezikoforma konstruaĵo",
     "reference-capacity": "20 guests",
     "capacity": "20 gastoj"
   },
@@ -61,51 +61,51 @@
   },
   "rct2.nemt": {
     "reference-name": "4-across Inverted Roller Coaster Trains",
-    "name": "Trajnoj de Pendita Onda Fervojo (Po 4 pasaĝeroj por vico)",
+    "name": "4-horizontalaj Trajnoj de Inversigita Onda Fervojo",
     "reference-description": "Suspended trains in which riders sit in rows",
-    "description": "Penditaj trajnoj, en kiu rajdantoj sidas en vicoj",
+    "description": "Penditaj trajnoj, en kiuj rajdantoj sidas en vicoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.intbob": {
     "reference-name": "6-seater Bobsleighs",
-    "name": "Bobsledoj kun 6 sidejoj",
+    "name": "Bobsledoj kun 6 seĝoj",
     "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
-    "description": "Bobsledoj kun tri vicoj, kaj ĉiu vico havas spacon por du uloj",
+    "description": "Bobsledoj kun tri vicoj, kie ĉiu vico havas spacon por du uloj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.ww.waborg06": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg02": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg04": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg08": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg05": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg01": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg03": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.waborg07": {
     "reference-name": "Aboriginal Art Set Piece",
-    "name": "Aborigena Artpeco"
+    "name": "Aborigena Artparto"
   },
   "rct2.ww.1x2abr01": {
     "reference-name": "Aboriginal Plain Tile",
@@ -153,11 +153,11 @@
   },
   "rct2.thcar": {
     "reference-name": "Air Powered Vertical Coaster Trains",
-    "name": "Aerofunkciigitaj Vertikalaj Trajnoj de Onda Fervojo",
+    "name": "Trajnoj de Aerofunkciigitaj Vertikalaj Onda Fervojo",
     "reference-description": "Air-powered launched roller coaster trains",
     "description": "Trajnoj de onda fervojo lanĉitaj per aero",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.zeplelin": {
     "reference-name": "Airship Themed Monorail Trains",
@@ -165,11 +165,11 @@
     "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
     "description": "Grandaj temitaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
     "reference-capacity": "8 passengers per car",
-    "capacity": "Po 8 pasaĝeroj por aŭto"
+    "capacity": "Po 8 pasaĝeroj por ĉaro"
   },
   "rct2.tap": {
     "reference-name": "Aleppo Pine Tree",
-    "name": "Alepo-Pino"
+    "name": "Alepo-Pinoarbo"
   },
   "rct2.tt.histfix2": {
     "reference-name": "Alien Historical Structures",
@@ -221,15 +221,15 @@
   },
   "rct2.tt.alnstr05": {
     "reference-name": "Alien Tower Bottom",
-    "name": "Ekstertera Turo-Fundparto"
+    "name": "Bazo de Ekstertera Turo"
   },
   "rct2.tt.alnstr06": {
     "reference-name": "Alien Tower Middle",
-    "name": "Ekstertera Turo-Mezparto"
+    "name": "Mezoparto de Ekstertera Turo"
   },
   "rct2.tt.alnstr07": {
     "reference-name": "Alien Tower Top",
-    "name": "Ekstertera Turo-Supro"
+    "name": "Supro de Ekstertera Turo"
   },
   "rct2.tt.alentre2": {
     "reference-name": "Alien Tree",
@@ -269,7 +269,7 @@
     "reference-description": "Spacious trains with simple lap restraints",
     "description": "Grandspacaj trajnoj kun simplaj sinobridoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.tt.cookspit": {
     "reference-name": "Animal cooking on Spit",
@@ -305,7 +305,7 @@
   },
   "rct2.tt.cavemenx": {
     "reference-name": "Animatronic Caveman lighting Fire",
-    "name": "Animatronika Kavernhomo flamigas Fajron"
+    "name": "Animatronika Kavernhomo flamiganta Fajron"
   },
   "rct2.tt.chanmaid": {
     "reference-name": "Animatronic Chained Maiden",
@@ -329,7 +329,7 @@
   },
   "rct2.tt.cagdstat": {
     "reference-name": "Animatronic Eagle on Cage",
-    "name": "Animatronikaj Aglo sur Kaĝo"
+    "name": "Animatronika Aglo sur Kaĝo"
   },
   "rct2.tt.evalien2": {
     "reference-name": "Animatronic Evil Alien",
@@ -413,7 +413,7 @@
   },
   "rct2.tt.strictop": {
     "reference-name": "Animatronic Triceratops",
-    "name": "Animatronikaj Triceratopoj"
+    "name": "Animatronika Triceratopo"
   },
   "rct2.tt.waveking": {
     "reference-name": "Animatronic Waving King",
@@ -469,23 +469,23 @@
   },
   "rct2.tt.artdec12": {
     "reference-name": "Art Deco Corner with Railings",
-    "name": "Artdekora Anguloparto kun Balkono"
+    "name": "Artdekora Angulo kun Balkono"
   },
   "rct2.tt.artdec26": {
     "reference-name": "Art Deco Corner with Railings",
-    "name": "Artdekora Anguloparto kun Balkono"
+    "name": "Artdekora Angulo kun Balkono"
   },
   "rct2.tt.artdec14": {
     "reference-name": "Art Deco Corner with Windows",
-    "name": "Artdekora Anguloparto kun Fenestroj"
+    "name": "Artdekora Angulo kun Fenestroj"
   },
   "rct2.tt.artdec11": {
     "reference-name": "Art Deco Corner with Windows",
-    "name": "Artdekora Anguloparto kun Fenestroj"
+    "name": "Artdekora Angulo kun Fenestroj"
   },
   "rct2.tt.artdec25": {
     "reference-name": "Art Deco Corner with Windows",
-    "name": "Artdekora Anguloparto kun Fenestroj"
+    "name": "Artdekora Angulo kun Fenestroj"
   },
   "rct2.tt.1920sand": {
     "reference-name": "Art Deco Food Stall",
@@ -587,11 +587,11 @@
   },
   "rct2.mft": {
     "reference-name": "Articulated Roller Coaster Trains",
-    "name": "Artika Trajnoj de Onda Fervojo",
+    "name": "Artikaj Trajnoj de Onda Fervojo",
     "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-    "description": "Trajnoj de Onda Fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj subĉielajn frontojn",
+    "description": "Trajnoj de onda fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj subĉielajn frontojn",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.pathash": {
     "reference-name": "Ash Footpath",
@@ -611,7 +611,7 @@
   },
   "rct2.tas": {
     "reference-name": "Aspen Tree",
-    "name": "Tremolo-Arbo"
+    "name": "Tremoloarbo"
   },
   "rct2.tt.titansta": {
     "reference-name": "Atlas Statue",
@@ -643,7 +643,7 @@
     "reference-description": "Roller coaster cars in the shape of automobiles",
     "description": "Ĉaroj de onda fervojo formitaj kiel aŭtoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.ggntocto": {
     "reference-name": "B-Movie Giant Octopus",
@@ -787,9 +787,9 @@
     "reference-name": "Barnstorming Trains",
     "name": "Trajnoj de Barnstorming",
     "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
-    "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo formitaj kiel duetaĝaj aeroplanoj",
+    "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo, formitaj kiel duetaĝaj aeroplanoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tbr1": {
     "reference-name": "Barrel",
@@ -827,9 +827,9 @@
     "reference-name": "Battering Ram Trains",
     "name": "Ramilego-Trajnoj",
     "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
-    "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
+    "description": "Kompaktaj trajnoj de onda fervojo kun ĉaroj kun kolono da seĝoj, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.bnoodles": {
     "reference-name": "Beef Noodles Stall",
@@ -859,13 +859,13 @@
     "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
     "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, temitaj por aspekti kiel Bengalaj Tigroj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.monbk": {
     "reference-name": "Bicycles",
     "name": "Bicikloj",
     "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
-    "description": "Specialaj bicikloj, kiuj veturas sur monorela trako, povigita per la pedalo de la rajdantoj",
+    "description": "Specialaj bicikloj, kiuj veturas sur monorela trako, povigitaj per la pedalo de la rajdantoj",
     "reference-capacity": "1 rider per bicycle",
     "capacity": "Po 1 rajdanto por biciklo"
   },
@@ -891,15 +891,15 @@
     "reference-description": "Powered vehicles in the shape of London Taxis",
     "description": "Ŝaltitaj veturiloj formitaj kiel Taksioj de Londono",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.blckdeth": {
     "reference-name": "Black Death Trains",
     "name": "Trajnoj de la Nigra Morto",
     "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
-    "description": "Ratformaj trajnoj, konsista de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
+    "description": "Ratformaj trajnoj, konsistaj de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tk4": {
     "reference-name": "Black King",
@@ -945,9 +945,9 @@
     "reference-name": "Bobsleigh Trains",
     "name": "Bobsledo-Trajnoj",
     "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
-    "description": "Trajnoj, konsista de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
+    "description": "Trajnoj, konsistaj de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.bolpot01": {
     "reference-name": "Boiling Pot",
@@ -973,9 +973,9 @@
     "reference-name": "Boomerang Trains",
     "name": "Bumerango-Trajnoj",
     "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
-    "description": "Trajnoj de onda fervojo, lanĉita per aero formita kiel bumerangoj",
+    "description": "Trajnoj de onda fervojo, lanĉitaj per aero kaj formitaj kiel bumerangoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct1.edge.brick": {
     "reference-name": "Brick",
@@ -1095,7 +1095,7 @@
     "reference-description": "Japanese Bullet Train themed roller coaster cars",
     "description": "Ĉaroj de onda fervojo kun temo de Japana Ŝinkanseno",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tbr": {
     "reference-name": "Bulrushes",
@@ -1169,15 +1169,15 @@
   },
   "rct2.ww.sbwplm03": {
     "reference-name": "Cabana Roof Piece",
-    "name": "Tegmentero de Budo"
+    "name": "Tegmentoparto de Budo"
   },
   "rct2.ww.sbwplm05": {
     "reference-name": "Cabana Roof Piece",
-    "name": "Tegmentero de Budo"
+    "name": "Tegmentoparto de Budo"
   },
   "rct2.ww.sbwplm04": {
     "reference-name": "Cabana Roof Piece",
-    "name": "Tegmentero de Budo"
+    "name": "Tegmentoparto de Budo"
   },
   "rct2.ww.sbwplm01": {
     "reference-name": "Cabana Top",
@@ -1185,35 +1185,35 @@
   },
   "rct2.ww.sbwplm07": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.sbwplm08": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.sbwplm06": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.wpalm03": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.wpalm01": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.wpalm04": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.wpalm02": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.ww.wpalm05": {
     "reference-name": "Cabana Wall Piece",
-    "name": "Muro de Budo"
+    "name": "Muroparto de Budo"
   },
   "rct2.tct": {
     "reference-name": "Cabbage Tree",
@@ -1319,7 +1319,7 @@
     "reference-description": "Cars in the shape of butterfly carnival floats",
     "description": "Ĉaroj formitaj kiel papilio-paradiloj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.crnvfrog": {
     "reference-name": "Carnival Frog Cars",
@@ -1327,7 +1327,7 @@
     "reference-description": "Cars in the shape of frog carnival floats",
     "description": "Ĉaroj formitaj kiel rano-paradiloj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.crnvlzrd": {
     "reference-name": "Carnival Lizard Cars",
@@ -1335,7 +1335,7 @@
     "reference-description": "Cars in the shape of lizard carnival floats",
     "description": "Ĉaroj formitaj kiel lacerto-paradiloj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.trckprt4": {
     "reference-name": "Cart Shaft",
@@ -1345,7 +1345,7 @@
     "reference-name": "Cash Machine",
     "name": "Bankaŭtomato",
     "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
-    "description": "Bankaŭtomato (Monomaŝino) por gastoj uzi se mankas al ili monrimedoj"
+    "description": "Bankaŭtomato (Monomaŝino) por gastoj se mankas al ili monrimedoj"
   },
   "rct2.station.castlebrown": {
     "reference-name": "Castle (Brown)",
@@ -1421,27 +1421,27 @@
   },
   "rct2.tt.mcastl13": {
     "reference-name": "Castle Tower Corner Piece",
-    "name": "Angulo de Turo de Kastelo"
+    "name": "Anguloparto de Turo de Kastelo"
   },
   "rct2.tt.mcastl14": {
     "reference-name": "Castle Tower Corner Piece",
-    "name": "Angulo de Turo de Kastelo"
+    "name": "Anguloparto de Turo de Kastelo"
   },
   "rct2.tt.mcastl15": {
     "reference-name": "Castle Tower Cross Piece",
-    "name": "Kruco de Turo de Kastelo"
+    "name": "Krucoparto de Turo de Kastelo"
   },
   "rct2.tt.mcastl16": {
     "reference-name": "Castle Tower Straight Piece",
-    "name": "Rektapeco de Turo de Kastelo"
+    "name": "Rektaparto de Turo de Kastelo"
   },
   "rct2.tt.mcastl17": {
     "reference-name": "Castle Tower T Piece",
-    "name": "T-peco de Turo de Kastelo"
+    "name": "T-Parto de Turo de Kastelo"
   },
   "rct2.tt.mcastl18": {
     "reference-name": "Castle Tower T Piece",
-    "name": "T-peco de Turo de Kastelo"
+    "name": "T-Parto de Turo de Kastelo"
   },
   "rct2.wc10": {
     "reference-name": "Castle Wall",
@@ -1525,7 +1525,7 @@
     "reference-description": "Self-drive go-karts in Stone Age style",
     "description": "Gokartoj kun Ŝtonepoka stilo",
     "reference-capacity": "Single-seater",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.tcl": {
     "reference-name": "Cedar of Lebanon Tree",
@@ -1537,7 +1537,7 @@
     "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
     "description": "Grandspacoj trajnoj kun simplaj sinobridoj, kaj ĉaroj, kiuj aspektas kiel la hundo de la infero kun multaj kapoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.clift1": {
     "reference-name": "Chairlift Cars",
@@ -1545,7 +1545,7 @@
     "reference-description": "Open cars for chairlift",
     "description": "Subĉielaj ĉaroj por seĝlifto",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.chbbase": {
     "reference-name": "Checkerboard Block",
@@ -1583,7 +1583,7 @@
     "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
     "description": "Gastoj batalas unu la alian en drakokapoformaj albatiĝantaj ĉaroj",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.ww.junkswng": {
     "reference-name": "Chinese Junk Swing Ride",
@@ -1701,15 +1701,15 @@
   },
   "rct2.tcj": {
     "reference-name": "Common Juniper Tree",
-    "name": "Ordinara Junipero-Arbo"
+    "name": "Ordinara Juniperoarbo"
   },
   "rct2.tco": {
     "reference-name": "Common Oak Tree",
-    "name": "Tigfrukta Kverko-Arbo"
+    "name": "Tigfrukta Kverkoarbo"
   },
   "rct2.tcy": {
     "reference-name": "Common Yew Tree",
-    "name": "Eŭropa Taksuso-Arbo"
+    "name": "Eŭropa Taksusoarbo"
   },
   "rct2.slct": {
     "reference-name": "Compact Inverted Coaster Trains",
@@ -1717,7 +1717,7 @@
     "reference-description": "Riders sit in pairs of seats suspended beneath the track",
     "description": "Rajdantoj sidas en paroj da seĝoj penditaj sub la trako",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.condorrd": {
     "reference-name": "Condor Trains",
@@ -1725,7 +1725,7 @@
     "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
     "description": "Rajdante en specialaj jungaĵoj sub la trako, rajdantoj spertas la senton de flugado en kondorformaj trajnoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.congaeel": {
     "reference-name": "Conger Eel Trains",
@@ -1733,7 +1733,7 @@
     "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
     "description": "Trajnoj kun ŝultrobridoj formitaj kiel kongroj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.wch": {
     "reference-name": "Conifer Hedge",
@@ -1779,47 +1779,47 @@
     "reference-description": "Roller coaster trains with shoulder restraints",
     "description": "Trajnoj de onda fervojo kun ŝultrobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.rcorr02": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr03": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr10": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr05": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr07": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr01": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr09": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr04": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr08": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.ww.rcorr11": {
     "reference-name": "Corrugated Roof Piece",
-    "name": "Onda Tegmentopeco"
+    "name": "Onda Tegmentoparto"
   },
   "rct2.corroof2": {
     "reference-name": "Corrugated Steel Base",
@@ -1963,7 +1963,7 @@
   },
   "rct2.tcrp": {
     "reference-name": "Corsican Pine Tree",
-    "name": "Nigra Pinarbo"
+    "name": "Nigra Pinoarbo"
   },
   "rct2.ww.cowboy01": {
     "reference-name": "Cowboy 1",
@@ -2051,7 +2051,7 @@
     "reference-description": "Riders drive the Eye of a Giant Cyclops",
     "description": "Rajdantoj stiras la Okulon de Giganta Ciklopo",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.tt.cyclopss": {
     "reference-name": "Cyclops Statue",
@@ -2283,7 +2283,7 @@
     "reference-description": "Riders bump into each other in self-drive electric dodgems",
     "description": "Rajdantoj albatiĝas al unu la alian per elektraj albatiĝantaj ĉaroj",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.music.dodgems": {
     "reference-name": "Dodgems beat style",
@@ -2357,31 +2357,31 @@
   },
   "rct2.ww.rdrab08": {
     "reference-name": "Drab Minaret Piece 1",
-    "name": "Dubekolora Minareto-Peco 1"
+    "name": "Dubekolora Minaretoparto 1"
   },
   "rct2.ww.rdrab09": {
     "reference-name": "Drab Minaret Piece 2",
-    "name": "Dubekolora Minareto-Peco 2"
+    "name": "Dubekolora Minaretoparto 2"
   },
   "rct2.ww.rdrab10": {
     "reference-name": "Drab Minaret Piece 3",
-    "name": "Dubekolora Minareto-Peco 3"
+    "name": "Dubekolora Minaretoparto 3"
   },
   "rct2.ww.rdrab11": {
     "reference-name": "Drab Roof Piece 1",
-    "name": "Dubekolora Tegmentopeco 1"
+    "name": "Dubekolora Tegmentoparto 1"
   },
   "rct2.ww.rdrab12": {
     "reference-name": "Drab Roof Piece 2",
-    "name": "Dubekolora Tegmentopeco 2"
+    "name": "Dubekolora Tegmentoparto 2"
   },
   "rct2.ww.rdrab13": {
     "reference-name": "Drab Roof Piece 3",
-    "name": "Dubekolora Tegmentopeco 3"
+    "name": "Dubekolora Tegmentoparto 3"
   },
   "rct2.ww.rdrab14": {
     "reference-name": "Drab Roof Piece 4",
-    "name": "Dubekolora Tegmentopeco 4"
+    "name": "Dubekolora Tegmentoparto 4"
   },
   "rct2.ww.rdrab07": {
     "reference-name": "Drab Small Tower Base",
@@ -2397,55 +2397,55 @@
   },
   "rct2.ww.wdrab09": {
     "reference-name": "Drab Step-up Piece 1",
-    "name": "Dubekolora Ŝtupopeco 1"
+    "name": "Dubekolora Ŝtupoparto 1"
   },
   "rct2.ww.wdrab13": {
     "reference-name": "Drab Step-up Piece 2",
-    "name": "Dubekolora Ŝtupopeco 2"
+    "name": "Dubekolora Ŝtupoparto 2"
   },
   "rct2.ww.wdrab01": {
     "reference-name": "Drab Wall Piece 1",
-    "name": "Dubekolora Murpeco 1"
+    "name": "Dubekolora Muroparto 1"
   },
   "rct2.ww.wdrab11": {
     "reference-name": "Drab Wall Piece 10",
-    "name": "Dubekolora Murpeco 10"
+    "name": "Dubekolora Muroparto 10"
   },
   "rct2.ww.wdrab12": {
     "reference-name": "Drab Wall Piece 11",
-    "name": "Dubekolora Murpeco 11"
+    "name": "Dubekolora Muroparto 11"
   },
   "rct2.ww.wdrab02": {
     "reference-name": "Drab Wall Piece 2",
-    "name": "Dubekolora Murpeco 2"
+    "name": "Dubekolora Muroparto 2"
   },
   "rct2.ww.wdrab03": {
     "reference-name": "Drab Wall Piece 3",
-    "name": "Dubekolora Murpeco 3"
+    "name": "Dubekolora Muroparto 3"
   },
   "rct2.ww.wdrab04": {
     "reference-name": "Drab Wall Piece 4",
-    "name": "Dubekolora Murpeco 4"
+    "name": "Dubekolora Muroparto 4"
   },
   "rct2.ww.wdrab05": {
     "reference-name": "Drab Wall Piece 5",
-    "name": "Dubekolora Murpeco 5"
+    "name": "Dubekolora Muroparto 5"
   },
   "rct2.ww.wdrab06": {
     "reference-name": "Drab Wall Piece 6",
-    "name": "Dubekolora Murpeco 6"
+    "name": "Dubekolora Muroparto 6"
   },
   "rct2.ww.wdrab07": {
     "reference-name": "Drab Wall Piece 7",
-    "name": "Dubekolora Murpeco 7"
+    "name": "Dubekolora Muroparto 7"
   },
   "rct2.ww.wdrab08": {
     "reference-name": "Drab Wall Piece 8",
-    "name": "Dubekolora Murpeco 8"
+    "name": "Dubekolora Muroparto 8"
   },
   "rct2.ww.wdrab10": {
     "reference-name": "Drab Wall Piece 9",
-    "name": "Dubekolora Murpeco 9"
+    "name": "Dubekolora Muroparto 9"
   },
   "rct2.tt.drgnattk": {
     "reference-name": "Dragon Attacking",
@@ -2457,7 +2457,7 @@
     "reference-description": "Dragon-themed roller coaster cars",
     "description": "Ĉaroj de onda fervojo kun drakotemo",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.dragnfly": {
     "reference-name": "Dragonfly Cars",
@@ -2465,7 +2465,7 @@
     "reference-description": "Dragonfly-shaped cars which swing from the rail above",
     "description": "Libeloformaj ĉaroj, kiuj svingiĝas sub la relo supere",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.drnks": {
     "reference-name": "Drinks Stall",
@@ -2547,7 +2547,7 @@
   },
   "rct2.ww.3x3eucal": {
     "reference-name": "Eucalyptus Tree",
-    "name": "Eŭkalipto-Arbo"
+    "name": "Eŭkaliptoarbo"
   },
   "rct2.ww.scgeurop": {
     "reference-name": "Europe Themeing",
@@ -2555,7 +2555,7 @@
   },
   "rct2.tel": {
     "reference-name": "European Larch Tree",
-    "name": "Eŭropa Lariko-Arbo"
+    "name": "Eŭropa Larikoarbo"
   },
   "rct2.ww.euroent": {
     "reference-name": "European Park Entrance",
@@ -2579,7 +2579,7 @@
     "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
     "description": "Rapidirante tra krutaj inversigoj, rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.music.fairground": {
     "reference-name": "Fairground organ style",
@@ -2643,7 +2643,7 @@
     "reference-description": "Riders joust on horse-themed dodgems",
     "description": "Rajdantoj batalas sur albatiĝantaj ĉaroj kun temo de ĉevalo",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.ww.firecrak": {
     "reference-name": "Fire Cracker Ride",
@@ -2693,7 +2693,7 @@
     "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
     "description": "Grandspaca trajno kun ŝultrobridoj kaj neniu planko, por doni pli ekscitan atrakcion",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tjf": {
     "reference-name": "Flower",
@@ -2705,7 +2705,7 @@
     "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
     "description": "Rajdantoj rajdas en floroformaj kusenveturiloj, kiujn ili stiras libere",
     "reference-capacity": "1 passenger per car",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.tt.1960tsrt": {
     "reference-name": "Flower Power T-Shirts",
@@ -2727,7 +2727,7 @@
     "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
     "description": "Rajdantoj estas tenitaj en komfortaj seĝoj sub la trako por havi la plej bonan sperton de flugado",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.fsauc": {
     "reference-name": "Flying Saucers",
@@ -2735,7 +2735,7 @@
     "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
     "description": "Gastoj rajdas en nifoformaj kusenveturiloj, kiujn ili stiras libere",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.ball3": {
     "reference-name": "Football",
@@ -2747,7 +2747,7 @@
     "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, konsistas el piedpilkoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.forbidft": {
     "reference-name": "Forbidden Fruit Tree",
@@ -2755,7 +2755,7 @@
   },
   "rct2.tt.shwdfrst": {
     "reference-name": "Forest Trees",
-    "name": "Arbaro-Arboj"
+    "name": "Arbaroarboj"
   },
   "rct2.wdiag": {
     "reference-name": "Fountain",
@@ -2771,7 +2771,7 @@
     "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
     "description": "Individuaj ĉaroj de onda fervojo, konstruitaj por trakoj kun harpingloformaj kurboj kaj krutaj malleviĝoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.chcks": {
     "reference-name": "Fried Chicken Stall",
@@ -2839,7 +2839,7 @@
     "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
     "description": "Linearaj induktaj motoroj plirapidigas gangstero-aŭtojn, kiuj havas 1920-ajn temon, el la stacio, por rapidiri tra kurboplenaj inversigoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tg2": {
     "reference-name": "Gardens",
@@ -2979,31 +2979,31 @@
   },
   "rct2.ww.wgeorg02": {
     "reference-name": "Georgian Ground Floor Wall Piece 1",
-    "name": "Georgia Ternivela Murpeco 1"
+    "name": "Georgia Ternivela Muroparto 1"
   },
   "rct2.ww.wgeorg04": {
     "reference-name": "Georgian Ground Floor Wall Piece 2",
-    "name": "Georgia Ternivela Murpeco 2"
+    "name": "Georgia Ternivela Muroparto 2"
   },
   "rct2.ww.wgeorg06": {
     "reference-name": "Georgian Ground Floor Wall Piece 3",
-    "name": "Georgia Ternivela Murpeco 3"
+    "name": "Georgia Ternivela Muroparto 3"
   },
   "rct2.ww.wgeorg07": {
     "reference-name": "Georgian Ground Floor Wall Piece 4",
-    "name": "Georgia Ternivela Murpeco 4"
+    "name": "Georgia Ternivela Muroparto 4"
   },
   "rct2.ww.wgeorg08": {
     "reference-name": "Georgian Ground Floor Wall Piece 5",
-    "name": "Georgia Ternivela Murpeco 5"
+    "name": "Georgia Ternivela Muroparto 5"
   },
   "rct2.ww.wgeorg09": {
     "reference-name": "Georgian Ground Floor Wall Piece 6",
-    "name": "Georgia Ternivela Murpeco 6"
+    "name": "Georgia Ternivela Muroparto 6"
   },
   "rct2.ww.rgeorg08": {
     "reference-name": "Georgian Ground Floor Wall Piece 7",
-    "name": "Georgia Ternivela Murpeco 7"
+    "name": "Georgia Ternivela Muroparto 7"
   },
   "rct2.ww.rgeorg01": {
     "reference-name": "Georgian Roof End Piece 1",
@@ -3015,51 +3015,51 @@
   },
   "rct2.ww.rgeorg03": {
     "reference-name": "Georgian Roof Piece 1",
-    "name": "Georgia Tegmentero 1"
+    "name": "Georgia Tegmentoparto 1"
   },
   "rct2.ww.rgeorg04": {
     "reference-name": "Georgian Roof Piece 2",
-    "name": "Georgia Tegmentero 2"
+    "name": "Georgia Tegmentoparto 2"
   },
   "rct2.ww.rgeorg05": {
     "reference-name": "Georgian Roof Piece 3",
-    "name": "Georgia Tegmentero 3"
+    "name": "Georgia Tegmentoparto 3"
   },
   "rct2.ww.rgeorg06": {
     "reference-name": "Georgian Roof Piece 4",
-    "name": "Georgia Tegmentero 4"
+    "name": "Georgia Tegmentoparto 4"
   },
   "rct2.ww.rgeorg07": {
     "reference-name": "Georgian Roof Piece 5",
-    "name": "Georgia Tegmentero 5"
+    "name": "Georgia Tegmentoparto 5"
   },
   "rct2.ww.rgeorg12": {
     "reference-name": "Georgian Roof Piece 7",
-    "name": "Georgia Tegmentero 7"
+    "name": "Georgia Tegmentoparto 7"
   },
   "rct2.ww.wgeorg01": {
     "reference-name": "Georgian Wall Piece 1",
-    "name": "Georgia Murpeco 1"
+    "name": "Georgia Muroparto 1"
   },
   "rct2.ww.wgeorg03": {
     "reference-name": "Georgian Wall Piece 2",
-    "name": "Georgia Murpeco 2"
+    "name": "Georgia Muroparto 2"
   },
   "rct2.ww.wgeorg05": {
     "reference-name": "Georgian Wall Piece 3",
-    "name": "Georgia Murpeco 3"
+    "name": "Georgia Muroparto 3"
   },
   "rct2.ww.wgeorg10": {
     "reference-name": "Georgian Wall Piece 4",
-    "name": "Georgia Murpeco 4"
+    "name": "Georgia Muroparto 4"
   },
   "rct2.ww.wgeorg11": {
     "reference-name": "Georgian Wall Piece 5",
-    "name": "Georgia Murpeco 5"
+    "name": "Georgia Muroparto 5"
   },
   "rct2.ww.wgeorg12": {
     "reference-name": "Georgian Wall Piece 6",
-    "name": "Georgia Murpeco 6"
+    "name": "Georgia Muroparto 6"
   },
   "rct2.tt.geyserxx": {
     "reference-name": "Geysers",
@@ -3071,7 +3071,7 @@
     "reference-description": "Powered monster-shaped cars that run on a ghost train track",
     "description": "Ŝaltitaj monstroformaj ĉaroj, kiuj veturas sur trako de fantomo-trajno",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.bigbassx": {
     "reference-name": "Giant Bass Guitar",
@@ -3147,7 +3147,7 @@
     "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
     "description": "Trajnoj de onda fervojo por la Altega Onda Fervojo, kapabla je glataj malleviĝoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.giraffe1": {
     "reference-name": "Giraffe 1",
@@ -3191,7 +3191,7 @@
     "reference-description": "Self-drive petrol-engined go-karts",
     "description": "Gokartoj kun benzinmotoroj, kiujn pasaĝeroj stiras per si mem",
     "reference-capacity": "single-seater",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.ww.1x2glama": {
     "reference-name": "Gold Llama",
@@ -3231,7 +3231,7 @@
     "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, konsistas el goriloformaj ĉaroj, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.surface.grass": {
     "reference-name": "Grass",
@@ -3295,7 +3295,7 @@
     "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
     "description": "Trajnoj kun ŝultrobridoj formitaj kiel granda blanka ŝarko",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tarmacg": {
     "reference-name": "Green Tarmac Footpath",
@@ -3395,7 +3395,7 @@
     "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
     "description": "Trajnoj de onda fervojo, kiuj havas la formon de mitologiaj birdecaj bestoj. Rajdantoj estas tenitaj en specialaj jungaĵoj, kaj veturas aŭ fronte al la ĉielo, aŭ fronte al la tero",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.hatst": {
     "reference-name": "Hat Stall",
@@ -3425,7 +3425,7 @@
     "reference-description": "Small powered cars that run on a ghost train track",
     "description": "Malgrandaj ŝaltitaj ĉaroj, kiuj veturas sur trako de fantomita trajno",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.haybails": {
     "reference-name": "Hay Bale",
@@ -3557,7 +3557,7 @@
   },
   "rct2.thl": {
     "reference-name": "Honey Locust Tree",
-    "name": "Kristodorna Glediĉio-Arbo"
+    "name": "Kristodorna Glediĉioarbo"
   },
   "rct2.music.horror": {
     "reference-name": "Horror style",
@@ -3609,7 +3609,7 @@
     "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
     "description": "Trajnoj de onda fervojo, kiuj estas lanĉita per aero, kaj havas la formon de hot-rod-aj aŭtoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.twh1": {
     "reference-name": "House",
@@ -3665,7 +3665,7 @@
     "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
     "description": "Teknologio de magneta levitacio estis realigita por krei la iluzion de estontecaj flugpendantaj aŭtoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.hvrbike4": {
     "reference-name": "Hoverbike Flying",
@@ -3689,7 +3689,7 @@
     "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
     "description": "Gastoj rajdas sur estonteca flugpendanta plato, kaj svingiĝas libere ĉirkaŭ anguloj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.hovrcar3": {
     "reference-name": "Hovercar Flying",
@@ -3713,7 +3713,7 @@
     "reference-description": "Powered vehicles in the shape of Huskie sleds",
     "description": "Ŝaltitaj veturiloj, kiuj havas la formon de sledoj por sledhundoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.goltr": {
     "reference-name": "Hyper-Twister Trains",
@@ -3721,7 +3721,7 @@
     "reference-description": "Spacious trains with simple lap restraints",
     "description": "Grandspacaj trajnoj kun simplaj sinobridoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.bmrb": {
     "reference-name": "Hyper-Twister Trains (wide cars)",
@@ -3729,7 +3729,7 @@
     "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
     "description": "Larĝaj ĉaroj kun po 4 seĝoj por vico, pli altaj seĝoj, kaj simplaj sinobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.arrt2": {
     "reference-name": "Hypercoaster Trains",
@@ -3737,7 +3737,7 @@
     "reference-description": "Comfortable trains with only lap bar restraints",
     "description": "Komfortaj trajnoj kun nur sinobridoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.edge.ice": {
     "reference-name": "Ice",
@@ -3921,11 +3921,11 @@
     "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
     "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tic": {
     "reference-name": "Incense Cedar Tree",
-    "name": "Bonodorfumo-Cedro-Arbo"
+    "name": "Bonodorfumo-Cedroarbo"
   },
   "rct2.ww.inflag05": {
     "reference-name": "Indian Silk Flag",
@@ -3949,51 +3949,51 @@
   },
   "rct2.tt.indwal05": {
     "reference-name": "Industrial Roof Corner Piece",
-    "name": "Angulo de Industria Tegmentero"
+    "name": "Anguloparto de Industria Tegmento"
   },
   "rct2.tt.indwal06": {
     "reference-name": "Industrial Roof Corner Piece",
-    "name": "Angulo de Industria Tegmentero"
+    "name": "Anguloparto de Industria Tegmento"
   },
   "rct2.tt.indwal21": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal22": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal24": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal23": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal25": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal29": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal20": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal27": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal28": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal26": {
     "reference-name": "Industrial Roof Piece",
-    "name": "Industria Tegmentero"
+    "name": "Industria Tegmentoparto"
   },
   "rct2.tt.indwal15": {
     "reference-name": "Industrial Wall Corner Piece",
@@ -4095,7 +4095,7 @@
   },
   "rct2.titc": {
     "reference-name": "Italian Cypress Tree",
-    "name": "Mediteranea Cipreso-Arbo"
+    "name": "Mediteranea Cipresoarbo"
   },
   "rct2.ww.italypor": {
     "reference-name": "Italian Police Ride",
@@ -4111,15 +4111,15 @@
     "reference-description": "Roller coaster cars themed to look like jaguars",
     "description": "Ĉaroj de onda fervojo temitaj por aspekti kiel jaguaroj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.japchblo": {
     "reference-name": "Japanese Cherry Blossom Tree",
-    "name": "Japana Sakuro-Arbo"
+    "name": "Japana Sakuroarbo"
   },
   "rct2.ww.jachtree": {
     "reference-name": "Japanese Cherry Tree",
-    "name": "Japana Ĉerizo-Arbo"
+    "name": "Japana Ĉerizoarbo"
   },
   "rct2.ww.wshogi17": {
     "reference-name": "Japanese Fence",
@@ -4139,7 +4139,7 @@
   },
   "rct2.ww.jappintr": {
     "reference-name": "Japanese Pine Tree",
-    "name": "Japana Pinarbo"
+    "name": "Japana Pinoarbo"
   },
   "rct2.ww.rshogi2": {
     "reference-name": "Japanese Roof",
@@ -4179,7 +4179,7 @@
   },
   "rct2.ww.japsnotr": {
     "reference-name": "Japanese Snowball Tree",
-    "name": "Japana Neĝbulo-Arbo"
+    "name": "Japana Neĝbuloarbo"
   },
   "rct2.tt.jazzmbr4": {
     "reference-name": "Jazz Band Member",
@@ -4227,7 +4227,7 @@
     "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
     "description": "Granda rakettornistroforma ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
     "reference-capacity": "8 passengers per car",
-    "capacity": "Po 8 pasaĝeroj por aŭto"
+    "capacity": "Po 8 pasaĝeroj por ĉaro"
   },
   "rct2.tt.jetplane": {
     "reference-name": "Jet Plane Cars",
@@ -4235,7 +4235,7 @@
     "reference-description": "Roller coaster cars in the shape of jet planes",
     "description": "Ĉaroj de onda fervojo formitaj kiel aeroplanoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.jski": {
     "reference-name": "Jet Skis",
@@ -4331,7 +4331,7 @@
     "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
     "description": "Granda koaloforma ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
     "reference-capacity": "8 passengers per car",
-    "capacity": "Po 8 pasaĝeroj por aŭto"
+    "capacity": "Po 8 pasaĝeroj por ĉaro"
   },
   "rct2.ww.rkreml08": {
     "reference-name": "Kremlin Large Tower Base",
@@ -4347,23 +4347,23 @@
   },
   "rct2.ww.rkreml01": {
     "reference-name": "Kremlin Minaret Piece 1",
-    "name": "Minareto de Kremlo Peco 1"
+    "name": "Minareto de Kremlo Parto 1"
   },
   "rct2.ww.rkreml02": {
     "reference-name": "Kremlin Minaret Piece 2",
-    "name": "Minareto de Kremlo Peco 2"
+    "name": "Minareto de Kremlo Parto 2"
   },
   "rct2.ww.rkreml03": {
     "reference-name": "Kremlin Minaret Piece 3",
-    "name": "Minareto de Kremlo Peco 3"
+    "name": "Minareto de Kremlo Parto 3"
   },
   "rct2.ww.rkreml04": {
     "reference-name": "Kremlin Roof Piece 1",
-    "name": "Tegmentero de Kremlo 1"
+    "name": "Tegmentoparto de Kremlo 1"
   },
   "rct2.ww.rkreml05": {
     "reference-name": "Kremlin Roof Piece 2",
-    "name": "Tegmentero de Kremlo 2"
+    "name": "Tegmentoparto de Kremlo 2"
   },
   "rct2.ww.rkreml07": {
     "reference-name": "Kremlin Small Tower Base",
@@ -4387,35 +4387,35 @@
   },
   "rct2.ww.wkreml03": {
     "reference-name": "Kremlin Wall Piece 1",
-    "name": "Murpeco de Kremlo 1"
+    "name": "Muroparto de Kremlo 1"
   },
   "rct2.ww.wkreml04": {
     "reference-name": "Kremlin Wall Piece 2",
-    "name": "Murpeco de Kremlo 2"
+    "name": "Muroparto de Kremlo 2"
   },
   "rct2.ww.wkreml05": {
     "reference-name": "Kremlin Wall Piece 3",
-    "name": "Murpeco de Kremlo 3"
+    "name": "Muroparto de Kremlo 3"
   },
   "rct2.ww.wkreml06": {
     "reference-name": "Kremlin Wall Piece 4",
-    "name": "Murpeco de Kremlo 4"
+    "name": "Muroparto de Kremlo 4"
   },
   "rct2.ww.wkreml07": {
     "reference-name": "Kremlin Wall Piece 5",
-    "name": "Murpeco de Kremlo 5"
+    "name": "Muroparto de Kremlo 5"
   },
   "rct2.ww.wkreml08": {
     "reference-name": "Kremlin Wall Piece 6",
-    "name": "Murpeco de Kremlo 6"
+    "name": "Muroparto de Kremlo 6"
   },
   "rct2.ww.wkreml09": {
     "reference-name": "Kremlin Wall Piece 7",
-    "name": "Murpeco de Kremlo 7"
+    "name": "Muroparto de Kremlo 7"
   },
   "rct2.ww.wkreml10": {
     "reference-name": "Kremlin Wall Piece 8",
-    "name": "Murpeco de Kremlo 8"
+    "name": "Muroparto de Kremlo 8"
   },
   "rct2.premt1": {
     "reference-name": "LIM Launched Roller Coaster Trains",
@@ -4423,7 +4423,7 @@
     "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
     "description": "Trajnoj de onda fervojo, kiujn linearaj induktaj motoroj plirapidigas",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.zldb": {
     "reference-name": "Ladybird Trains",
@@ -4431,7 +4431,7 @@
     "reference-description": "Roller coaster trains with small ladybird-shaped cars",
     "description": "Trajnoj de onda fervojo kun malgrandaj kokcineloformaj ĉaroj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.lamppir": {
     "reference-name": "Lamp",
@@ -4519,7 +4519,7 @@
   },
   "rct2.tlc": {
     "reference-name": "Lawson Cypress Tree",
-    "name": "Lawson-Cipreso-Arbo"
+    "name": "Lawson-Cipresoarbo"
   },
   "rct2.skytr": {
     "reference-name": "Lay-down Cars",
@@ -4527,7 +4527,7 @@
     "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
     "description": "Malgrandaj penditaj ĉaroj, en kiuj la pasaĝeroj rajdas kuŝiĝante, frontas al la tero, kaj svingiĝas libere de unu flanko al la alia",
     "reference-capacity": "1 passenger per car",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.vekst": {
     "reference-name": "Lay-down Roller Coaster Trains",
@@ -4535,7 +4535,7 @@
     "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
     "description": "Rajdantoj estas kuŝiĝantaj kaj tenitaj en specialaj jungaĵoj, kaj veturas aŭ fronte al la ĉielo aŭ fronte al la tero",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.mktstal2": {
     "reference-name": "Lemonade Market Stall",
@@ -4567,7 +4567,7 @@
     "reference-description": "Limousine-themed roller coaster cars",
     "description": "Ĉaroj de onda fervojo kun temo de limuzino",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.afrclion": {
     "reference-name": "Lion",
@@ -4579,7 +4579,7 @@
     "reference-description": "Roller coaster cars themed to look like lions",
     "description": "Ĉaroj de onda fervojo temita por aspekti kiel leonoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.littermn": {
     "reference-name": "Litter Bin",
@@ -4659,7 +4659,7 @@
     "reference-description": "Roller coaster trains with small log-shaped cars",
     "description": "Trajnoj de onda fervojo kun malgrandaj ŝtipoformaj ĉaroj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tml": {
     "reference-name": "Logs",
@@ -4687,7 +4687,7 @@
     "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
     "description": "Trajnoj de onda fervojo kun sinobridoj, kiuj kapablas veturi tra vertikalaj lopoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.wmayan17": {
     "reference-name": "Lost City Column Piece",
@@ -4839,7 +4839,7 @@
   },
   "rct2.tmg": {
     "reference-name": "Magnolia Tree",
-    "name": "Magnolio-Arbo"
+    "name": "Magnolioarbo"
   },
   "rct2.ww.tmarch1": {
     "reference-name": "Maharaja Palace Arch 1",
@@ -5087,7 +5087,7 @@
     "reference-description": "Cars shaped like an old mine cart",
     "description": "Ĉaroj formitaj kiel malnova minĉaro",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.smc2": {
     "reference-name": "Mine Cars",
@@ -5095,7 +5095,7 @@
     "reference-description": "Individual cars shaped like wooden mine trucks",
     "description": "Individuaj ĉaroj formitaj kiel lignaj minkamionoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.minecart": {
     "reference-name": "Mine Cart Trains",
@@ -5103,7 +5103,7 @@
     "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
     "description": "Lignaj trajnoj de onda fervojo, kun komforta seĝoj kaj sinobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.smh1": {
     "reference-name": "Mine Hut",
@@ -5135,7 +5135,7 @@
     "reference-description": "Mine train-themed roller coaster trains",
     "description": "Trajnoj de onda fervojo kun temo de mintrajno",
     "reference-capacity": "2 or 4 passengers per car",
-    "capacity": "Por 2 aŭ 4 pasaĝeroj por aŭto"
+    "capacity": "Por 2 aŭ 4 pasaĝeroj por ĉaro"
   },
   "rct2.golf1": {
     "reference-name": "Mini Golf",
@@ -5151,7 +5151,7 @@
     "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
     "description": "Ŝaltitaj helikopteroformaj ĉaroj, kiujn la pedalado de la rajdantoj funkciigas",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.minotaur": {
     "reference-name": "Minotaur Statue",
@@ -5183,7 +5183,7 @@
   },
   "rct2.tmzp": {
     "reference-name": "Montezuma Pine Tree",
-    "name": "Pinarbo de Montezuma"
+    "name": "Pinoarbo de Montezuma"
   },
   "rct2.ww.wcuzco28": {
     "reference-name": "Monumental Broken Wall Piece",
@@ -5341,7 +5341,7 @@
     "reference-description": "Individual cars shaped like mice",
     "description": "Individualaj ĉaroj formitaj kiel musoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.wmouse": {
     "reference-name": "Mouse Cars",
@@ -5349,7 +5349,7 @@
     "reference-description": "Individual cars shaped like a mouse",
     "description": "Individualaj ĉaroj formitaj kiel muso",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.rmud05": {
     "reference-name": "Mud Roof Piece",
@@ -5393,7 +5393,7 @@
     "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
     "description": "Ĉaroj kun seĝoj, kiuj kapablas renversigi la rajdantojn",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.mythentr": {
     "reference-name": "Mythological Entrance",
@@ -5827,7 +5827,7 @@
     "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
     "description": "Trajnoj de onda fervojo, en kiuj rajdantoj rajdas en staranta pozicio kaj la aŭtoj estas temita por aspekti kiel strutoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.outriggr": {
     "reference-name": "Outrigger Canoes",
@@ -5903,7 +5903,7 @@
     "reference-description": "Roller coaster trains with cuddly panda cars",
     "description": "Trajnoj de onda fervojo kun karesigaj pandaj ĉaroj",
     "reference-capacity": "1 passenger per car",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.pkesfh": {
     "reference-name": "Park Entrance Building",
@@ -5923,7 +5923,7 @@
     "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
     "description": "Ŝaltitaj veturiloj formitaj kiel Pegaso tiranta ĉaron",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.penguinb": {
     "reference-name": "Penguin Trains",
@@ -5931,7 +5931,7 @@
     "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
     "description": "Pingvenoformaj trajnoj, konsista el ĉaroj kun 2 seĝoj, kie la rajdantoj estas post unu la alian",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tt.peramob2": {
     "reference-name": "Period Automobile",
@@ -6145,7 +6145,7 @@
     "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
     "description": "Penditaj trajnoj kun formo de blankaj ursoj, en kiuj rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.suppleg2": {
     "reference-name": "Pole",
@@ -6165,7 +6165,7 @@
     "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
     "description": "Trajnoj de onda fervojo kun sinobridoj, kiuj kapablas veturi tra vertikalaj lopoj, temita por aspeki kiel policajn aŭtojn",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.policecr": {
     "reference-name": "Police Cars",
@@ -6199,7 +6199,7 @@
     "reference-description": "Mine train-themed roller coaster trains that propel themselves",
     "description": "Minotrajno-temitaj trajnoj de onda fervojo, kiuj pelas per si mem",
     "reference-capacity": "2 or 4 passengers per car",
-    "capacity": "Po 2 aŭ 4 pasaĝeroj por aŭto"
+    "capacity": "Po 2 aŭ 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.jurasent": {
     "reference-name": "Prehistoric Entrance",
@@ -6329,7 +6329,7 @@
     "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
     "description": "Rajdantoj estas tenitaj en komfortaj seĝoj sub la trako por havi la plejan praan sperton de flugado",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tsmp": {
     "reference-name": "Pumpkin",
@@ -6349,11 +6349,11 @@
   },
   "rct2.rcr": {
     "reference-name": "Racing Cars",
-    "name": "Vetkurantaj Aŭtoj",
+    "name": "Vetkuraŭtoj",
     "reference-description": "Powered vehicles in the shape of racing cars",
-    "description": "Ŝaltitaj veturiloj formitaj kiel vetkurantaj aŭtoj",
+    "description": "Ŝaltitaj veturiloj formitaj kiel vetkuraŭtoj",
     "reference-capacity": "1 passenger per car",
-    "capacity": "Po 1 pasaĝero por aŭto"
+    "capacity": "Po 1 pasaĝero por ĉaro"
   },
   "rct2.tt.raptorxx": {
     "reference-name": "Racing Raptors",
@@ -6517,7 +6517,7 @@
     "reference-description": "Monorail trains with open cabins",
     "description": "Monorelaj trajnoj kun subĉielaj kajutoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.revf1": {
     "reference-name": "Reverse Freefall Car",
@@ -6533,7 +6533,7 @@
     "reference-description": "Bogied cars capable of turning around on special reversing sections",
     "description": "Boĝiĉaroj kapablas je turniĝi ĉirkaŭ specialaj inversigantaj partoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.ww.afrrhino": {
     "reference-name": "Rhino",
@@ -6545,7 +6545,7 @@
     "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
     "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj, temitaj por aspekti kiel rinoceroj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.wallpr32": {
     "reference-name": "Rigging",
@@ -6651,7 +6651,7 @@
     "reference-description": "Roller coaster cars themed to look like rockets",
     "description": "Ĉaroj de onda fervojo, temitaj por aspekti kiel raketoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.jurrpath": {
     "reference-name": "Rocky FootPath",
@@ -6891,7 +6891,7 @@
     "reference-description": "Replicas of the famous London Routemaster bus",
     "description": "Replikaĵoj de la fama Londona Etaĝa Buso",
     "reference-capacity": "10 passengers per car",
-    "capacity": "Po 10 pasaĝeroj por aŭto"
+    "capacity": "Po 10 pasaĝeroj por ĉaro"
   },
   "rct2.rboat": {
     "reference-name": "Rowing Boats",
@@ -6943,7 +6943,7 @@
     "reference-description": "Replicas of the San Francisco Trams",
     "description": "Replikaĵoj de la tramoj de San Francisco",
     "reference-capacity": "10 passengers per car",
-    "capacity": "Po 10 pasaĝeroj por aŭto"
+    "capacity": "Po 10 pasaĝeroj por ĉaro"
   },
   "rct2.surface.sand": {
     "reference-name": "Sand",
@@ -7131,11 +7131,11 @@
     "reference-description": "Miniature trams themed to look like North American school buses",
     "description": "Miniaturaj tramoj temitaj por aspekti kiel Nordamerikaj lernejo-busoj",
     "reference-capacity": "10 passengers per car",
-    "capacity": "Po 10 pasaĝeroj por aŭto"
+    "capacity": "Po 10 pasaĝeroj por ĉaro"
   },
   "rct2.tsp": {
     "reference-name": "Scots Pine Tree",
-    "name": "Arbara Pinarbo"
+    "name": "Arbara Pinoarbo"
   },
   "rct2.ssig1": {
     "reference-name": "Scrolling Sign",
@@ -7189,7 +7189,7 @@
     "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
     "description": "Trajnoj de onda fervojo kun ŝultrobridoj, temitaj por aspekti kiel fokoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.schnpits": {
     "reference-name": "Seaplane Pits",
@@ -7325,7 +7325,7 @@
     "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
     "description": "Trajnoj de onda fervojo kun ekstra-larĝaj ĉaroj, konstruitaj por vertikalaj faloj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.ssk1": {
     "reference-name": "Skeleton",
@@ -7337,15 +7337,15 @@
     "reference-description": "Open cars for chairlift",
     "description": "Subĉielaj ĉaroj por seĝlifto",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.ww.skidoo": {
     "reference-name": "Skidoo Dodgems",
-    "name": "Motorsledo-Albatiĝantaj-Ĉaroj",
+    "name": "Motorsledoformaj Albatiĝantaj Ĉaroj",
     "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
     "description": "Gastoj glitas en motorsledoformaj veturiloj, kiujn ili stiras libere",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.smskull": {
     "reference-name": "Skull",
@@ -7417,23 +7417,23 @@
   },
   "rct2.ww.sbskys03": {
     "reference-name": "Skyscraper Lift Piece",
-    "name": "Liftparto de Ĉielskrapanto"
+    "name": "Liftoparto de Ĉielskrapanto"
   },
   "rct2.ww.sbskys04": {
     "reference-name": "Skyscraper Lift Piece",
-    "name": "Liftparto de Ĉielskrapanto"
+    "name": "Liftoparto de Ĉielskrapanto"
   },
   "rct2.ww.wskysc05": {
     "reference-name": "Skyscraper Lift Section Piece",
-    "name": "Parto de Liftparto de Ĉielskrapanto"
+    "name": "Parto de Liftoparto de Ĉielskrapanto"
   },
   "rct2.ww.wskysc07": {
     "reference-name": "Skyscraper Lift Section Piece",
-    "name": "Parto de Liftparto de Ĉielskrapanto"
+    "name": "Parto de Liftoparto de Ĉielskrapanto"
   },
   "rct2.ww.wskysc04": {
     "reference-name": "Skyscraper Lift Section Piece",
-    "name": "Parto de Liftparto de Ĉielskrapanto"
+    "name": "Parto de Liftoparto de Ĉielskrapanto"
   },
   "rct2.ww.sbskys06": {
     "reference-name": "Skyscraper Metal Set 1 Concave Piece",
@@ -7481,7 +7481,7 @@
     "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, konsistas el bradipoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.mamthw06": {
     "reference-name": "Small Angled Mammoth Fence",
@@ -7521,7 +7521,7 @@
     "reference-description": "Small monorail cars with open sides",
     "description": "Malgrandaj monorelaj ĉaroj kun subĉielaj flankoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.1x1jugt2": {
     "reference-name": "Small Rainforest Tree 1",
@@ -7605,7 +7605,7 @@
     "reference-description": "Single cars shaped like a soap box",
     "description": "Individuaj ĉaroj, kiuj havas la formon de sapskatolo",
     "reference-capacity": "4 riders per car",
-    "capacity": "Po 4 rajdantoj por aŭto"
+    "capacity": "Po 4 rajdantoj por ĉaro"
   },
   "rct2.tt.softoyst": {
     "reference-name": "Soft Toy Stall",
@@ -7747,7 +7747,7 @@
     "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
     "description": "Musoformaj ĉaroj, kiuj milde turniĝadas por malorienti la rajdantojn",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.spdrcr": {
     "reference-name": "Spiral Roller Coaster Trains",
@@ -7755,7 +7755,7 @@
     "reference-description": "Compact roller coaster trains with cars with in-line seating",
     "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.hskelt": {
     "reference-name": "Spiral Slide",
@@ -7781,7 +7781,7 @@
     "reference-description": "Powered vehicles in the shape of sports cars",
     "description": "Ŝaltitaj veturiloj formitaj kiel sportaŭtoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.scgsport": {
     "reference-name": "Sports Themeing",
@@ -7797,7 +7797,7 @@
     "reference-description": "Russian satellite-shaped cars which swing from the rail above",
     "description": "Rusaj satelitoformaj ĉaroj, kiuj svingiĝas sub la relo supere",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.tsq": {
     "reference-name": "Squirrel Shaped Tree",
@@ -7809,7 +7809,7 @@
     "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
     "description": "Individuaj ĉaroj de onda fervojo formitaj kiel diliĝenco, kun komforta seĝoj kaj sinobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.stamphrd": {
     "reference-name": "Stampeding Herd Trains",
@@ -7817,7 +7817,7 @@
     "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
     "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio, temita por aspekti kiel kureganta dinosaŭra grego",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.togst": {
     "reference-name": "Stand-up Roller Coaster Trains",
@@ -7825,7 +7825,7 @@
     "reference-description": "Roller coaster trains in which the riders ride in a standing position",
     "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.bmsu": {
     "reference-name": "Stand-up Twister Trains",
@@ -7833,7 +7833,7 @@
     "reference-description": "A train with shoulder restraints, in which the riders stand up",
     "description": "Trajno kun ŝultrobridoj, en kiuj la rajdantoj stariĝas",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.starfrdr": {
     "reference-name": "Star Fruit Drink Stall",
@@ -7919,7 +7919,7 @@
   },
   "rct2.tt.4x4stnhn": {
     "reference-name": "Stone Age Temple",
-    "name": "Stone Age Temple"
+    "name": "Ŝtonepoka Templo"
   },
   "rct2.benchstn": {
     "reference-name": "Stone Bench",
@@ -7983,7 +7983,7 @@
     "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
     "description": "Grandspacaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
     "reference-capacity": "5 or 10 passengers per car",
-    "capacity": "Po 5 aŭ 10 pasaĝeroj por aŭto"
+    "capacity": "Po 5 aŭ 10 pasaĝeroj por ĉaro"
   },
   "rct1.ll.edge.green": {
     "reference-name": "Stucco (Green)",
@@ -8069,7 +8069,7 @@
     "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
     "description": "Larĝaj trajnoj de onda fervojo, sur kiuj rajdantoj staras sur surfotabulo kun speciale desegnitaj sinobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.smono": {
     "reference-name": "Suspended Monorail Trains",
@@ -8077,7 +8077,7 @@
     "reference-description": "Large capacity monorail train cars",
     "description": "Grandspacaj monorelaj trajnoĉaroj",
     "reference-capacity": "8 passengers per car",
-    "capacity": "Po 8 pasaĝeroj por aŭto"
+    "capacity": "Po 8 pasaĝeroj por ĉaro"
   },
   "rct2.tt.seaplane": {
     "reference-name": "Suspended Seaplane Cars",
@@ -8085,7 +8085,7 @@
     "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el hidroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.arrsw2": {
     "reference-name": "Suspended Swinging Aeroplane Cars",
@@ -8093,7 +8093,7 @@
     "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el aeroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.arrsw1": {
     "reference-name": "Suspended Swinging Cars",
@@ -8101,7 +8101,7 @@
     "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.sb1hspb1": {
     "reference-name": "Suspension Bridge Base Piece",
@@ -8189,7 +8189,7 @@
     "reference-description": "Small cars which swing from the rail above",
     "description": "Malgrandaj ĉaroj, kiuj svingiĝas sub la relo supere",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.vekvamp": {
     "reference-name": "Swinging Floorless Cars",
@@ -8197,7 +8197,7 @@
     "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
     "description": "Penditaj trajnoj de onda fervojo, kiu enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkau anguloj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.swsh2": {
     "reference-name": "Swinging Inverter Ship",
@@ -8223,7 +8223,7 @@
     "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
     "description": "Trajnoj de onda fervojo en la stilo de francaj rapidaj trajnoj (TGV), kiuj akceliĝas per liniaj induktaj motoroj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.tnt2": {
     "reference-name": "TNT Barrels",
@@ -8471,7 +8471,7 @@
     "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
     "description": "Sledformaj ĉaroj de onda fervojo kun kolono da seĝoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.mktstal1": {
     "reference-name": "Toffee Apple Market Stall",
@@ -8537,7 +8537,7 @@
     "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
     "description": "Trajnoj de onda fervojo, kiu havas formon de replikaĵaj Trabant aŭtoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.trckprt5": {
     "reference-name": "Track Bend",
@@ -8573,7 +8573,7 @@
     "reference-description": "Old-timer replica trams",
     "description": "Eksmoda replikaĵa tramoj",
     "reference-capacity": "10 passengers per car",
-    "capacity": "Po 10 pasaĝeroj por aŭto"
+    "capacity": "Po 10 pasaĝeroj por ĉaro"
   },
   "rct2.tt.travlr01": {
     "reference-name": "Traveller Van",
@@ -8709,7 +8709,7 @@
     "reference-description": "Riders lock horns with each other in triceratops dodgems",
     "description": "Rajdantoj ŝlosas kornojn kun unu la alian en triceratopaj aŭtetoj",
     "reference-capacity": "1 person per car",
-    "capacity": "Po 1 ulo por aŭto"
+    "capacity": "Po 1 ulo por ĉaro"
   },
   "rct2.tt.trilobte": {
     "reference-name": "Trilobite Boats",
@@ -8833,7 +8833,7 @@
     "reference-description": "Roller coaster cars capable of heartline twists",
     "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.utcarr": {
     "reference-name": "Twister Cars (starting reversed)",
@@ -8841,7 +8841,7 @@
     "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
     "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, startanta inversigita",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.bmsd": {
     "reference-name": "Twister Trains",
@@ -8849,7 +8849,7 @@
     "reference-description": "Spacious trains with shoulder restraints",
     "description": "Grandspacaj trajnoj kun ŝultrobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.alencrsh": {
     "reference-name": "UFO Crash Site",
@@ -8881,7 +8881,7 @@
     "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
     "description": "Trajnoj de onda fervojo kun temo de valkiroj kaj ekstra-larĝaj ĉaroj. La trajnoj estis konstruitaj por vertikalaj faloj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.ssig3": {
     "reference-name": "Vertical 3D Sign",
@@ -8893,11 +8893,11 @@
     "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
     "description": "Grandaj ĉaroj de onda fervojo, en kiu rajdantoj sidas en seĝoj penditaj sub la trako",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ww.1x1atre2": {
     "reference-name": "Vine Tree",
-    "name": "Vito-Arbo"
+    "name": "Vitoarbo"
   },
   "rct2.vcr": {
     "reference-name": "Vintage Cars",
@@ -8905,7 +8905,7 @@
     "reference-description": "Powered vehicles in the shape of vintage cars",
     "description": "Ŝaltitaj veturiloj en la formo de malnovaj aŭtoj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.vreel": {
     "reference-name": "Virginia Reel Tubs",
@@ -8913,7 +8913,7 @@
     "reference-description": "Circular cars that spin around as they travel along the track",
     "description": "Rondaj ĉaroj, kiuj turniĝante veturas laŭ la trako",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "openrct2.terrain.void": {
     "reference-name": "Void",
@@ -9185,7 +9185,7 @@
   },
   "rct2.tww": {
     "reference-name": "Weeping Willow Tree",
-    "name": "Plorsaliko-Arbo"
+    "name": "Plorsalikoarbo"
   },
   "rct2.tmw": {
     "reference-name": "Wheels",
@@ -9217,7 +9217,7 @@
   },
   "rct2.twp": {
     "reference-name": "White Poplar Tree",
-    "name": "Blanka Poplo-Arbo"
+    "name": "Blanka Poploarbo"
   },
   "rct2.tq1": {
     "reference-name": "White Queen",
@@ -9261,11 +9261,11 @@
   },
   "rct2.ww.sbwind19": {
     "reference-name": "Wind Sculpted Floor Piece",
-    "name": "Vento-Skulptita Plankpeco"
+    "name": "Vento-Skulptita Plankparto"
   },
   "rct2.ww.sbwind18": {
     "reference-name": "Wind Sculpted Floor Piece",
-    "name": "Vento-Skulptita Plankpeco"
+    "name": "Vento-Skulptita Plankparto"
   },
   "rct2.ww.sbwind07": {
     "reference-name": "Wind Sculpted Rock Formation Base",
@@ -9301,15 +9301,15 @@
   },
   "rct2.ww.sbwind16": {
     "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-    "name": "Vento-Skulptita Tegmento - Plata Tegmentero"
+    "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
   },
   "rct2.ww.sbwind17": {
     "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-    "name": "Vento-Skulptita Tegmento - Plata Tegmentero"
+    "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
   },
   "rct2.ww.sbwind15": {
     "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-    "name": "Vento-Skulptita Tegmento - Plata Tegmentero"
+    "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
   },
   "rct2.ww.sbwind20": {
     "reference-name": "Wind Sculpted Wall Base",
@@ -9367,7 +9367,7 @@
     "reference-description": "Roller coaster trains with small grub-shaped cars",
     "description": "Trajnoj de onda fervojo kun malgrandaj larvoformaj ĉaroj",
     "reference-capacity": "2 passengers per car",
-    "capacity": "Po 2 pasaĝeroj por aŭto"
+    "capacity": "Po 2 pasaĝeroj por ĉaro"
   },
   "rct2.scgwond": {
     "reference-name": "Wonderland Themeing",
@@ -9505,7 +9505,7 @@
     "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
     "description": "Trajnoj de ligna onda fervojo kun komfortaj seĝoj kaj sinobridoj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.ptct2": {
     "reference-name": "Wooden Roller Coaster Trains (6 seater)",
@@ -9513,7 +9513,7 @@
     "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
     "description": "Trajnoj de ligna onda fervojo kun komfortaj seĝoj kaj sinobridoj",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.ptct2r": {
     "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
@@ -9521,7 +9521,7 @@
     "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
     "description": "Lignaj trajnoj de onda fervojo kun komfortaj seĝoj kaj sinobridoj, kiu havas inversigitajn seĝojn",
     "reference-capacity": "6 passengers per car",
-    "capacity": "Po 6 pasaĝeroj por aŭto"
+    "capacity": "Po 6 pasaĝeroj por ĉaro"
   },
   "rct2.sfric1": {
     "reference-name": "Wooden Side-Friction Cars",
@@ -9529,7 +9529,7 @@
     "reference-description": "Basic cars for the Side-Friction Roller Coaster",
     "description": "Bazaj ĉaroj por la Ligna Onda Fervojo kun Flanka Froto",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.bn5": {
     "reference-name": "Wooden Sign",
@@ -9561,11 +9561,11 @@
     "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
     "description": "Trajnoj por la Altega Onda Fervojo, kiuj estis temitaj por aspekti kiel longaj flavaj taksioj",
     "reference-capacity": "4 passengers per car",
-    "capacity": "Po 4 pasaĝeroj por aŭto"
+    "capacity": "Po 4 pasaĝeroj por ĉaro"
   },
   "rct2.tt.yewtreex": {
     "reference-name": "Yew Tree",
-    "name": "Taksuso-Arbo"
+    "name": "Taksusoarbo"
   },
   "rct2.ww.afrzebra": {
     "reference-name": "Zebra",


### PR DESCRIPTION
This commit kind of marks the start of the editing and refining process

Let's get the largest tasks out of the way first:

- Standardize format of tree names for most trees
- Use "por ĉaro" instead of "por aŭto" for most ride capacity labels
- Use "parto" instead of "peco" or "ero"
- Verify 100% of objects translated (only 4 purposely same entries, not bad)