### PR TITLE
ko-KR: Apply #2199

### DIFF
--- a/data/language/ko-KR.txt
+++ b/data/language/ko-KR.txt
@@ -3654,6 +3654,8 @@ STR_6450    :{BLACK}“{STRING}”
 STR_6451    :{BLACK}“{STRING}” - {STRING}
 STR_6452    :{WINDOW_COLOUR_2}판매: {BLACK}{STRING}
 STR_6453    :버전 정보 복사
+STR_6454    :팻말 이름을 변경할 수 없습니다…
+STR_6455    :팻말 이름을 변경할 수 없습니다…
 
 #############
 # Scenarios #


### PR DESCRIPTION
Applying for issue(s):
- #2199

Currently Korean both uses the same word, ``팻말`` as translations of ``banner`` and ``sign``.