### PR TITLE
en-US: Remove "3D Theater" and apply ATM localization to object.

### DIFF
--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -202,7 +202,7 @@ STR_3102    :Re-paint colored scenery on landscape
 STR_3122    :{WINDOW_COLOUR_2}Favorite ride of: {BLACK}{COMMA32} guest
 STR_3123    :{WINDOW_COLOUR_2}Favorite ride of: {BLACK}{COMMA32} guests
 
-STR_3372    :{BLACK}= A.T.M.
+STR_3372    :{BLACK}= ATM
 STR_3373    :{BLACK}= Restroom
 
 # Strings added by OpenRCT2. Only add strings that differ from UK English!

--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -10,7 +10,6 @@ STR_0015    :Bobsled Coaster
 STR_0027    :Bumper Cars
 STR_0035    :Carousel
 STR_0038    :Restroom
-STR_0041    :3D Theater
 STR_0045    :Elevator
 STR_0047    :ATM
 STR_0517    :Passengers ride in miniature trains along a narrow-gauge railroad track

--- a/objects/en-US.json
+++ b/objects/en-US.json
@@ -2981,9 +2981,9 @@
     },
     "rct2.ride.atm1": {
         "reference-name": "Cash Machine",
-        "name": "Cash Machine",
+        "name": "ATM",
         "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
-        "description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds"
+        "description": "An ATM for guests to use if they run low on funds"
     },
     "rct2.ride.kart1": {
         "reference-name": "Go-Karts",


### PR DESCRIPTION
The 3D Theater localization is a misnomer as Cinema and Theater are distinct terms, with Cinema refering to films specifically and it doesn't seem to be an Americanism so the original en-GB is still correct.

For the ATM i've decided to go with "ATM" instead of "A.T.M." as periods don't seem to be frequently used for abbreviating it at least in regards to en-US specifically from what i could tell. I've also changed this for the string used in the map window.