### PR TITLE
de-DE: adjust translation of 'shift'

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -3326,7 +3326,7 @@ STR_6199    :Datum setzen
 STR_6200    :Datum zurücksetzen
 STR_6201    :{MONTH}
 STR_6202    :Stil des virtuellen Bodens:
-STR_6203    :Um vertikales Platzieren von Elementen zu vereinfachen, wird ein virtueller Boden eingeblendet, wenn Strg oder Shift gehalten wird
+STR_6203    :Um vertikales Platzieren von Elementen zu vereinfachen, wird ein virtueller Boden eingeblendet, wenn die Strg- oder Umschalttaste gehalten wird.
 STR_6215    :Konstruktion
 STR_6216    :Betrieb
 STR_6217    :Bahn- / Streckenverfügbarkeit


### PR DESCRIPTION
Although the english word 'shift' is sometimes used in german, the translation uses the german word 'Umschalt' in other places  (e.g. 2782, 6413-6415).
