### PR TITLE
de-DE: Fix translation of STR_6497

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -3595,7 +3595,7 @@ STR_6493    :Dieser Park wurde in einer späteren Version von OpenRCT2 gespeiche
 STR_6494    :Nach Fahrgeschäftstyp gruppieren
 STR_6495    :Fahrgeschäfte nach Fahrgeschäftstyp gruppieren, anstatt jedes Fahrzeug separat anzuzeigen.
 STR_6496    :{WINDOW_COLOUR_2}{STRINGID}
-STR_6497    :Klicken Sie auf eine Kachel, um ihre Kachelelemente anzuzeigen.{NEWLINE}Strg + Klick auf Kachel, um sie direkt auszuwählen.
+STR_6497    :Klicken Sie auf eine Kachel, um ihre Kachelelemente anzuzeigen.{NEWLINE}Strg + Klick auf ein Kachelelement, um es direkt auszuwählen.
 STR_6498    :Aktivieren, um quadratische Kartenform beizubehalten.
 STR_6499    :Fahrzeugtyp nicht vom Streckendesignformat unterstüzt
 STR_6500    :Streckenelemente nicht vom Streckendesignformat unterstüzt


### PR DESCRIPTION
STR_6497 is:
Click on a tile to show its tile elements.{NEWLINE}Ctrl + click a tile element to select it directly.

The previous german translation said:
Click on a tile to show its tile elements.{NEWLINE}Ctrl + click a tile to select it directly.