### PR TITLE
Objects en-us American Football > Football

### DIFF
--- a/objects/en-US.json
+++ b/objects/en-US.json
@@ -5421,7 +5421,7 @@
     },
     "rct2.scenery_small.ball2": {
         "reference-name": "American Football",
-        "name": "American Football"
+        "name": "Football"
     },
     "rct2.scenery_small.tjf": {
         "reference-name": "Flower",
@@ -5829,7 +5829,7 @@
     },
     "rct2.scenery_small.ball1": {
         "reference-name": "American Football",
-        "name": "American Football"
+        "name": "Football"
     },
     "rct2.scenery_small.tsh": {
         "reference-name": "Horse Statue",


### PR DESCRIPTION
This seems like a slight oversight which was inherited from vanilla, as the "American Football Helmet" is just "Football Helmet" in en-us while the actual american football scenery pieces themselves were still just known as "American Football" as they were in en-gb. This fixes that so they're both known as just "Football" in en-us.