### PR TITLE
Objects en-US Grey > Gray

### DIFF
--- a/objects/en-US.json
+++ b/objects/en-US.json
@@ -2549,7 +2549,7 @@
     },
     "rct2.footpath_railings.concrete": {
         "reference-name": "Concrete Railings (Grey-Brown)",
-        "name": "Concrete Railings (Grey-Brown)"
+        "name": "Concrete Railings (Gray-Brown)"
     },
     "rct2.audio.base": {
         "reference-name": "Base audio for the game.",
@@ -9703,7 +9703,7 @@
     },
     "rct1aa.footpath_surface.tiles_grey": {
         "reference-name": "Grey Tiled Footpath",
-        "name": "Grey Tiled Footpath"
+        "name": "Gray Tiled Footpath"
     },
     "rct1.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Square)",
@@ -9751,7 +9751,7 @@
     },
     "rct1ll.terrain_surface.roof_grey": {
         "reference-name": "Roof (Grey)",
-        "name": "Roof (Grey)"
+        "name": "Roof (Gray)"
     },
     "rct1ll.terrain_surface.wood": {
         "reference-name": "Wood",
@@ -9799,7 +9799,7 @@
     },
     "rct1aa.terrain_edge.grey": {
         "reference-name": "Stucco (Grey)",
-        "name": "Stucco (Grey)"
+        "name": "Stucco (Gray)"
     },
     "rct1ll.terrain_edge.purple": {
         "reference-name": "Stucco (Purple)",


### PR DESCRIPTION
I noticed that a few objects still had grey in their name in en-US, this fixes that.
