### PR TITLE
Improve STR_5612 and STR_5961 in sv-SE

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -2780,7 +2780,7 @@ STR_5608    :BH
 STR_5609    :CH
 STR_5610    :Ta bort den valda rutan eller elementet. Detta kommer tvinga en borttagning, inga pengar kommer ges eller användas. Använd med försiktighet.
 STR_5611    :G
-STR_5612    :Spökflagga
+STR_5612    :Skissflagga
 STR_5613    :B
 STR_5614    :Trasig flagga
 STR_5615    :L
@@ -3084,7 +3084,7 @@ STR_5957    :Nordväst
 STR_5958    :Nordost
 STR_5959    :Sydost
 STR_5960    :Placering i väderstreck:
-STR_5961    :Entré-index: {BLACK}{COMMA16}
+STR_5961    :Noteringsindex: {BLACK}{COMMA16}
 STR_5962    :Kollisionsdetektering:
 STR_5963    :Upphöjda hörn:
 STR_5964    :Diagonal


### PR DESCRIPTION
STR_5612: "Spök" literally means ghost, but it is not a word that is commonly used in the context of ghost elements in computer games. "Skiss" means sketch, draft or outline, which rather translates the idea of what it is.

STR_5961: "entré" means entry in the sense of entrance, but not in the sense of a list item.