### PR TITLE
de-DE: Fix typo

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -147,7 +147,7 @@ STR_0560    :
 STR_0561    :
 STR_0562    :Angetriebene Wagen fahren auf einer mehrstöckigen Strecke mit gruseliger Landschaft und Spezialeffekten
 STR_0563    :Die Fahrgäste sitzen in komfortablen Wagen mit einfachen Beckenhalterungen, in denen sie gigantische, gemäßigte Gefälle erleben, aber auch viel Zeit oben „in der Luft“ verbringen
-STR_0564    :Diese Holzachterbahn ist schnell, rauh, laut und gibt einem das Gefühl, außer Kontrolle zu sein, wobei man häufig „in der Luft“ ist
+STR_0564    :Diese Holzachterbahn ist schnell, rau, laut und gibt einem das Gefühl, außer Kontrolle zu sein, wobei man häufig „in der Luft“ ist
 STR_0565    :Eine einfache Holzachterbahn mit nur leichten Gefällen und Kurven, bei der die Wagen nur mit Hilfe von seitlichen Führungsrollen und der Schwerkraft auf der Strecke gehalten werden
 STR_0566    :Voneinander unabhängige Achterbahnwagen rasen auf einer engen Zickzack-Strecke mit scharfen Kurven und kurzen, starken Gefällen
 STR_0567    :Die Passagiere befinden sich in Sitzen, die an beiden Seiten der Bahn hängen, auf der sie über Kopf steile Gefälle hinunterrasen und verschiedene Inversionsfiguren erleben


### PR DESCRIPTION
Same typo as in 95d0c00cee4285e44d01c8a336e41294a67e8dea