### PR TITLE
Fixing some translation errors in Polish localization

### DIFF
--- a/data/language/pl-PL.txt
+++ b/data/language/pl-PL.txt
@@ -2997,11 +2997,11 @@ STR_5838    :Pokaż osobny przycisk dla okienka Finansów w pasku narzędzi
 STR_5839    :Pokaż osobny przycisk dla okienka Badań i Rozwoju w pasku narzędzi
 STR_5840    :Pokaż osobny przycisk dla okienka kodów w pasku narzędzi
 STR_5841    :Pokaż osobny przycisk dla okienka komunikatów w pasku narzędzi
-STR_5842    :Posortuj scenariusze w zakładkach według trudności (zaszłość RCT2) lub ich źródła (zaszłośćRCT1)
+STR_5842    :Posortuj scenariusze w zakładkach według trudności (zaszłość RCT2) lub ich źródła (zaszłość RCT1)
 STR_5843    :Włącz odblokowywanie scenariuszy (zaszłość RCT1)
 STR_5844    :Pozostań podłączony do gry wieloosobowej{NEWLINE}nawet w przypadku desynchronizacji i błędów połączenia
 STR_5845    :Dodaje przełącznik trybu debugowania{NEWLINE}do paska narzędzi.{NEWLINE}Włącza skrót klawiaturowy do konsoli developerskiej
-STR_5846    :Ustaw częstotliwość zapisy gry OpenRCT2
+STR_5846    :Ustaw częstotliwość zapisu gry OpenRCT2
 STR_5847    :Wybierz sekwencje parków na ekran tytułowy.{NEWLINE}Sekwencje tytułowe z RCT1/2 wymagają zaimportowanych odpowiednich scenariuszy
 STR_5849    :Automatycznie rozlokuj{NEWLINE}nowo zatrudniony personel
 STR_5851    :Ustaw domyślną częstotliwość inspekcji{NEWLINE}na nowych atrakcjach
@@ -3189,7 +3189,7 @@ STR_6034    :{BLACK}{STRING}
 STR_6035    :Proszę wybrać katalog z RCT1
 STR_6036    :Wyczyść
 STR_6037    :Proszę wybrać prawidłowy katalog RCT1
-STR_6038    :Jeżeli masz zainstalowane RCT1, ustaw tę opcję na ścieżkę z której załadowane będą scenariusze, muzyka, etc.
+STR_6038    :Jeżeli masz zainstalowane RCT1, ustaw tę opcję na ścieżkę do owej gry, aby załadować scenariusze, muzykę, etc. z pierwszej części
 STR_6039    :Szybkie niszczenie atrakcji
 STR_6040    :Edytuj Opcje Scenariusza
 STR_6041    :{BLACK}Nie masz zatrudnionych mechaników!
@@ -3305,7 +3305,7 @@ STR_6161    :Przełącz widok siatki
 STR_6162    :Spinning Wild Mouse
 STR_6163    :Pojazdy wyglądające jak myszki, szybko jeżdżą po ciasnych zakrętach i krótkich zjazdach, dodatkowo łagodnie się kręcą przez co dezorientują gości
 STR_6164    :{WHITE}❌
-STR_6165    :Użyj synchronizacji pionowej
+STR_6165    :Synchronizacja pionowa
 STR_6166    :Synchronizuje każdą wyświetlaną klatkę z częstotliwością odświeżania monitora, zapobiegając rozrywaniu ekranu.
 STR_6167    :Zaawansowane
 STR_6168    :Sekwencja tytułowa
@@ -3497,7 +3497,7 @@ STR_6392    :Nie można znaleźć {STRING} w tej ścieżce
 STR_6393    :Wybór celu
 STR_6394    :Cel
 STR_6395    :Utrzymanie
-STR_6396    :Wyłącz wygaszacz ekranu i oszczędzanie energii monitora
+STR_6396    :Wyłącz oszczędzanie energii monitora
 STR_6397    :Jeśli zaznaczone, wygaszacz ekranu i inne funkcje oszczędzania ekranu zostaną wyłączone gdy OpenRCT2 jest uruchomione.
 STR_6398    :Plik zawiera niewspierane typy kolejek. Zaktualizuj do nowszej wersji OpenRCT2..
 STR_6399    :OpenRCT2 wmymaga do działania plików z orginalnego Roller Coaster Tycoon 2.  Ustaw wartość “game_path” w config.ini na folder w którym zostało zainstalowane RollerCoaster Tycoon 2, następnie zrestartuj OpenRCT2.


### PR DESCRIPTION
Fixing some translation errors in Polish localization, like names of the options too long to fit in the window they supposed to fit in or incorrect spelling in autosave interval option.