### PR TITLE
es-ES: Make string 6537 shorter

### DIFF
--- a/data/language/es-ES.txt
+++ b/data/language/es-ES.txt
@@ -3643,7 +3643,7 @@ STR_6533    :{WINDOW_COLOUR_2}Factor de emoción: {BLACK}-{COMMA16}%
 STR_6534    :{WINDOW_COLOUR_2}Factor de intensidad: {BLACK}-{COMMA16}%
 STR_6535    :{WINDOW_COLOUR_2}Factor de náusea: {BLACK}-{COMMA16}%
 STR_6536    :Este parque fue guardado en una versión más reciente de OpenRCT2. Este parque se guardó en la v{INT32}, actualmente estás en la v{INT32}.
-STR_6537    :Permitir el uso de caminos normales como cola
+STR_6537    :Permitir usar caminos normales como cola
 STR_6538    :Muestra caminos normales en el menú desplegable de colas de la ventana Senderos.
 
 ##############


### PR DESCRIPTION
Today I was playing OpenRCT2 and I've noticed that the string 6537 is to long to fit the cheats window, so I've edited the string.

Before:
![image](https://user-images.githubusercontent.com/7508197/209522508-82f2c688-b194-426a-815d-f056881733bc.png)

After:
![image](https://user-images.githubusercontent.com/7508197/209522526-efeb476f-184d-42b3-87f8-9f130ddc7707.png)
