### PR TITLE
pt-BR: Fix typo on STR_1487

### DIFF
--- a/data/language/pt-BR.txt
+++ b/data/language/pt-BR.txt
@@ -874,7 +874,7 @@ STR_1483    :“Eu me sinto muito mal”
 STR_1484    :“Eu quero ir em algo mais emocionante do que {STRINGID}”
 STR_1485    :“{STRINGID} parece muito intenso para mim”
 STR_1486    :“Eu não terminei meu {STRINGID} ainda”
-STR_1487    :“Só de olhar para {STRINGID} já me sento mal”
+STR_1487    :“Só de olhar para {STRINGID} já me sinto mal”
 STR_1488    :“Eu não vou pagar tudo isso para ir em {STRINGID}”
 STR_1489    :“Eu quero ir para casa”
 STR_1490    :“{STRINGID} tem um preço bom”


### PR DESCRIPTION
<!--
If you are applying translations for an issue (or multiple), please list them below
-->

Fixes typo on STR_1487. 

`sento` is `I sit`, and `sinto` is `I feel`.
