### PR TITLE
Add .DS_Store and result.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # en-GB is maintained in main repository
 data/language/en-GB.txt
 
+# File resulting from running translation_check.py locally 
+result.md
+
 # Visual Studio
 .vs
 *.user
@@ -17,3 +20,6 @@ cmake-build-debug
 
 # IntelliJ IDEA
 *.iml
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adds two commonly generated files to the `.gitignore`

- `.DS_Store` which macOS generates several of in various folders to store folder attributes
- `result.md` which is produced by the `translation_check.py` script when run locally as described in the project readme