### PR TITLE
Close #2315: Stop tracking language and maintainers >6mo inactive

### DIFF
--- a/.github/ISSUE_TEMPLATE/changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/changed_field_template.md
@@ -38,4 +38,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @rzhao271 @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @izhangfei @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr

--- a/.github/ISSUE_TEMPLATE/changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/changed_field_template.md
@@ -38,4 +38,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @dimateos @groenroos @rmnvgr @LucaRed @telk5093 @Goddesen @Gymnasiast @marcinkunert @Tupaschoal @daihakken

--- a/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
@@ -44,4 +44,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @rzhao271 @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @izhangfei @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr

--- a/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_and_changed_field_template.md
@@ -44,4 +44,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @dimateos @groenroos @rmnvgr @LucaRed @telk5093 @Goddesen @Gymnasiast @marcinkunert @Tupaschoal @daihakken

--- a/.github/ISSUE_TEMPLATE/new_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_field_template.md
@@ -38,4 +38,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @octaroot @LPSGizmo @danidoedel @Wuzzy2 @tellovishous @rzhao271 @anon569 @LucaRed @AaronVanGeffen @telk5093 @Goddesen @Gymnasiast @renansimoes @Tupaschoal @izhangfei @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr

--- a/.github/ISSUE_TEMPLATE/new_field_template.md
+++ b/.github/ISSUE_TEMPLATE/new_field_template.md
@@ -38,4 +38,4 @@ Updated in:
 - [ ] zh-TW
 
 Notification when new strings arrive:
-@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @anon569 @LucaRed @telk5093 @Goddesen @Gymnasiast @Tupaschoal @daihakken @marcinkunert @groenroos @dimateos @rmnvgr
+@Omaranwa @J0anJosep @LPSGizmo @Wuzzy2 @tellovishous @dimateos @groenroos @rmnvgr @LucaRed @telk5093 @Goddesen @Gymnasiast @marcinkunert @Tupaschoal @daihakken

--- a/README.md
+++ b/README.md
@@ -45,28 +45,28 @@ To do this, go to the directory where OpenRCT2 resides (not to be confused with 
 |-----------------------------------------------------------------------------------------------------------------------------------------------| ---------- |
 | [![](https://img.shields.io/badge/ar--EG-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ar-EG.txt) | [Omaranwa](https://github.com/Omaranwa)          |
 | [![](https://img.shields.io/badge/ca--ES-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ca-ES.txt) | [J0anJosep](https://github.com/J0anJosep)          |
-| [![](https://img.shields.io/badge/cs--CZ-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/cs-CZ.txt) | [octaroot](https://github.com/octaroot)            |
 | [![](https://img.shields.io/badge/da--DK-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/da-DK.txt) | [LPSGizmo](https://github.com/LPSGizmo)          |
-| [![](https://img.shields.io/badge/de--DE-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/de-DE.txt) | [danidoedel](https://github.com/danidoedel), [Wuzzy2](https://github.com/Wuzzy2)        |
+| [![](https://img.shields.io/badge/de--DE-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/de-DE.txt) | [Wuzzy2](https://github.com/Wuzzy2)        |
 | [![](https://img.shields.io/badge/en--GB-maintained-green.svg)](https://github.com/OpenRCT2/OpenRCT2/blob/develop/data/language/en-GB.txt   ) | -Anyone-                                           |
-| [![](https://img.shields.io/badge/eo--ZZ-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/eo-ZZ.txt)  | [tellovishous](https://github.com/tellovishous), [rzhao271](https://github.com/rzhao271) |
+| [![](https://img.shields.io/badge/eo--ZZ-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/eo-ZZ.txt)  | [tellovishous](https://github.com/tellovishous) |
 | [![](https://img.shields.io/badge/es--ES-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/es-ES.txt) | [dimateos](https://github.com/dimateos) 		|
 | [![](https://img.shields.io/badge/fi--FI-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/fi-FI.txt) | [groenroos](https://github.com/groenroos)          |
 | [![](https://img.shields.io/badge/fr--FR-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/fr-FR.txt) | [rmnvgr](https://github.com/rmnvgr) |
-| [![](https://img.shields.io/badge/hu--HU-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/hu-HU.txt) | [anon569](https://github.com/anon569)              |
 | [![](https://img.shields.io/badge/it--IT-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/it-IT.txt) | [LucaRed](https://github.com/LucaRed)              |
-| [![](https://img.shields.io/badge/ja--JP-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ja-JP.txt) | [AaronVanGeffen](https://github.com/AaronVanGeffen)|
 | [![](https://img.shields.io/badge/ko--KR-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ko-KR.txt) | [telk5093](https://github.com/telk5093)            |
 | [![](https://img.shields.io/badge/nb--NO-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/nb-NO.txt) | [Goddesen](https://github.com/Goddesen)            |
 | [![](https://img.shields.io/badge/nl--NL-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/nl-NL.txt) | [Gymnasiast](https://github.com/Gymnasiast )      |
 | [![](https://img.shields.io/badge/pl--PL-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/pl-PL.txt) | [marcinkunert](https://github.com/marcinkunert) |
-| [![](https://img.shields.io/badge/pt--BR-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/pt-BR.txt) | [renansimoes](https://github.com/renansimoes), [Tupaschoal](https://github.com/Tupaschoal)      |
-| [![](https://img.shields.io/badge/sv--SE-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/sv-SE.txt) | [galfisk](https://github.com/galfisk)                |
-| [![](https://img.shields.io/badge/zh--CN-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/zh-CN.txt) | [izhangfei](https://github.com/izhangfei)          |
+| [![](https://img.shields.io/badge/pt--BR-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/pt-BR.txt) | [Tupaschoal](https://github.com/Tupaschoal)      |
+| [![](https://img.shields.io/badge/zh--CN-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/zh-CN.txt) | |
 | [![](https://img.shields.io/badge/zh--TW-maintained-green.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/zh-TW.txt) | [daihakken](https://github.com/daihakken)         |
-| Not maintained <!-- Languages that are outdated with strings missing from OpenRCT2/vanilla-->                                                 | |                                                 
-| [![](https://img.shields.io/badge/tr--TR-outdated-yellow.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/tr-TR.txt)  |                                                    |
-| [![](https://img.shields.io/badge/ru--RU-outdated-red.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ru-RU.txt)     |                                                    |
+| Not maintained <!-- Languages that are outdated with strings missing from OpenRCT2/vanilla--> ||
+| [![](https://img.shields.io/badge/hu--HU-outdated-yellow.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/hu-HU.txt) ||
+| [![](https://img.shields.io/badge/sv--SE-outdated-yellow.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/sv-SE.txt) ||
+| [![](https://img.shields.io/badge/cs--CZ-outdated-red.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/cs-CZ.txt) ||
+| [![](https://img.shields.io/badge/ja--JP-outdated-red.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ja-JP.txt) ||
+| [![](https://img.shields.io/badge/ru--RU-outdated-red.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/ru-RU.txt) ||
+| [![](https://img.shields.io/badge/tr--TR-outdated-red.svg)](https://github.com/OpenRCT2/Localisation/blob/master/data/language/tr-TR.txt) ||
 
 | en-US only contains strings that differ from en-GB <!--en-US doesn't get updated more than it's needed-->           
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
This applies the suggestion I gave in #2315. I've made separate commits for >1y inactivity and >6mo inactivity, but personally I think we should go for 6mo tracking, as it seems enough time.

Once (if) this is merged, I can go after all issues to check those languages out and close if all active are fulfilled.