### PR TITLE
eo-ZZ: Minor fix for string 6493

### DIFF
--- a/data/language/eo-ZZ.txt
+++ b/data/language/eo-ZZ.txt
@@ -3685,7 +3685,7 @@ STR_6489    :Eraro: Malkongrua Versio de Parko
 STR_6490    :Averto: Parte Kongrua Versio de Parko
 STR_6491    :Ĉi tiu parko estis konservita en pli nova versio de OpenRCT2. Parko estas v{INT32} kaj bezonas almenaŭ v{INT32}.
 STR_6492    :Ĉi tiu parko estis konservita en malnova versio de OpenRCT2, kaj ne povas esti malfermita per ĉi tiu versio de OpenRCT2. Parko estas v{INT32}.
-STR_6493    :Ĉi tiu parko estis konservita en pli nova versio de OpenRCT2, kelkaj datumoj eble estos perditaj. Parko estas v{INT32} kaj bezonas almenaŭ v{INT32}.
+STR_6493    :Ĉi tiu parko estis konservita en pli nova versio de OpenRCT2, kelkaj datumoj eble estas perditaj. Parko estas v{INT32} kaj bezonas almenaŭ v{INT32}.
 
 #############
 # Scenarios #


### PR DESCRIPTION
<!--
If you are applying translations for an issue (or multiple), please list them below
-->

My assumption for string 6493 was that it was shown before loading and thus "some data may be lost" was future tense, but I was recently informed that it actually shows _after_ loading, so I've fixed the tense for one of the words to be more accurate.