### PR TITLE
Fix STR_6603 in de-DE

### DIFF
--- a/data/language/de-DE.txt
+++ b/data/language/de-DE.txt
@@ -3670,7 +3670,7 @@ STR_6599    :Geisterelement konnte nicht gefunden werden
 STR_6600    :Ballon konnte nicht gefunden werden
 STR_6601    :Mitarbeiter konnte nicht gefunden werden
 STR_6602    :Fahrgeschäft/Attraktion konnte nicht gefunden werden
-STR_6603    :Attraktionseingang konnte nicht gefunden werden
+STR_6603    :Attraktionsobjekteintrag konnte nicht gefunden werden
 STR_6604    :Spieler konnte nicht gefunden werden
 STR_6605    :Eingangselement konnte nicht gefunden werden
 STR_6606    :Oberflächenelement konnte nicht gefunden werden


### PR DESCRIPTION
'Eingang' means 'entrance' but not 'entry' in the sense of an index entry.