### PR TITLE
en-US: Remove "Tunnel of Horror" for falling back to "Ghost Train"

### DIFF
--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -13,7 +13,6 @@ STR_0038    :Restroom
 STR_0041    :3D Theater
 STR_0045    :Elevator
 STR_0047    :ATM
-STR_0052    :Tunnel Of Horror
 STR_0517    :Passengers ride in miniature trains along a narrow-gauge railroad track
 STR_0529    :Mine train themed roller coaster trains career along steel roller coaster track made to look like old railroad track
 STR_0537    :Guests bump into each other in self-driven electric bumper cars


### PR DESCRIPTION
This name has puzzled me for years, i've never once seen this ride type refered to as a "Tunnel of Horror" in real life and almost always see it refered to as a Ghost Train, Haunted Mansion Ride, or just simply Dark Ride. I've opted for removing it so that it falls back to "Ghost Train" from en-GB but i am open for the other two options i mentioned if those might make more sense in en-US vs Ghost Train.