### PR TITLE
Update it-IT.txt

### DIFF
--- a/data/language/it-IT.txt
+++ b/data/language/it-IT.txt
@@ -1685,7 +1685,7 @@ STR_2329    :{WINDOW_COLOUR_2}Distanze e velocità:
 STR_2330    :{WINDOW_COLOUR_2}Temperatura:
 STR_2331    :{WINDOW_COLOUR_2}Indicazioni altezza:
 STR_2332    :Unità
-STR_2333    :Impostazioni audio
+STR_2333    :Effetti sonori
 STR_2334    :Sterline (£)
 STR_2335    :Dollari ($)
 STR_2336    :Franchi (F)


### PR DESCRIPTION
Fixed wrong translation of STR_2333 in Italian.

"Sound effects" was erroneously translated as "Impostazioni audio" which means "Sound settings" instead, so I changed it into "Effetti sonori" that is the correct translation.

Before:

![image](https://user-images.githubusercontent.com/8672431/185758535-d3d6341d-d763-43a6-9a01-9f7c875ea60c.png)

After:

![image](https://user-images.githubusercontent.com/8672431/185758569-7aa5da72-62d5-4322-a2a1-64b82b13a525.png)