### PR TITLE
de-DE: changed colour translation of honey dew

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -3650,7 +3650,7 @@ STR_6548    :Geländer an Kreuzung zeigen
 STR_6549    :Kompabilitätsobjekte können nicht ausgewählt werden!
 STR_6550    :Dieser Eintrag wird für die Abwärtskompabilität mit alten oder beschädigten Objekten bereitgestellt. Er kann nicht ausgewählt werden. Er kann nur abgewählt werden.
 STR_6551    :Armeegrün
-STR_6552    :Honigtau
+STR_6552    :Honigmelone
 STR_6553    :Loh
 STR_6554    :Kastanienrot
 STR_6555    :Koralle


### PR DESCRIPTION
Honey dew is a melon fruit or a sugar-rich sticky substance secreted by various animals. The colour refers to the former, the previous translation to the latter.