### PR TITLE
fr-FR: Apply #2243

### DIFF
--- a/data/language/fr-FR.txt
+++ b/data/language/fr-FR.txt
@@ -3663,6 +3663,8 @@ STR_6455    :Impossible de renommer le panneau…
 STR_6456    :Capture d’écran géante
 STR_6457    :Signaler un bug sur GitHub
 STR_6458    :Suivre sur la vue principale
+STR_6460    :O
+STR_6461    :Orientation
 
 #############
 # Scenarios #


### PR DESCRIPTION
French "Direction" couldn't be used as the "D" initial is already used in the inspector window. "Orientation" in this context is synonymous.

Applying for issue(s):
- #2243 
