### PR TITLE
eo-OO: Use el/da instead of de

### DIFF
--- a/data/language/eo-OO.txt
+++ b/data/language/eo-OO.txt
@@ -1725,10 +1725,10 @@ STR_2374    :Alta
 STR_2375    :Tre Alta
 STR_2376    :Ekstrema
 STR_2377    :Ultra-Ekstrema
-STR_2378    :{SMALLFONT}{BLACK}Agordi pli malgrandan areon de tero
-STR_2379    :{SMALLFONT}{BLACK}Agordi pli grandan areon de tero
-STR_2380    :{SMALLFONT}{BLACK}Agordi pli malgrandan areon de akvo
-STR_2381    :{SMALLFONT}{BLACK}Agordi pli grandan areon de akvo
+STR_2378    :{SMALLFONT}{BLACK}Agordi pli malgrandan areon da tero
+STR_2379    :{SMALLFONT}{BLACK}Agordi pli grandan areon da tero
+STR_2380    :{SMALLFONT}{BLACK}Agordi pli malgrandan areon da akvo
+STR_2381    :{SMALLFONT}{BLACK}Agordi pli grandan areon da akvo
 STR_2382    :Tero
 STR_2383    :Akvo
 STR_2384    :{WINDOW_COLOUR_2}Via celo:
@@ -4152,10 +4152,10 @@ STR_NAME    :Vitra Tegmento
 STR_NAME    :Vitra Tegmento
 
 [ACWW33]
-STR_NAME    :Muro de Lignaj Fostoj
+STR_NAME    :Muro el Lignaj Fostoj
 
 [ACWWF32]
-STR_NAME    :Muro de Lignaj Fostoj
+STR_NAME    :Muro el Lignaj Fostoj
 
 ## End OpenRCT2 Official
 

--- a/objects/eo-OO.json
+++ b/objects/eo-OO.json
@@ -445,7 +445,7 @@
   },
   "rct2.ww.antilopp": {
     "reference-name": "Antelope Pair",
-    "name": "Duo de Antilopoj"
+    "name": "Duo da Antilopoj"
   },
   "rct2.tt.fltsign2": {
     "reference-name": "Anti-Gravity LCD Billboard",
@@ -595,7 +595,7 @@
   },
   "rct2.pathash": {
     "reference-name": "Ash Footpath",
-    "name": "Trotuaro de Cindropovo"
+    "name": "Trotuaro el Cindropovo"
   },
   "rct2.tt.ashnymph": {
     "reference-name": "Ash Tree with Nymphs",
@@ -3767,7 +3767,7 @@
   },
   "rct2.sip": {
     "reference-name": "Ice Palace",
-    "name": "Palaco de Glacio"
+    "name": "Palaco el Glacio"
   },
   "rct2.ww.iceent": {
     "reference-name": "Ice Park Entrance",
@@ -3775,79 +3775,79 @@
   },
   "rct2.ww.pipebase": {
     "reference-name": "Ice Pipe Base",
-    "name": "Tubobazo de Glacio"
+    "name": "Tubobazo el Glacio"
   },
   "rct2.ww.vertpipe": {
     "reference-name": "Ice Pipe Section",
-    "name": "Tuboparto de Glacio"
+    "name": "Tuboparto el Glacio"
   },
   "rct2.ww.pipevent": {
     "reference-name": "Ice Pipe Vent",
-    "name": "Tubo-Eligejo de Glacio"
+    "name": "Tubo-Eligejo el Glacio"
   },
   "rct2.ww.roofice6": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.roofice2": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.roofice5": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.roofice3": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.roofice1": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.roofice4": {
     "reference-name": "Ice Roof",
-    "name": "Tegmento de Glacio"
+    "name": "Tegmento el Glacio"
   },
   "rct2.ww.wallice9": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice8": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice4": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice1": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice5": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice2": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice7": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice3": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallic10": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.ww.wallice6": {
     "reference-name": "Ice Wall",
-    "name": "Muro de Glacio"
+    "name": "Muro el Glacio"
   },
   "rct2.music.ice": {
     "reference-name": "Ice style",
@@ -4207,7 +4207,7 @@
   },
   "rct2.walljb16": {
     "reference-name": "Jellybean Wall",
-    "name": "Muro de Ĝelateno-Faboj"
+    "name": "Muro el Ĝelateno-Faboj"
   },
   "rct2.tt.jetplan1": {
     "reference-name": "Jet Aeroplane",
@@ -5353,39 +5353,39 @@
   },
   "rct2.ww.rmud05": {
     "reference-name": "Mud Roof Piece",
-    "name": "Parto de Kot-Tegmento"
+    "name": "Parto de Tegmento el Koto"
   },
   "rct2.ww.wmud08": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Tegmento el Koto"
   },
   "rct2.ww.wmud04": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud02": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud06": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud03": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud07": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud05": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.ww.wmud01": {
     "reference-name": "Mud Wall Piece",
-    "name": "Parto de Kotmuro"
+    "name": "Parto de Muro el Koto"
   },
   "rct2.arrx": {
     "reference-name": "Multi-Dimension Coaster Trains",
@@ -6125,11 +6125,11 @@
   },
   "rct2.wcw2": {
     "reference-name": "Playing Card Wall",
-    "name": "Muro de Ludkarto"
+    "name": "Muro el Ludkartoj"
   },
   "rct2.wcw1": {
     "reference-name": "Playing Card Wall",
-    "name": "Muro de Ludkarto"
+    "name": "Muro el Ludkartoj"
   },
   "rct2.romroof2": {
     "reference-name": "Plinth",
@@ -9485,19 +9485,19 @@
   },
   "rct2.wallwdps": {
     "reference-name": "Wooden Post Fence",
-    "name": "Barilo de Lignaj Fostoj"
+    "name": "Barilo el Lignaj Fostoj"
   },
   "rct2.wpw2": {
     "reference-name": "Wooden Post Wall",
-    "name": "Muro de Lignaj Fostoj"
+    "name": "Muro el Lignaj Fostoj"
   },
   "rct2.wc18": {
     "reference-name": "Wooden Post Wall",
-    "name": "Muro de Lignaj Fostoj"
+    "name": "Muro el Lignaj Fostoj"
   },
   "rct2.wpw1": {
     "reference-name": "Wooden Post Wall",
-    "name": "Muro de Lignaj Fostoj"
+    "name": "Muro el Lignaj Fostoj"
   },
   "rct2.ptct1": {
     "reference-name": "Wooden Roller Coaster Trains",


### PR DESCRIPTION
Learned at the last minute that `<object> of <material>` should use el rather than de.
Blessed regex + find next functionality