### PR TITLE
de-DE: Add missing OpenRCT2 scenery strings

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -4103,6 +4103,59 @@ STR_SCNR    :Fort Anachronism
 STR_PARK    :Fort Anachronism
 STR_DTLS    :
 
+###########
+# Scenery #
+###########
+
+## Start OpenRCT2 Official
+
+[TTPIRF02]
+STR_NAME    :Dach
+
+[TTPIRF03]
+STR_NAME    :Dach
+
+[TTPIRF04]
+STR_NAME    :Dach
+
+[TTPIRF05]
+STR_NAME    :Dach
+
+[TTPIRF07]
+STR_NAME    :Dach
+
+[TTPIRF08]
+STR_NAME    :Dach
+
+[TTRFWD01]
+STR_NAME    :Dach
+
+[TTRFWD02]
+STR_NAME    :Dach
+
+[TTRFWD03]
+STR_NAME    :Dach
+
+[TTRFWD04]
+STR_NAME    :Dach
+
+[TTRFWD05]
+STR_NAME    :Dach
+
+[TTRFWD06]
+STR_NAME    :Dach
+
+[TTRFWD07]
+STR_NAME    :Dach
+
+[TTRFWD08]
+STR_NAME    :Dach
+
+[TTRFGL01]
+STR_NAME    :Glasdach
+
+## End of OpenRCT2 Official
+
 ###############################################################################
 ## RCT2 Scenarios
 ###############################################################################


### PR DESCRIPTION
This adds translations for the OpenRCT2 scenery stuff.