### PR TITLE
es-ES: Apply #2165 and fix some BREAKING leftover english strings

### DIFF
--- a/data/language/es-ES.txt
+++ b/data/language/es-ES.txt
@@ -3386,7 +3386,7 @@ STR_6157    :Consola
 STR_6158    :No se pudo cargar este archivo…{NEWLINE}Versión RCT incompatible: {COMMA16}
 STR_6159    :Próximo Suave
 STR_6160    :{WINDOW_COLOUR_2}Vehículos Disponibles: {BLACK}{STRING}
-STR_6161    :Alternar Líneas de Cuadrícula
+STR_6161    :Alternar líneas de cuadrícula
 STR_6162    :Ratón Giratorio Salvaje
 STR_6163    :Carros con forma de ratón atraviesan giros cerrados y caídas cortas, mientras giran gentilmente para desorientar a los pasajeros.
 STR_6164    :{WHITE}❌
@@ -3613,7 +3613,7 @@ STR_6409    :El archivo seleccionado no es el Instalador sin conexión de GOG pa
 STR_6436    :Activar/desactivar invisibilidad
 STR_6437    :Invisible
 STR_6438    :I
-STR_6439    :Inspector de casillas: Activar/desactivar invisibilidad
+STR_6439    :Inspector de cuadrícula: Activar/desactivar invisibilidad
 STR_6454    :No se puede cambiar el nombre del banner…
 STR_6455    :No se puede cambiar el nombre del señal…
 STR_6456    :Captura de pantalla gigante


### PR DESCRIPTION
Applying for issue(s):
- #2165
- Also fixed STR_6404 and STR_6408 which had some leftover english strings (breaking them)
