### PR TITLE
en-US: Update WWTT flying saucer vehicle names

### DIFF
--- a/objects/en-US.json
+++ b/objects/en-US.json
@@ -271,7 +271,7 @@
     },
     "rct2tt.ride.cyclopsx": {
         "reference-name": "Cyclops Ride",
-        "name": "Cyclops Ride",
+        "name": "Cyclops Bumper Cars",
         "reference-description": "Riders drive the Eye of a Giant Cyclops",
         "description": "Riders drive the Eye of a Giant Cyclops",
         "reference-capacity": "1 person per car",
@@ -347,7 +347,7 @@
     },
     "rct2tt.ride.flwrpowr": {
         "reference-name": "Flower Power Ride",
-        "name": "Flower Power Ride",
+        "name": "Flower Power Bumper Cars",
         "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
         "description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
         "reference-capacity": "1 passenger per car",
@@ -7129,7 +7129,7 @@
     },
     "rct2ww.ride.dragdodg": {
         "reference-name": "Chinese Dragonhead Ride",
-        "name": "Chinese Dragonhead Ride",
+        "name": "Chinese Dragonhead Bumper Cars",
         "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
         "description": "Guests battle each other in dragonhead-shaped bumper cars",
         "reference-capacity": "1 person per car",


### PR DESCRIPTION
The en-GB strings for these objects were recently changed on the objects repo to refer to them as "Dodgems" so as such, this updates them to "Bumper Cars" in en-US.