### PR TITLE
fr-FR: Apply #2251

### DIFF
--- a/data/language/fr-FR.txt
+++ b/data/language/fr-FR.txt
@@ -2244,7 +2244,7 @@ STR_3185    :Petit décor
 STR_3186    :Grand décor
 STR_3187    :Murs/Clôtures
 STR_3188    :Panneaux de direction
-STR_3189    :Allées
+STR_3189    :Allées classiques
 STR_3190    :Suppléments allées
 STR_3191    :Groupes de décor
 STR_3192    :Entrée du parc


### PR DESCRIPTION
There's no good translation for "legacy" in French. I chose "classique" to denote the old way of doing it.

Applying for issue(s):
- #2251
