### PR TITLE
ko-KR: Fix a translation

### DIFF
--- a/objects/ko-KR.json
+++ b/objects/ko-KR.json
@@ -5897,7 +5897,7 @@
   },
   "official.scgpanda": {
     "reference-name": "Panda Theming",
-    "name": "판다 테마 공원"
+    "name": "판다 테마"
   },
   "official.zpanda": {
     "reference-name": "Panda Trains",


### PR DESCRIPTION
Fix that there is no ``공원``(park) in the original string.