### PR TITLE
de-DE: adjust translation of STR_6515

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -3613,7 +3613,7 @@ STR_6511    :Null-G-Rolle (rechts)
 STR_6512    :Große Null-G-Rolle (l.)
 STR_6513    :Große Null-G-Rolle (r.)
 STR_6514    :Ungültige Höhe!
-STR_6515    :{BLACK}RollerCoaster Tycoon 1 nicht verknüpft - Es werden Fallback-Bilder verwendet.
+STR_6515    :{BLACK}RollerCoaster Tycoon 1 nicht verknüpft. Es werden Fallback-Bilder verwendet.
 STR_6516    :Eines oder mehrere der hinzugefügten Objekte benötigen eine Verknüpfung mit RollerCoaster Tycoon 1 für eine korrekte Anzeige. Es werden Fallback-Bilder verwendet.
 STR_6517    :Eines oder mehrere Objekte in diesem Park benötigen eine Verknüpfung mit RollerCoaster Tycoon 1 für eine korrekte Anzeige. Es werden Fallback-Bilder verwendet.
 STR_6518    :{BLACK}Zeigen Sie auf ein Szenario, um seine Beschreibung und sein Ziel zu sehen. Klicken Sie, um das Spiel zu beginnen.


### PR DESCRIPTION
The sentence should not contain in upper case after the hyphen. Either it must continue in lower case or the hyphen can be changed to a full stop.
- Argument for the former is that it is closer to the english sentence.
- Argument for the latter is that it is more consistent with STR_6516 and STR_6517.
- A (subjective) choice was made for the latter.