### PR TITLE
de-DE: remove abbreviation in 1673

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -1059,7 +1059,7 @@ STR_1669    :{WINDOW_COLOUR_2}Zufriedenheit: {BLACK}{COMMA16}%
 STR_1670    :{WINDOW_COLOUR_2}Besucher gesamt: {BLACK}{COMMA32}
 STR_1671    :{WINDOW_COLOUR_2}Gesamtgewinn: {BLACK}{CURRENCY2DP}
 STR_1672    :Bremsen
-STR_1673    :Drehkontrolle umschalt.
+STR_1673    :Drehkontrolle umschalten
 STR_1674    :Bremsgeschwindigkeit
 STR_1675    :{POP16}{VELOCITY}
 STR_1676    :Geschwindigkeitsgrenze{NEWLINE}für Bremsen einstellen


### PR DESCRIPTION
It does not make sense to abbreviate only two letters. Space-wise, the english version is much longer.