### PR TITLE
sv-SE: improve consistency of track design translation

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -274,8 +274,8 @@ STR_0883    :Spara spel
 STR_0884    :Ladda landskap
 STR_0885    :Spara landskap
 STR_0887    :Avsluta scenarioredigeraren
-STR_0888    :Avsluta åktursdesignern
-STR_0889    :Avsluta spårdesignredigeraren
+STR_0888    :Avsluta bandesignern
+STR_0889    :Avsluta bandesignhanterare
 STR_0891    :Skärmdump
 STR_0892    :Skärmdumpen sparades som ’{STRINGID}’
 STR_0893    :Skärmdumpen misslyckades!
@@ -2378,8 +2378,8 @@ STR_3331    :Vägen från parkentrén till kartkanten är antingen inte komplett
 STR_3332    :Parkentrén är åt fel håll eller har ingen väg som leder till kartkanten
 STR_3333    :Exportera egendefinierade objekt med sparade spel
 STR_3334    :Välj om egendefinierade objekt (extra objekt som inte följer med basspelet) ska sparas i sparade spel och scenarion, vilket låter spelare importera dessa data
-STR_3335    :Åktursdesigner – Välj åkturstyp och fordon
-STR_3336    :Bandesign-hanterare – Välj åkturstyp
+STR_3335    :Bandesigner – Välj åkturstyp och fordon
+STR_3336    :Bandesignhanterare – Välj åkturstyp
 STR_3338    :{BLACK}Egendesignad layout
 STR_3339    :{BLACK}{COMMA16} design tillgänglig, eller egendesignad layout
 STR_3340    :{BLACK}{COMMA16} designer tillgängliga, eller egendesignad layout
@@ -2501,9 +2501,9 @@ STR_5196    :Landrättigheter
 STR_5197    :Dekorationer
 STR_5198    :Gångväg
 STR_5199    :Åkturkonstruktion
-STR_5200    :Spårdesignplacering
+STR_5200    :Bandesignplacering
 STR_5201    :Ny åktur
-STR_5202    :Spårdesignval
+STR_5202    :Bandesignval
 STR_5203    :Åkturer
 STR_5204    :Åkturslista
 STR_5205    :Besökare
@@ -2516,8 +2516,8 @@ STR_5211    :Forskningslista
 STR_5212    :Dekorationsinställningar
 STR_5213    :Målinställningar
 STR_5214    :Kartgenerator
-STR_5215    :Spårdesignfönstret
-STR_5216    :Spårdesignlistan
+STR_5215    :Bandesignfönstret
+STR_5216    :Bandesignlistan
 STR_5217    :Fusk
 STR_5218    :Teman
 STR_5219    :Inställningar


### PR DESCRIPTION
"track design" occurs 39 times. In the swedish translation, it is translated to

- "bandesign" 32 times
- "spårdesign" 5 times
- "åktursdesign" 2 times

This commit changes "spårdesign" and "åktursdesign" to "bandesign".

"track designs manager" occurs 4 times. In the swedish translation, (after the change above) it is translated to

- "bandesignhanterare" 3 times
- "bandesignredigeraren" 1 time

This commit changes "bandesignredigeraren" to "bandesignhanterare".
Furthermore, it removes a hyphen in "Bandesign-hanterare" in STR_3336.