### PR TITLE
ru-RU: Retranslate objects JSON

### DIFF
--- a/objects/ru-RU.json
+++ b/objects/ru-RU.json
@@ -805,7 +805,7 @@
     },
     "rct1aa.ride.virginia_reel_tubs": {
         "reference-name": "Virginia Reel Tubs",
-        "name": "Трубы \"Вирджиния\"",
+        "name": "Трубы «Вирджиния»",
         "reference-description": "Circular cars that spin around as they travel along the track",
         "description": "Круглые машины, которые вращаются во время езды.",
         "reference-capacity": "4 passengers per car",
@@ -1149,7 +1149,7 @@
     },
     "rct1ll.ride.face_off_cars": {
         "reference-name": "Face-off Cars",
-        "name": "Машины \"лицом-к-лицу\"",
+        "name": "Машины «лицом-к-лицу»",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
         "description": "Люди сидят парами друг напротив друга, проходя резкие петли и перевороты",
         "reference-capacity": "4 passengers per car",
@@ -1513,7 +1513,7 @@
     },
     "rct2.audio.circus": {
         "reference-name": "Ambient sound effects for the Circus attraction.",
-        "name": "Звуковые эффекты для аттракциона \"Цирк\"."
+        "name": "Звуковые эффекты для аттракциона «Цирк»."
     },
     "rct2.audio.title": {
         "reference-name": "Title screen music for RollerCoaster Tycoon 2.",
@@ -2701,7 +2701,7 @@
     },
     "rct2.ride.slcfo": {
         "reference-name": "Face-off Cars",
-        "name": "Машины \"лицом-к-лицу\"",
+        "name": "Машины «лицом-к-лицу»",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
         "description": "Люди сидят парами друг напротив друга, проходя резкие петли и перевороты",
         "reference-capacity": "4 passengers per car",
@@ -2831,7 +2831,7 @@
         "reference-name": "Sub Sandwich Stall",
         "name": "Саб-сэндвичи",
         "reference-description": "A stall selling fresh sub sandwiches",
-        "description": "Ларёк, продающий сэндвичи стиля \"саб\""
+        "description": "Ларёк, продающий сэндвичи стиля «саб»"
     },
     "rct2.ride.sungst": {
         "reference-name": "Sunglasses Stall",
@@ -3001,7 +3001,7 @@
     },
     "rct2.ride.vreel": {
         "reference-name": "Virginia Reel Tubs",
-        "name": "Трубы \"Вирджиния\"",
+        "name": "Трубы «Вирджиния»",
         "reference-description": "Circular cars that spin around as they travel along the track",
         "description": "Круглые машины, которые вращаются во время езды.",
         "reference-capacity": "4 passengers per car",
@@ -3043,7 +3043,7 @@
         "reference-name": "Wonton Soup Stall",
         "name": "Вонтон-супная",
         "reference-description": "A stall selling Wonton Soup",
-        "description": "Ларёк, продающий суп с пельменями \"вонтон\""
+        "description": "Ларёк, продающий суп с пельменями «вонтон»"
     },
     "rct2.ride.zldb": {
         "reference-name": "Ladybird Trains",
@@ -3283,7 +3283,7 @@
     },
     "rct2.scenery_group.scgcandy": {
         "reference-name": "Giant Candy Theming",
-        "name": "Тема \"огромные конфеты\""
+        "name": "Тема «огромные конфеты»"
     },
     "rct2.scenery_group.scgclass": {
         "reference-name": "Classical/Roman Theming",
@@ -3303,11 +3303,11 @@
     },
     "rct2.scenery_group.scggiant": {
         "reference-name": "Giant Garden Theming",
-        "name": "Тема \"огромный сад\""
+        "name": "Тема «огромный сад»"
     },
     "rct2.scenery_group.scghallo": {
         "reference-name": "Creepy Theming",
-        "name": "Тема \"ужасы\""
+        "name": "Тема «ужасы»"
     },
     "rct2.scenery_group.scgindus": {
         "reference-name": "Mechanical Theming",
@@ -3315,11 +3315,11 @@
     },
     "rct2.scenery_group.scgjungl": {
         "reference-name": "Jungle Theming",
-        "name": "Тема \"джунгли\""
+        "name": "Тема «джунгли»"
     },
     "rct2.scenery_group.scgjuras": {
         "reference-name": "Jurassic Theming",
-        "name": "Тема \"юрский период\""
+        "name": "Тема «юрский период»"
     },
     "rct2.scenery_group.scgmart": {
         "reference-name": "Martian Theming",
@@ -3335,7 +3335,7 @@
     },
     "rct2.scenery_group.scgorien": {
         "reference-name": "Pagoda Theming",
-        "name": "Тема \"пагода\""
+        "name": "Тема «пагода»"
     },
     "rct2.scenery_group.scgpathx": {
         "reference-name": "Signs and Items for Footpaths",
@@ -3351,7 +3351,7 @@
     },
     "rct2.scenery_group.scgsixfl": {
         "reference-name": "Six Flags Theming",
-        "name": "Тема \"Six Flags\""
+        "name": "Тема «Six Flags»"
     },
     "rct2.scenery_group.scgsnow": {
         "reference-name": "Snow and Ice Theming",
@@ -3363,7 +3363,7 @@
     },
     "rct2.scenery_group.scgspook": {
         "reference-name": "Spooky Theming",
-        "name": "Тема \"страх\""
+        "name": "Тема «страх»"
     },
     "rct2.scenery_group.scgsport": {
         "reference-name": "Sports Theming",
@@ -3387,11 +3387,11 @@
     },
     "rct2.scenery_group.scgwond": {
         "reference-name": "Wonderland Theming",
-        "name": "Тема \"страна чудес\""
+        "name": "Тема «страна чудес»"
     },
     "rct2.scenery_group.scgwwest": {
         "reference-name": "Wild West Theming",
-        "name": "Тема \"дикий запад\""
+        "name": "Тема «дикий запад»"
     },
     "rct2.scenery_large.badrack": {
         "reference-name": "Badminton Racket",
@@ -3403,15 +3403,15 @@
     },
     "rct2.scenery_large.glthent": {
         "reference-name": "‘Goliath’ Sign",
-        "name": "Знак \"Голиаф\""
+        "name": "Знак «Голиаф»"
     },
     "rct2.scenery_large.mdsaent": {
         "reference-name": "‘Medusa’ Sign",
-        "name": "Знак \"Медуза\""
+        "name": "Знак «Медуза»"
     },
     "rct2.scenery_large.nitroent": {
         "reference-name": "‘Nitro’ Sign",
-        "name": "Знак \"Нитро\""
+        "name": "Знак «Нитро»"
     },
     "rct2.scenery_large.prship": {
         "reference-name": "Pirate Ship",
@@ -5175,7 +5175,7 @@
     },
     "rct2.scenery_wall.walltxgt": {
         "reference-name": "‘Texas Giant’ Sign",
-        "name": "Знак \"Техасский Гигант\""
+        "name": "Знак «Техасский Гигант»"
     },
     "rct2.scenery_wall.wallu132": {
         "reference-name": "Wall",
@@ -5579,7 +5579,7 @@
     },
     "rct2dlc.scenery_group.scgpanda": {
         "reference-name": "Panda Theming",
-        "name": "Тема \"панда\""
+        "name": "Тема «панда»"
     },
     "rct2dlc.scenery_small.bigpanda": {
         "reference-name": "Giant Panda",
@@ -5627,7 +5627,7 @@
     },
     "rct2tt.footpath_railings.rocky": {
         "reference-name": "Jungle Railings",
-        "name": "Перила в стиле \"джунгли\""
+        "name": "Перила в стиле «джунгли»"
     },
     "rct2tt.footpath_surface.circuitboard": {
         "reference-name": "Circuit Footpath",
@@ -5727,7 +5727,7 @@
     },
     "rct2tt.ride.blckdeth": {
         "reference-name": "Black Death Trains",
-        "name": "Поезда \"чёрная смерть\"",
+        "name": "Поезда «чёрная смерть»",
         "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Поезда в виде крыс, с двухвестными машинами, где пассажиры сидят друг за другом",
         "reference-capacity": "2 passengers per car",
@@ -5751,7 +5751,7 @@
     },
     "rct2tt.ride.cerberus": {
         "reference-name": "Cerberus Trains",
-        "name": "Поезда \"Цербер\"",
+        "name": "Поезда «Цербер»",
         "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
         "description": "Просторный поест с простой безопасностью на ноги, с машинами в форме многоголовой собаки из Подземелья",
         "reference-capacity": "4 passengers per car",
@@ -5855,9 +5855,9 @@
     },
     "rct2tt.ride.hotrodxx": {
         "reference-name": "Hot Rod Trains",
-        "name": "Поезда \"Hot Rod\"",
+        "name": "Поезда «Hot Rod»",
         "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
-        "description": "Поезда, запускаемые воздушным толчком, в форме машин \"Hot Rod\"",
+        "description": "Поезда, запускаемые воздушным толчком, в форме машин «Hot Rod»",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 пассажира на машину"
     },
@@ -5973,7 +5973,7 @@
     },
     "rct2tt.ride.pegasusx": {
         "reference-name": "Pegasus Cars",
-        "name": "Машины \"Пегас\"",
+        "name": "Машины «Пегас»",
         "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
         "description": "Электрические машины в форме пегасов",
         "reference-capacity": "2 passengers per car",
@@ -6159,7 +6159,7 @@
         "reference-park_name": "Crater Carnage",
         "park_name": "Crater Carnage",
         "reference-details": "You own a dusty old meteor crater. In the true entrepreneurial spirit, you’ve decided to construct an asteroid theme park and convert your seemingly worthless land into a sizeable fortune.",
-        "details": "Вы владеете старым метеоритным кратером. В духе истинного предпренимателя, вы решаете построить парк в космическом стиле, превратив эту \"никчёмную\" землю в огромный капитал."
+        "details": "Вы владеете старым метеоритным кратером. В духе истинного предпренимателя, вы решаете построить парк в космическом стиле, превратив эту «никчёмную» землю в огромный капитал."
     },
     "rct2tt.scenario_text.extraterrestrial_extravaganza": {
         "reference-name": "Extraterrestrial Extravaganza",
@@ -6243,11 +6243,11 @@
     },
     "rct2tt.scenery_group.scg1960s": {
         "reference-name": "Rock ’n’ Roll Theming",
-        "name": "Тема \"Рок-н-Ролл\""
+        "name": "Тема «Рок-н-Ролл»"
     },
     "rct2tt.scenery_group.scgfutur": {
         "reference-name": "Future Theming",
-        "name": "Тема \"Будущее\""
+        "name": "Тема «Будущее»"
     },
     "rct2tt.scenery_group.scgjurra": {
         "reference-name": "Prehistoric Theming",
@@ -6415,11 +6415,11 @@
     },
     "rct2tt.scenery_large.ghotrod1": {
         "reference-name": "Hot Rod Car",
-        "name": "Машина \"Hot Rod\""
+        "name": "Машина «Hot Rod»"
     },
     "rct2tt.scenery_large.ghotrod2": {
         "reference-name": "Hot Rod Car",
-        "name": "Машина \"Hot Rod\""
+        "name": "Машина «Hot Rod»"
     },
     "rct2tt.scenery_large.gschlbus": {
         "reference-name": "School Bus",
@@ -7255,87 +7255,87 @@
     },
     "rct2tt.scenery_small.hevbth01": {
         "reference-name": "Heavenly Bath Pool",
-        "name": "Бассейн \"Райская ванна\""
+        "name": "Бассейн «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth02": {
         "reference-name": "Heavenly Bath Pool Corner",
-        "name": "Угол бассейна \"Райская ванна\""
+        "name": "Угол бассейна «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth03": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Фонтан \"Райская ванна\""
+        "name": "Фонтан «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth04": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Фонтан \"Райская ванна\""
+        "name": "Фонтан «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth05": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Арка \"Райская ванна\""
+        "name": "Арка «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth06": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Арка \"Райская ванна\""
+        "name": "Арка «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth07": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "\"Райская ванна\""
+        "name": "«Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth08": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Лестница \"Райская ванна\""
+        "name": "Лестница «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth09": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Лестница \"Райская ванна\""
+        "name": "Лестница «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth10": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Архитектура \"Райская ванна\""
+        "name": "Архитектура «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth11": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Архитектура \"Райская ванна\""
+        "name": "Архитектура «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth12": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Архитектура \"Райская ванна\""
+        "name": "Архитектура «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth13": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Архитектура \"Райская ванна\""
+        "name": "Архитектура «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth14": {
         "reference-name": "Heavenly Bath Window",
-        "name": "Окно \"Райская ванна\""
+        "name": "Окно «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth15": {
         "reference-name": "Heavenly Bath Floor",
-        "name": "Пол \"Райская ванна\""
+        "name": "Пол «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth16": {
         "reference-name": "Heavenly Bath Pool Steps",
-        "name": "Лестница в бассейн \"Райская ванна\""
+        "name": "Лестница в бассейн «Райская ванна»"
     },
     "rct2tt.scenery_small.hevbth17": {
         "reference-name": "Heavenly Bath Pool Edge",
-        "name": "Край бассейна \"Райская ванна\""
+        "name": "Край бассейна «Райская ванна»"
     },
     "rct2tt.scenery_small.hevrof01": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Крыша \"Райская ванна\""
+        "name": "Крыша «Райская ванна»"
     },
     "rct2tt.scenery_small.hevrof02": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Крыша \"Райская ванна\""
+        "name": "Крыша «Райская ванна»"
     },
     "rct2tt.scenery_small.hevrof03": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Крыша \"Райская ванна\""
+        "name": "Крыша «Райская ванна»"
     },
     "rct2tt.scenery_small.hevrof04": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Крыша \"Райская ванна\""
+        "name": "Крыша «Райская ванна»"
     },
     "rct2tt.scenery_small.horsecrt": {
         "reference-name": "Horse",
@@ -8475,7 +8475,7 @@
     },
     "rct2ww.ride.anaconda": {
         "reference-name": "Anaconda Trains",
-        "name": "Поезда \"Анаконда\"",
+        "name": "Поезда «Анаконда»",
         "reference-description": "Spacious trains with simple lap restraints",
         "description": "Просторные поезда с простой безопасностью на ноги",
         "reference-capacity": "6 passengers per car",
@@ -8491,7 +8491,7 @@
     },
     "rct2ww.ride.bomerang": {
         "reference-name": "Boomerang Trains",
-        "name": "Поезда \"Бумеранг\"",
+        "name": "Поезда «Бумеранг»",
         "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
         "description": "Поезда для аттракционов в форме бумеранга, запускаемые воздухом",
         "reference-capacity": "2 passengers per car",
@@ -8523,7 +8523,7 @@
     },
     "rct2ww.ride.condorrd": {
         "reference-name": "Condor Trains",
-        "name": "Поезда \"Кондор\"",
+        "name": "Поезда «Кондор»",
         "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
         "description": "Спецальные запряжки в форме кондоров, подвешивающие пассажиров на трек сверху, что позволяет им испытать чувство полета",
         "reference-capacity": "4 passengers per car",
@@ -8723,9 +8723,9 @@
     },
     "rct2ww.ride.londonbs": {
         "reference-name": "Routemaster Buses",
-        "name": "Автобусы \"Routemaster\"",
+        "name": "Автобусы «Routemaster»",
         "reference-description": "Replicas of the famous London Routemaster bus",
-        "description": "Реплики знаменитых лондонских автобусов \"Routemaster\"",
+        "description": "Реплики знаменитых лондонских автобусов «Routemaster»",
         "reference-capacity": "10 passengers per car",
         "capacity": "10 пассажиров на машину"
     },
@@ -8811,7 +8811,7 @@
     },
     "rct2ww.ride.rssncrrd": {
         "reference-name": "Trabant Cars",
-        "name": "Машины \"Trabant\"",
+        "name": "Машины «Trabant»",
         "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
         "description": "Машины для аттракционов в форме автомобилей от Trabant",
         "reference-capacity": "4 passengers per car",
@@ -8835,7 +8835,7 @@
     },
     "rct2ww.ride.skidoo": {
         "reference-name": "Skidoo Dodgems",
-        "name": "Машины для автодрома \"Skidoo\"",
+        "name": "Машины для автодрома «Skidoo»",
         "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
         "description": "Скользящие реплики машин Skidoo, свободно управляемые пассажирами",
         "reference-capacity": "1 person per car",
@@ -8851,7 +8851,7 @@
     },
     "rct2ww.ride.sputnikr": {
         "reference-name": "Sputnik Cars",
-        "name": "Машины \"Спутник\"",
+        "name": "Машины «Спутник»",
         "reference-description": "Russian satellite-shaped cars which swing from the rail above",
         "description": "Подвесные машины в форме русского искуственного спутника",
         "reference-capacity": "2 passengers per car",
@@ -8859,7 +8859,7 @@
     },
     "rct2ww.ride.steamtrn": {
         "reference-name": "Maharaja Steam Trains",
-        "name": "Паровоз \"Махараджа\"",
+        "name": "Паровоз «Махараджа»",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
         "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
@@ -9091,11 +9091,11 @@
     },
     "rct2ww.scenery_large.1x2abr02": {
         "reference-name": "Aboriginal Snake Artwork",
-        "name": "Аборигенский рисунок \"Змея\""
+        "name": "Аборигенский рисунок «Змея»"
     },
     "rct2ww.scenery_large.1x2abr03": {
         "reference-name": "Aboriginal Spirit Artwork",
-        "name": "Аборигенский рисунок \"Дух\""
+        "name": "Аборигенский рисунок «Дух»"
     },
     "rct2ww.scenery_large.1x2azt01": {
         "reference-name": "Temple Wall Piece with Head",
@@ -9155,7 +9155,7 @@
     },
     "rct2ww.scenery_large.3x3hmsen": {
         "reference-name": "HMS Endeavour",
-        "name": "Корабль \"HMS Endeavour\""
+        "name": "Корабль «HMS Endeavour»"
     },
     "rct2ww.scenery_large.3x3mantr": {
         "reference-name": "Mangrove Tree",
@@ -10087,7 +10087,7 @@
     },
     "rct2ww.scenery_small.sbh3rt66": {
         "reference-name": "Route 66 Sign",
-        "name": "Знак \"Route 66\""
+        "name": "Знак «Route 66»"
     },
     "rct2ww.scenery_small.sbh4totm": {
         "reference-name": "Large Totem Pole",

--- a/objects/ru-RU.json
+++ b/objects/ru-RU.json
@@ -1,11 +1,11 @@
 {
     "couger.scenery_wall.acww33": {
         "reference-name": "Wooden Post Wall",
-        "name": "Wooden Post Wall"
+        "name": "Стена из деревянных столбов"
     },
     "couger.scenery_wall.acwwf32": {
         "reference-name": "Wooden Post Wall",
-        "name": "Wooden Post Wall"
+        "name": "Стена из деревянных столбов"
     },
     "mamabear.scenery_wall.mg-prar": {
         "reference-name": "Wall with Passageway",
@@ -13,107 +13,107 @@
     },
     "official.scenery_small.support_structure_half": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "official.scenery_wall.post_flipped": {
         "reference-name": "Post",
-        "name": "Пост"
+        "name": "Столб"
     },
     "official.scenery_wall.support_structure_full": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "official.scenery_wall.support_structure_half": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "official.terrain_edge.void": {
         "reference-name": "Void",
-        "name": "Void"
+        "name": "Пустота"
     },
     "openrct2.footpath_railings.invisible": {
         "reference-name": "Invisible Railings",
-        "name": "Invisible Railings"
+        "name": "Невидимые рельсы"
     },
     "openrct2.footpath_surface.invisible": {
         "reference-name": "Invisible Footpath",
-        "name": "Invisible Footpath"
+        "name": "Невидимая тропа"
     },
     "openrct2.footpath_surface.queue_invisible": {
         "reference-name": "Invisible Queue",
-        "name": "Invisible Queue"
+        "name": "Невидимая очередь"
     },
     "openrct2.ride.alpine_coaster": {
         "reference-name": "Alpine Coaster Cars",
-        "name": "Alpine Coaster Cars",
+        "name": "Альпийские машины",
         "reference-description": "Wheeled sleds equipped with manually operated brakes",
-        "description": "Wheeled sleds equipped with manually operated brakes",
+        "description": "Сани с колесами и ручными тормозами",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 passengers per car"
+        "capacity": "2 пассажира на машину"
     },
     "openrct2.ride.hybrid_coaster": {
         "reference-name": "Hybrid Coaster Trains",
-        "name": "Hybrid Coaster Trains",
+        "name": "Гибридные поезда",
         "reference-description": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
-        "description": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
+        "description": "Поезда с безопасностью для ног, способные совершать резкие падения и перевороты",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 пассажира на машину"
     },
     "openrct2.ride.modern_twister": {
         "reference-name": "Modern Twister Trains",
-        "name": "Modern Twister Trains",
+        "name": "Современные поезда-твистер",
         "reference-description": "Spacious trains with lap restraints, capable of tight twists and inversions",
-        "description": "Spacious trains with lap restraints, capable of tight twists and inversions",
+        "description": "Просторные поезда с безопасностью для ног, способные совершать легкие твисты и перевороты",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 пассажира на машину"
     },
     "openrct2.ride.single_rail_coaster": {
         "reference-name": "Single Rail Roller Coaster Trains",
-        "name": "Single Rail Roller Coaster Trains",
+        "name": "Однорельсовые поезда",
         "reference-description": "Roller coaster trains in which riders are seated single file",
-        "description": "Roller coaster trains in which riders are seated single file",
+        "description": "Поезда, в которых пассажиры сидят друг за другом",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 passenger per car"
+        "capacity": "1 пассажир на машину"
     },
     "openrct2.station.noentrance": {
         "reference-name": "No entrance",
-        "name": "No entrance"
+        "name": "Нет входа"
     },
     "openrct2.station.noplatformnoentrance": {
         "reference-name": "No entrance, no platform",
-        "name": "No entrance, no platform"
+        "name": "Нет входа, нет платформы"
     },
     "openrct2.terrain_surface.void": {
         "reference-name": "Void",
-        "name": "Void"
+        "name": "Пустота"
     },
     "rct1.audio.title": {
         "reference-name": "Title screen music for RollerCoaster Tycoon (Loopy Landscapes).",
-        "name": "Title screen music for RollerCoaster Tycoon (Loopy Landscapes)."
+        "name": "Музыка главного меню RollerCoaster Tycoon (Loopy Landscapes)."
     },
     "rct1.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Sloped)",
-        "name": "Дорожка"
+        "name": "Сумашедший тротуар (с наклоном)"
     },
     "rct1.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Square)",
-        "name": "Дорожка"
+        "name": "Грязная тропа (квадрат)"
     },
     "rct1.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Sloped)",
-        "name": "Blue Queue (Sloped)"
+        "name": "Синяя очередь (с наклоном)"
     },
     "rct1.footpath_surface.road": {
         "reference-name": "Road",
-        "name": "Путь"
+        "name": "Дорога"
     },
     "rct1.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Sloped)",
-        "name": "Асфальт"
+        "name": "Асфальт (с наклоном)"
     },
     "rct1.footpath_surface.tiles_brown": {
         "reference-name": "Brown Tiled Footpath",
-        "name": "Brown Tiled Footpath"
+        "name": "Коричневая плитка"
     },
     "rct1.ride.bobsleigh_trains": {
         "reference-name": "Bobsleigh Trains",
@@ -121,7 +121,7 @@
         "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Поезд состоящий из двухместных вагонов, где пассажиры сидят друг за другом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.bumper_boats": {
         "reference-name": "Bumper Boats",
@@ -129,165 +129,165 @@
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Маленькие круглые лодочки с моторами управляются пассажирами.",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.cat_cars": {
         "reference-name": "Cheshire Cats",
-        "name": "Чешир",
+        "name": "Чеширский кот",
         "reference-description": "Powered cat-shaped vehicles",
         "description": "Машинки в виде котов едут по рельсам",
         "reference-capacity": "2 passengers per cat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на кота"
     },
     "rct1.ride.chairlift_cars": {
         "reference-name": "Chairlift Cars",
-        "name": "Кресло-лифт",
+        "name": "Кресла для канатки",
         "reference-description": "Open cars for chairlift",
-        "description": "Открытые вагончики",
+        "description": "Открытые кресла для канатной дороги",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.corkscrew_trains": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Corkscrew Roller Coaster Trains",
+        "name": "Штопорные поезда",
         "reference-description": "Roller coaster trains with shoulder restraints",
-        "description": "Roller coaster trains with shoulder restraints",
+        "description": "Поезда с безопасностью для плеч",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.dinghies": {
         "reference-name": "Dinghies",
         "name": "Шлюпки",
         "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
-        "description": "Люди катаются в шлюпках.",
+        "description": "Надувные шлюпки, которые могут плыть по полу- или полностью закрытой трубе.",
         "reference-capacity": "2 passengers per dinghy",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на шлюпку"
     },
     "rct1.ride.dodgems": {
         "reference-name": "Dodgems",
-        "name": "Кар",
+        "name": "Машины для автодрома",
         "reference-description": "Riders bump into each other in self-drive electric dodgems",
-        "description": "Электромобильчики",
+        "description": "Пассажиры сталкиваются друг с другом в этих электрических мини-автомобилях",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел."
+        "capacity": "1 пассажир на машину"
     },
     "rct1.ride.fruity_ices_stall": {
         "reference-name": "Fruity Ices Stall",
-        "name": "Мороженое",
+        "name": "Фруктовый лёд",
         "reference-description": "A themed stall selling fruity ice creams",
-        "description": "Палатка с фруктовым мороженым"
+        "description": "Ларёк продающий мороженные с фруктовым вкусом"
     },
     "rct1.ride.go_karts": {
         "reference-name": "Go-Karts (with helmets)",
-        "name": "Go-Karts (with helmets)",
+        "name": "Картинг (со шлемом)",
         "reference-description": "Self-driven petrol-engined go-karts that come with safety helmets",
-        "description": "Self-driven petrol-engined go-karts that come with safety helmets",
+        "description": "Бензиновые машины для картинга со шлемами безопасности",
         "reference-capacity": "single-seater",
         "capacity": "одиночные"
     },
     "rct1.ride.horses": {
         "reference-name": "Horses",
-        "name": "Стиплчез",
+        "name": "Лошади",
         "reference-description": "Single cars shaped like a horse",
-        "description": "Люди едут на машинках в виде лошадей.",
+        "description": "Машины в форме лошадей",
         "reference-capacity": "2 riders per horse",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на лошадь"
     },
     "rct1.ride.inverted_trains": {
         "reference-name": "Inverted Coaster Trains",
-        "name": "Inverted Coaster Trains",
+        "name": "Перевёрнутый поезд",
         "reference-description": "Inverted roller coaster train, consisting of seats hanging from a supporting frame running on the track above.",
-        "description": "Inverted roller coaster train, consisting of seats hanging from a supporting frame running on the track above.",
+        "description": "Сиденья, свешивающиеся вниз с поддерживающей рамки на треке сверху.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.ladybird_trains": {
         "reference-name": "Ladybird Trains",
         "name": "Божья Коровка",
         "reference-description": "Roller coaster trains with small ladybird-shaped cars",
-        "description": "Поезд с маленькими божьими коровками",
+        "description": "Поезд с машинами в форме маленьких божьих коровок",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.log_trains": {
         "reference-name": "Log Trains",
         "name": "Бревна",
         "reference-description": "Roller coaster trains with small log-shaped cars",
-        "description": "Поезда с небольшими вагончиками.",
+        "description": "Поезд с миниатюрными машинами в форме бревна.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.logs": {
         "reference-name": "Logs",
-        "name": "Ущелье",
+        "name": "Бревна",
         "reference-description": "Log-shaped boats built for running in water channels",
-        "description": "Лодки в виде бревен плывут по каналу, периодически плюхаясь со склонов.",
+        "description": "Машины в виде лодок для плаванья по водным каналам.",
         "reference-capacity": "4 passengers per boat",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.mine_cars": {
         "reference-name": "Mine Cars",
-        "name": "Деревянная Шахта",
+        "name": "Шахтёрские машины",
         "reference-description": "Cars shaped like an old mine cart",
-        "description": "Маленькие вагонетки едут по зигзагообразному деревянному треку.",
+        "description": "Машины в форме старых вагонеток.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.mine_trains": {
         "reference-name": "Mine Trains",
-        "name": "Шахтёрские горки",
+        "name": "Шахтёрские поезда",
         "reference-description": "Mine train-themed roller coaster trains",
-        "description": "Горный поезд несется по стальным рельсам, похожим на старинную железную дорогу.",
+        "description": "Поезда для аттракционов, похожие те, что ходят в шахтах",
         "reference-capacity": "2 or 4 passengers per car",
-        "capacity": "2 или 4 пассажира"
+        "capacity": "2 или 4 пассажира на машину"
     },
     "rct1.ride.motorbikes": {
         "reference-name": "Motorbikes",
         "name": "Мотоциклы",
         "reference-description": "Single cars shaped like a motorbike",
-        "description": "Пассажиры едут в вагончиках в виде мотоциклов по треку",
+        "description": "Машины, похожие по форме на мотоцикл",
         "reference-capacity": "2 riders per bike",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на мотоцикл"
     },
     "rct1.ride.mouse_cars": {
         "reference-name": "Mouse Cars",
-        "name": "Деревянные мышки",
+        "name": "Мышки",
         "reference-description": "Individual cars shaped like a mouse",
-        "description": "Маленькие машинки в виде мышек едут по деревянному треку.",
+        "description": "Машины, похожие по форме на мышей",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.pickup_trucks": {
         "reference-name": "Pickup Trucks",
         "name": "Грузовики",
         "reference-description": "Powered vehicles in the shape of pickup trucks",
-        "description": "Powered vehicles in the shape of pickup trucks",
+        "description": "Электромашины в форме грузовиков",
         "reference-capacity": "1 passenger per truck",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на грузовик"
     },
     "rct1.ride.racing_cars": {
         "reference-name": "Racing Cars",
-        "name": "Машинки",
+        "name": "Гоночные машины",
         "reference-description": "Powered vehicles in the shape of racing cars",
-        "description": "Гоночные Машинки",
+        "description": "Электромашины, похожие по форме на гоночные",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct1.ride.reverse_freefall_car": {
         "reference-name": "Reverse Freefall Car",
-        "name": "Обратный вагончик",
+        "name": "Машина для реверсивных аттракционов",
         "reference-description": "Large coaster car for the Reverse Freefall Coaster",
-        "description": "Большой вагончик для реверсивных горок",
+        "description": "Большая машина для реверсивных аттракционов",
         "reference-capacity": "8 passengers",
         "capacity": "8 пассажиров"
     },
     "rct1.ride.river_rapids_boats": {
         "reference-name": "River Rapids Boats",
-        "name": "Перекаты",
+        "name": "Лодки для Речных Порогов",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
-        "description": "Круглые лодки плывут по широкому каналу, попадая на водопады и стремительные перекаты",
+        "description": "Круглые вращающиеся лодки, которые создают всплески во время путешествия по речным порогам",
         "reference-capacity": "8 passengers per boat",
-        "capacity": "8 пассажиров"
+        "capacity": "8 пассажиров на лодку"
     },
     "rct1.ride.rocket_cars": {
         "reference-name": "Rocket Cars",
@@ -295,125 +295,125 @@
         "reference-description": "Roller coaster cars themed to look like rockets",
         "description": "Вагончики для горок в виде ракет",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.single_person_swinging_cars": {
         "reference-name": "Single-Person Swinging Cars",
-        "name": "Single-Person Swinging Cars",
+        "name": "Качающиеся машины",
         "reference-description": "Single-seater cars which hang from the rail above, and are free to swing from side to side",
-        "description": "Single-seater cars which hang from the rail above, and are free to swing from side to side",
+        "description": "Машины для одного, подвешенные на рельс сверху, что позволяет им раскачиваться",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct1.ride.small_monorail_cars": {
         "reference-name": "Small Monorail Cars",
-        "name": "Моно-вагончики",
+        "name": "Монорельсовые вагоны",
         "reference-description": "Small monorail cars with open sides",
-        "description": "Мал. монорельсовые вагончики",
+        "description": "Маленькие монорельсовые вагоны с открытыми сторонами",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.sports_cars": {
         "reference-name": "Sports Cars",
         "name": "Спорткары",
         "reference-description": "Powered vehicles in the shape of sports cars",
-        "description": "Машинки в форме спорткаров",
+        "description": "Электромашины в форме спорткаров",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1.ride.stand_up_trains": {
         "reference-name": "Stand-up Roller Coaster Trains",
-        "name": "Стоячие горки",
+        "name": "Стоячие поезда",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position",
-        "description": "Кольцевые горки, где люди катаются стоя.",
+        "description": "Поезда, в которых люди едут в стоячей позиции.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.steam_trains": {
         "reference-name": "Steam Trains",
         "name": "Паровозы",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct1.ride.steel_rc_trains": {
         "reference-name": "Roller Coaster Trains",
-        "name": "Roller Coaster Trains",
+        "name": "Поезда для аттракционов",
         "reference-description": "Roller coaster train with a streamlined front car.",
-        "description": "Roller coaster train with a streamlined front car.",
+        "description": "Поезд для аттракционов с гладкой передней машиной.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пасс на вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.steel_rc_trains_reversed": {
         "reference-name": "Roller Coaster Trains (Reversed)",
-        "name": "Roller Coaster Trains (Reversed)",
+        "name": "Поезда для аттракционов (реверс)",
         "reference-description": "Roller coaster train running in reverse, so that the passengers face backwards.",
-        "description": "Roller coaster train running in reverse, so that the passengers face backwards.",
+        "description": "Поезда для аттракционов, едущие в обратную сторону: пассажиры повернуты лицом назад.",
         "reference-capacity": "4 riders per car",
-        "capacity": "4 пасс на вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.streamlined_monorail_trains": {
         "reference-name": "Streamlined Monorail Trains",
-        "name": "Моно-паровозики",
+        "name": "Гладкие монорельсовые поезда",
         "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
-        "description": "Вместимые монорельсовые поезда с паровозами",
+        "description": "Вместитильные поезда для монорельсов, с гладкими передними и задними машинами",
         "reference-capacity": "5 or 10 passengers per car",
-        "capacity": "5 или 10 пассажиров"
+        "capacity": "5 или 10 пассажиров на машину"
     },
     "rct1.ride.suspended_swinging_aeroplane_cars": {
         "reference-name": "Suspended Swinging Aeroplane Cars",
-        "name": "Аэропланы",
+        "name": "Раскачивающиеся подвесные самолёты",
         "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
-        "description": "Suspended roller coaster train consisting of airplane shaped cars able to swing freely as the train goes around corners",
+        "description": "Подвесной поезд, состоящий из машин-самолётов, свободно раскачивающихся на резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажираpa"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.suspended_swinging_cars": {
         "reference-name": "Suspended Swinging Cars",
-        "name": "Подвесные вагоны",
+        "name": "Подвесные машины",
         "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-        "description": "Suspended roller coaster train consisting of cars able to swing freely as the train goes around corners",
+        "description": "Подвесной поезд, состоящий из машин, свободно раскачивающихся на резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.swinging_lay_down_cars": {
         "reference-name": "Lay-down Cars",
-        "name": "Мини-летающие горки",
+        "name": "Лежачие машины",
         "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
-        "description": "Пассажиры едут лежа в вагончиках по одиночному рельсу, свободно качаясь на поворотах.",
+        "description": "Маленькие подвесные машины, в которых пассажиры лежат лицом вниз и качаются из стороны в сторону",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct1.ride.toilets": {
         "reference-name": "Toilets",
         "name": "Туалет",
         "reference-description": "Basic toilets housed in a prefabricated concrete building",
-        "description": "Уборная для посетителей парка"
+        "description": "Простые туалеты, находящиеся в сборном бетонном здании"
     },
     "rct1.ride.vertical_drop_trains": {
         "reference-name": "Six-seater Twister Trains",
-        "name": "Вертикальные горки",
+        "name": "Шестиместные поезда Твистер",
         "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
-        "description": "Широкие вагончики падают по вертикальному треку.",
-        "reference-capacity": "6 passengers per car",
+        "description": "Поезда с широкими машинами, предназначенными для падения с большой высоты.",
+        "reference-capacity": "6 пассажиров на машину",
         "capacity": "6 пассажиров"
     },
     "rct1.ride.wooden_rc_trains": {
         "reference-name": "Wooden Roller Coaster Trains",
-        "name": "Wooden Roller Coaster Trains",
+        "name": "Деревянные поезда",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+        "description": "Деревянные поезда для аттракционов с набитыми сиденьями и безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.ride.wooden_rc_trains_reversed": {
         "reference-name": "Wooden Roller Coaster Trains (Reversed)",
-        "name": "Wooden Roller Coaster Trains (Reversed)",
+        "name": "Деревянные поезда (реверс)",
         "reference-description": "Wooden roller coaster trains, but running in reverse, so that the passengers face backwards.",
-        "description": "Wooden roller coaster trains, but running in reverse, so that the passengers face backwards.",
+        "description": "Деревянные поезда, едущие в обратном направлении: пассажиры смотрят назад.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1.scenario_text.bumbly_beach": {
         "reference-name": "Bumbly Beach",
@@ -421,7 +421,7 @@
         "reference-park_name": "Bumbly Beach",
         "park_name": "Bumbly Beach",
         "reference-details": "Develop Bumbly Beach’s small amusement park into a thriving theme park",
-        "details": "Develop Bumbly Beach’s small amusement park into a thriving theme park"
+        "details": "Превратите крошечный парк на Bumbly Beach в успешный парк аттракционов"
     },
     "rct1.scenario_text.crumbly_woods": {
         "reference-name": "Crumbly Woods",
@@ -429,7 +429,7 @@
         "reference-park_name": "Crumbly Woods",
         "park_name": "Crumbly Woods",
         "reference-details": "A large park with well-designed but rather old rides. Replace the old rides or add new rides to make the park more popular.",
-        "details": "A large park with well-designed but rather old rides. Replace the old rides or add new rides to make the park more popular."
+        "details": "Большой парк с хорошими, но старыми аттракционами. Замените старые аттракционы или добавьте новые, чтобы прибавить парку популярности."
     },
     "rct1.scenario_text.diamond_heights": {
         "reference-name": "Diamond Heights",
@@ -437,7 +437,7 @@
         "reference-park_name": "Diamond Heights",
         "park_name": "Diamond Heights",
         "reference-details": "Diamond Heights is already a successful theme park with great rides - develop it to double its value",
-        "details": "Diamond Heights is already a successful theme park with great rides - develop it to double its value"
+        "details": "Diamond Heights - успешный парк с замечательными аттракционами. Удвойте его стоимость"
     },
     "rct1.scenario_text.dynamite_dunes": {
         "reference-name": "Dynamite Dunes",
@@ -445,7 +445,7 @@
         "reference-park_name": "Dynamite Dunes",
         "park_name": "Dynamite Dunes",
         "reference-details": "Built in the middle of the desert, this theme park contains just one roller coaster but has space for expansion",
-        "details": "Built in the middle of the desert, this theme park contains just one roller coaster but has space for expansion"
+        "details": "Этот парк содержит лишь один аттракцион в середине пустыни, но тут полно места чтобы расширяться"
     },
     "rct1.scenario_text.evergreen_gardens": {
         "reference-name": "Evergreen Gardens",
@@ -453,7 +453,7 @@
         "reference-park_name": "Evergreen Gardens",
         "park_name": "Evergreen Gardens",
         "reference-details": "Convert the beautiful Evergreen Gardens into a thriving theme park",
-        "details": "Convert the beautiful Evergreen Gardens into a thriving theme park"
+        "details": "Превратите прекрасный сад Evergreen Gardens в успешный парк аттракционов"
     },
     "rct1.scenario_text.forest_frontiers": {
         "reference-name": "Forest Frontiers",
@@ -461,7 +461,7 @@
         "reference-park_name": "Forest Frontiers",
         "park_name": "Forest Frontiers",
         "reference-details": "Deep in the forest, build a thriving theme park in a large cleared area",
-        "details": "Deep in the forest, build a thriving theme park in a large cleared area"
+        "details": "Постройте успешный парк аттракционов глубоко в лесу - на большой, плоской территории"
     },
     "rct1.scenario_text.ivory_towers": {
         "reference-name": "Ivory Towers",
@@ -469,7 +469,7 @@
         "reference-park_name": "Ivory Towers",
         "park_name": "Ivory Towers",
         "reference-details": "A well-established park, which has a few problems",
-        "details": "A well-established park, which has a few problems"
+        "details": "Хорошо известный парк, у которого есть несколько проблем"
     },
     "rct1.scenario_text.karts_coasters": {
         "reference-name": "Karts & Coasters",
@@ -477,7 +477,7 @@
         "reference-park_name": "Karts & Coasters",
         "park_name": "Karts & Coasters",
         "reference-details": "A large park hidden in the forest, with only go-kart tracks and wooden roller coasters",
-        "details": "A large park hidden in the forest, with only go-kart tracks and wooden roller coasters"
+        "details": "Большой парк спрятанный в лесу, где построен только картинг и деревянные аттракционы"
     },
     "rct1.scenario_text.katies_dreamland": {
         "reference-name": "Katie’s Dreamland",
@@ -485,7 +485,7 @@
         "reference-park_name": "Katie’s Dreamland",
         "park_name": "Katie’s Dreamland",
         "reference-details": "A small theme park with a few rides and room for expansion. Your aim is to double the park value.",
-        "details": "A small theme park with a few rides and room for expansion. Your aim is to double the park value."
+        "details": "Маленький парк с небольшим количеством аттракционов и большим пустым пространством. Ваша задача - удвоить его стоимость."
     },
     "rct1.scenario_text.leafy_lake": {
         "reference-name": "Leafy Lake",
@@ -493,7 +493,7 @@
         "reference-park_name": "Leafy Lake",
         "park_name": "Leafy Lake",
         "reference-details": "Starting from scratch, build a theme park around a large lake",
-        "details": "Starting from scratch, build a theme park around a large lake"
+        "details": "Начните с нуля, и постройте парк вокруг большого озера"
     },
     "rct1.scenario_text.lightning_peaks": {
         "reference-name": "Lightning Peaks",
@@ -501,7 +501,7 @@
         "reference-park_name": "Lightning Peaks",
         "park_name": "Lightning Peaks",
         "reference-details": "The beautiful mountains of Lightning Peaks are popular with walkers and sightseers. Use the available land to attract a new thrill-seeking clientele.",
-        "details": "The beautiful mountains of Lightning Peaks are popular with walkers and sightseers. Use the available land to attract a new thrill-seeking clientele."
+        "details": "Красивые горы Lightning Peaks уже популярны среди хайкеров и туристов. Используйте оставшееся место, чтобы привлечь новую, экстремальную клиентуру."
     },
     "rct1.scenario_text.mega_park": {
         "reference-name": "Mega Park",
@@ -509,7 +509,7 @@
         "reference-park_name": "Mega Park",
         "park_name": "Mega Park",
         "reference-details": "Just for fun!",
-        "details": "Just for fun!"
+        "details": "Просто веселитесь!"
     },
     "rct1.scenario_text.mels_world": {
         "reference-name": "Mel’s World",
@@ -517,7 +517,7 @@
         "reference-park_name": "Mel’s World",
         "park_name": "Mel’s World",
         "reference-details": "This theme park has some well-designed modern rides, but plenty of space for expansion",
-        "details": "This theme park has some well-designed modern rides, but plenty of space for expansion"
+        "details": "В этом парке есть несколько хороших, современных аттракционов, но много и пустого места"
     },
     "rct1.scenario_text.millennium_mines": {
         "reference-name": "Millennium Mines",
@@ -525,7 +525,7 @@
         "reference-park_name": "Millennium Mines",
         "park_name": "Millennium Mines",
         "reference-details": "Convert a large abandoned mine from a tourist attraction into a theme park",
-        "details": "Convert a large abandoned mine from a tourist attraction into a theme park"
+        "details": "Превратите заброшенную шахту, уже привлекающую туристов, в парк аттракционов"
     },
     "rct1.scenario_text.mystic_mountain": {
         "reference-name": "Mystic Mountain",
@@ -533,7 +533,7 @@
         "reference-park_name": "Mystic Mountain",
         "park_name": "Mystic Mountain",
         "reference-details": "In the hilly forests of Mystic Mountain, build a theme park from scratch",
-        "details": "In the hilly forests of Mystic Mountain, build a theme park from scratch"
+        "details": "Постройте парк с нуля в холмах и лесах на горе Mystic Mountain"
     },
     "rct1.scenario_text.pacific_pyramids": {
         "reference-name": "Pacific Pyramids",
@@ -541,7 +541,7 @@
         "reference-park_name": "Pacific Pyramids",
         "park_name": "Pacific Pyramids",
         "reference-details": "Convert the Egyptian Ruins tourist attraction into a thriving theme park",
-        "details": "Convert the Egyptian Ruins tourist attraction into a thriving theme park"
+        "details": "Превратите эти египетские руины в успешный парк аттракционов"
     },
     "rct1.scenario_text.paradise_pier": {
         "reference-name": "Paradise Pier",
@@ -549,7 +549,7 @@
         "reference-park_name": "Paradise Pier",
         "park_name": "Paradise Pier",
         "reference-details": "Convert this sleepy town’s pier into a thriving attraction",
-        "details": "Convert this sleepy town’s pier into a thriving attraction"
+        "details": "Превратите пирс этого спящего города в успешний парк аттракционов"
     },
     "rct1.scenario_text.pokey_park": {
         "reference-name": "Pokey Park",
@@ -557,7 +557,7 @@
         "reference-park_name": "Pokey Park",
         "park_name": "Pokey Park",
         "reference-details": "A small, cramped amusement park which requires major expansion",
-        "details": "A small, cramped amusement park which requires major expansion"
+        "details": "Маленький и тесный парк, который надо сильно расширять"
     },
     "rct1.scenario_text.rainbow_valley": {
         "reference-name": "Rainbow Valley",
@@ -565,7 +565,7 @@
         "reference-park_name": "Rainbow Valley",
         "park_name": "Rainbow Valley",
         "reference-details": "Rainbow Valley’s local authority won’t allow any landscape changes or large tree removal, but you must develop the area into a large theme park",
-        "details": "Rainbow Valley’s local authority won’t allow any landscape changes or large tree removal, but you must develop the area into a large theme park"
+        "details": "Власти Rainbow Valley запрещают вам менять ландшафт и убирать большие деревья, но вы всё равно должны построить здесь большой парк"
     },
     "rct1.scenario_text.thunder_rock": {
         "reference-name": "Thunder Rock",
@@ -573,7 +573,7 @@
         "reference-park_name": "Thunder Rock",
         "park_name": "Thunder Rock",
         "reference-details": "Thunder Rock stands in the middle of a desert and attracts many tourists. Use the available space to build rides to attract more people.",
-        "details": "Thunder Rock stands in the middle of a desert and attracts many tourists. Use the available space to build rides to attract more people."
+        "details": "Thunder Rock находится в середине пустыни и привлекает много туристов. Используйте это место чтобы построить аттракционы, и привлечь ещё больше."
     },
     "rct1.scenario_text.trinity_islands": {
         "reference-name": "Trinity Islands",
@@ -581,7 +581,7 @@
         "reference-park_name": "Trinity Islands",
         "park_name": "Trinity Islands",
         "reference-details": "Several islands form the basis for this new park",
-        "details": "Several islands form the basis for this new park"
+        "details": "Этот новый парк будет построен на нескольких островах"
     },
     "rct1.scenario_text.white_water_park": {
         "reference-name": "White Water Park",
@@ -589,7 +589,7 @@
         "reference-park_name": "White Water Park",
         "park_name": "White Water Park",
         "reference-details": "A park with some excellent water-based rides requires expansion",
-        "details": "A park with some excellent water-based rides requires expansion"
+        "details": "Парк с замечательными водными аттракционами, который нужно расширить"
     },
     "rct1.scenery_wall.playing_card_wall_1": {
         "reference-name": "Playing Card Wall",
@@ -601,51 +601,51 @@
     },
     "rct1.scenery_wall.roman_column_wall": {
         "reference-name": "Roman Column Wall",
-        "name": "Римская стена"
+        "name": "Стена из римских колонн"
     },
     "rct1.scenery_wall.wooden_fence_brown": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1.scenery_wall.wooden_fence_brown_gate": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1.scenery_wall.wooden_fence_red": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1.scenery_wall.wooden_fence_white": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1.terrain_edge.brick": {
         "reference-name": "Brick",
-        "name": "Brick"
+        "name": "Кирпич"
     },
     "rct1.terrain_edge.iron": {
         "reference-name": "Iron",
-        "name": "Iron"
+        "name": "Железо"
     },
     "rct1aa.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Square)",
-        "name": "Гравий"
+        "name": "Гравийная тропа (квадрат)"
     },
     "rct1aa.footpath_surface.queue_green": {
         "reference-name": "Green Queue",
-        "name": "Green Queue"
+        "name": "Зелёная очередь"
     },
     "rct1aa.footpath_surface.queue_red": {
         "reference-name": "Red Queue (Sloped)",
-        "name": "Red Queue (Sloped)"
+        "name": "Красная очередь (с наклоном)"
     },
     "rct1aa.footpath_surface.queue_yellow": {
         "reference-name": "Yellow Queue (Sloped)",
-        "name": "Yellow Queue (Sloped)"
+        "name": "Жёлтая очередь (с наклоном)"
     },
     "rct1aa.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Sloped)",
-        "name": "Дорожка"
+        "name": "Коричневый асфальт (с наклоном)"
     },
     "rct1aa.footpath_surface.tarmac_green": {
         "reference-name": "Green Tarmac Footpath",
@@ -653,123 +653,123 @@
     },
     "rct1aa.footpath_surface.tarmac_red": {
         "reference-name": "Red Tarmac Footpath (Sloped)",
-        "name": "Red Tarmac Footpath (Sloped)"
+        "name": "Красный асфальт (с наклоном)"
     },
     "rct1aa.footpath_surface.tiles_grey": {
         "reference-name": "Grey Tiled Footpath",
-        "name": "Grey Tiled Footpath"
+        "name": "Серая плитка"
     },
     "rct1aa.ride.bicycles": {
         "reference-name": "Bicycles",
-        "name": "Моноциклы",
+        "name": "Велосипеды",
         "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
-        "description": "Особые велосипеды с педальной тягой едут по стальным рельсам.",
+        "description": "Особые велосипеды, предназначенные для езды по монорельсу. Они двигаются вперёд благодаря движению педалей.",
         "reference-capacity": "1 rider per bicycle",
-        "capacity": "1 человек"
+        "capacity": "1 пассажир на велосипед"
     },
     "rct1aa.ride.floorless_twister_trains": {
         "reference-name": "Floorless Twister Trains",
-        "name": "Горки без пола",
+        "name": "Поезда Твистер без пола",
         "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
-        "description": "Широкие поезда без пола дают пассажирам чувство свободы, когда они едут по извивающейся трассе.",
+        "description": "Широкий поезд с безопасностью для плеч, но без пола, увеличивающий уровень энергии своих пассажиров.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.flying_saucers": {
         "reference-name": "Flying Saucers",
-        "name": "Тарелочки",
+        "name": "Летающие тарелки",
         "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
-        "description": "Самодвижущиеся машины",
+        "description": "Летающие машины в форме тарелок, которыми свободно управляют пассажиры",
         "reference-capacity": "1 person per car",
-        "capacity": "1 человек"
+        "capacity": "1 человек на машину"
     },
     "rct1aa.ride.ghost_train_cars": {
         "reference-name": "Ghost Train Cars",
-        "name": "Призрак",
+        "name": "Машины-призраки",
         "reference-description": "Powered monster-shaped cars that run on a ghost train track",
-        "description": "Машинки в виде монстров едут по страшным лабиринтам",
+        "description": "Машины в форме монстров, едущие по призрачным рельсам",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1aa.ride.heartline_twister_cars": {
         "reference-name": "Twister Cars",
         "name": "Твистер-Кар",
         "reference-description": "Roller coaster cars capable of heartline twists",
-        "description": "Вагончики, способные вращаться",
+        "description": "Машины, способные совершать перевороты в стиле Heartline",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.hyper_twister_trains": {
         "reference-name": "Hyper-Twister Trains (wide cars)",
-        "name": "Гипер-твистер (широкий)",
+        "name": "Гипер-твистер (широкие машины)",
         "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
-        "description": "Wide 4-across cars with raised seating and simple lap restraints",
+        "description": "Широкие машины, вмещающие 4 человека, с поднятыми сиденьями и простой безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.lay_down_trains": {
         "reference-name": "Lay-down Roller Coaster Trains",
-        "name": "Лежачие горки",
+        "name": "Лежачие поезда",
         "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
-        "description": "Люди лежат на специальных ремнях и несутся по крутому треку",
+        "description": "Специальная запряжка держит людей в лежачей позиции, позволяя им ехать либо на спине, либо на животе",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.mini_helicopters": {
         "reference-name": "Mini Helicopters",
-        "name": "Вертолётики",
+        "name": "Мини-вертолёты",
         "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
-        "description": "Машинки в виде вертолетиков.",
+        "description": "Машины в виде вертолётов, управляемые педалями.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 passengers per car"
+        "capacity": "2 пассажира на машину"
     },
     "rct1aa.ride.reverser_cars": {
         "reference-name": "Reverser Cars",
-        "name": "Горки с 4м измерением",
+        "name": "Реверсные машины",
         "reference-description": "Bogied cars capable of turning around on special reversing sections",
-        "description": "Вагончики на деревянных рельсах, меняющие направление на середине трека.",
+        "description": "Машины с отверстием, позволяющим им менять свое направление на предназначенных для этого секциях",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct1aa.ride.side_friction_cars": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Дерев. вагончики",
+        "name": "Деревянные машины с боковым трением",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Вагончики для боковых горок.",
+        "description": "Машины для аттракционов с боковым трением.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.ski_lift_cars": {
         "reference-name": "Ski-lift Chairs",
         "name": "Лыжные кресла",
         "reference-description": "Open cars for chairlift",
-        "description": "Открытые вагончики",
+        "description": "Открытые машины для канаток",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1aa.ride.splash_boats": {
         "reference-name": "Splash Boats",
-        "name": "Лодки",
+        "name": "Всплесковые лодки",
         "reference-description": "Large capacity boats, built for water tracks with very steep drops",
-        "description": "Вместительные лодки плывут по широкому каналу при помощи ременного привода.",
+        "description": "Вместительные лодки, построенные для водных треков с очень резкими падениями",
         "reference-capacity": "16 passengers per boat",
-        "capacity": "16 пассажиров"
+        "capacity": "16 пассажиров на лодку"
     },
     "rct1aa.ride.stand_up_twister_trains": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Стоячие горки",
+        "name": "Стоячие поезда Твистер",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
-        "description": "Посетители едут стоя в широких поездах в специальных креплениях.",
+        "description": "Поезд с безопасностью для плеч, предназначенный для езды стоя.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.steam_trains_covered": {
         "reference-name": "Steam Trains with Covered Cars",
-        "name": "Паровозики с вагончиками",
+        "name": "Паравоз с накрытыми вагонами",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct1aa.ride.steel_wild_mouse_cars": {
         "reference-name": "Mouse Cars",
@@ -777,47 +777,47 @@
         "reference-description": "Individual cars shaped like mice",
         "description": "Машинки в виде мышек",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.suspended_monorail_trains": {
         "reference-name": "Suspended Monorail Trains",
-        "name": "Подвесные поезда",
+        "name": "Подвесной монорельс",
         "reference-description": "Large capacity monorail train cars",
         "description": "Большие монорельсовые поезда",
         "reference-capacity": "8 passengers per car",
-        "capacity": "8 пассажиров"
+        "capacity": "8 пассажиров на машину"
     },
     "rct1aa.ride.twister_trains": {
         "reference-name": "Twister Trains",
-        "name": "Твистер-коастер",
+        "name": "Твистер-поезд",
         "reference-description": "Spacious trains with shoulder restraints",
-        "description": "Широкие поезда скользят по гладким рельсам со множеством поворотов",
+        "description": "Вместительные поезда с безопасностью для плеч",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.vintage_cars": {
         "reference-name": "Vintage Cars",
         "name": "Ретрокары",
         "reference-description": "Powered vehicles in the shape of vintage cars",
-        "description": "Люди катаются на старинных автомобильчиках.",
+        "description": "Машины в форме старых автомобилей.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1aa.ride.virginia_reel_tubs": {
         "reference-name": "Virginia Reel Tubs",
-        "name": "Вирджиния",
+        "name": "Трубы \"Вирджиния\"",
         "reference-description": "Circular cars that spin around as they travel along the track",
-        "description": "Круглые вагончики едут по трассе и одновременно крутятся.",
+        "description": "Круглые машины, которые вращаются во время езды.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1aa.ride.wooden_articulated_trains": {
         "reference-name": "Articulated Roller Coaster Trains",
         "name": "Сочленённые поезда",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-        "description": "Поезда для горок с короткими вагончиками",
+        "description": "Поезда с короткими машинами в один ряд, с открытой передней частью",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1aa.scenario_text.adrenaline_heights": {
         "reference-name": "Adrenaline Heights",
@@ -825,7 +825,7 @@
         "reference-park_name": "Adrenaline Heights",
         "park_name": "Adrenaline Heights",
         "reference-details": "Build a park to appeal to the high-intensity thrill-seeking local people",
-        "details": "Build a park to appeal to the high-intensity thrill-seeking local people"
+        "details": "Постройте парк, привлекающий местных экстремалов"
     },
     "rct1aa.scenario_text.barony_bridge": {
         "reference-name": "Barony Bridge",
@@ -833,7 +833,7 @@
         "reference-park_name": "Barony Bridge",
         "park_name": "Barony Bridge",
         "reference-details": "An old redundant bridge is yours to develop into an amusement park",
-        "details": "An old redundant bridge is yours to develop into an amusement park"
+        "details": "Вам достался старый, никому не нужный мост. Постройте вокруг него парк"
     },
     "rct1aa.scenario_text.butterfly_dam": {
         "reference-name": "Butterfly Dam",
@@ -841,7 +841,7 @@
         "reference-park_name": "Butterfly Dam",
         "park_name": "Butterfly Dam",
         "reference-details": "The area around a dam is available for you to develop into an amusement park",
-        "details": "The area around a dam is available for you to develop into an amusement park"
+        "details": "Вам доступна область вокруг дамбы для строения парка"
     },
     "rct1aa.scenario_text.canary_mines": {
         "reference-name": "Canary Mines",
@@ -849,7 +849,7 @@
         "reference-park_name": "Canary Mines",
         "park_name": "Canary Mines",
         "reference-details": "This abandoned mine already has the makings of a tourist attraction with its miniature railway and a pair of vertical drop roller coasters",
-        "details": "This abandoned mine already has the makings of a tourist attraction with its miniature railway and a pair of vertical drop roller coasters"
+        "details": "Эта заброшенная шахта уже привлекает туристов своей миниатюрной железной дорогой и парочкой вертикальных аттракционов"
     },
     "rct1aa.scenario_text.coaster_canyon": {
         "reference-name": "Coaster Canyon",
@@ -857,7 +857,7 @@
         "reference-park_name": "Coaster Canyon",
         "park_name": "Coaster Canyon",
         "reference-details": "A vast canyon is yours to turn into a theme park",
-        "details": "A vast canyon is yours to turn into a theme park"
+        "details": "Превратите огромный каньон в парк"
     },
     "rct1aa.scenario_text.coaster_crazy": {
         "reference-name": "Coaster Crazy",
@@ -865,7 +865,7 @@
         "reference-park_name": "Coaster Crazy",
         "park_name": "Coaster Crazy",
         "reference-details": "You have limited funds but unlimited time to turn this mountainside area into a vast roller coaster park",
-        "details": "You have limited funds but unlimited time to turn this mountainside area into a vast roller coaster park"
+        "details": "У вас есть ограниченное количество денег - но неограниченное количество времени - чтобы превратить эту горную область в огромный парк аттракционов"
     },
     "rct1aa.scenario_text.fiasco_forest": {
         "reference-name": "Fiasco Forest",
@@ -873,7 +873,7 @@
         "reference-park_name": "Fiasco Forest",
         "park_name": "Fiasco Forest",
         "reference-details": "Full of badly designed and dangerous rides, you have a very limited budget and time to fix the problems and turn the park around",
-        "details": "Full of badly designed and dangerous rides, you have a very limited budget and time to fix the problems and turn the park around"
+        "details": "Тут полно плохих и опасных аттракционов, и у вас очень ограниченный бюджет чтобы исправить все проблемы этого парка"
     },
     "rct1aa.scenario_text.fruit_farm": {
         "reference-name": "Fruit Farm",
@@ -881,7 +881,7 @@
         "reference-park_name": "Fruit Farm",
         "park_name": "Fruit Farm",
         "reference-details": "A thriving fruit farm has built a railroad to boost its income, your job is to develop it into a full-blown amusement park",
-        "details": "A thriving fruit farm has built a railroad to boost its income, your job is to develop it into a full-blown amusement park"
+        "details": "Успешная фруктовая ферма построила железную дорогу для улучшения своих доходов. Ваша задача - превратить её в парк"
     },
     "rct1aa.scenario_text.fun_fortress": {
         "reference-name": "Fun Fortress",
@@ -889,7 +889,7 @@
         "reference-park_name": "Fun Fortress",
         "park_name": "Fun Fortress",
         "reference-details": "This castle is all yours to turn into a theme park",
-        "details": "This castle is all yours to turn into a theme park"
+        "details": "Этот замок - ваш, чтобы превратить его в парк"
     },
     "rct1aa.scenario_text.funtopia": {
         "reference-name": "Funtopia",
@@ -897,7 +897,7 @@
         "reference-park_name": "Funtopia",
         "park_name": "Funtopia",
         "reference-details": "Covering land both sides of a highway, this park has several rides already operating",
-        "details": "Covering land both sides of a highway, this park has several rides already operating"
+        "details": "Этот парк, покрывающий две стороны большого шоссе, уже имеет несколько аттракционов"
     },
     "rct1aa.scenario_text.future_world": {
         "reference-name": "Future World",
@@ -905,7 +905,7 @@
         "reference-park_name": "Future World",
         "park_name": "Future World",
         "reference-details": "This futuristic park has plenty of space for new rides on its alien landscape",
-        "details": "This futuristic park has plenty of space for new rides on its alien landscape"
+        "details": "В этом парке будущего, с пришельским ландшафтом, полно места для аттракционов"
     },
     "rct1aa.scenario_text.gentle_glen": {
         "reference-name": "Gentle Glen",
@@ -913,7 +913,7 @@
         "reference-park_name": "Gentle Glen",
         "park_name": "Gentle Glen",
         "reference-details": "The local population prefer gentle and relaxing rides, so it is your job to expand this park to suit their tastes",
-        "details": "The local population prefer gentle and relaxing rides, so it is your job to expand this park to suit their tastes"
+        "details": "Местное население предпочитает мягкие, расслабляющие аттракционы. Ваша задача - расширить свой парк под их вкус"
     },
     "rct1aa.scenario_text.geoffrey_gardens": {
         "reference-name": "Geoffrey Gardens",
@@ -921,7 +921,7 @@
         "reference-park_name": "Geoffrey Gardens",
         "park_name": "Geoffrey Gardens",
         "reference-details": "A large garden park needs turning into a thriving theme park",
-        "details": "A large garden park needs turning into a thriving theme park"
+        "details": "Большой сад, который нужно превратить в парк"
     },
     "rct1aa.scenario_text.giggle_downs": {
         "reference-name": "Giggle Downs",
@@ -929,7 +929,7 @@
         "reference-park_name": "Giggle Downs",
         "park_name": "Giggle Downs",
         "reference-details": "A four lane steeplechase ride is the centrepiece of this expanding park",
-        "details": "A four lane steeplechase ride is the centrepiece of this expanding park"
+        "details": "Четырехполосная лошадинная гонка - центральный элемент этого расширяющегося парка"
     },
     "rct1aa.scenario_text.harmonic_hills": {
         "reference-name": "Harmonic Hills",
@@ -937,7 +937,7 @@
         "reference-park_name": "Harmonic Hills",
         "park_name": "Harmonic Hills",
         "reference-details": "The local authority won’t allow you to build above tree height in this park",
-        "details": "The local authority won’t allow you to build above tree height in this park"
+        "details": "Местные власти не позволяют вам строить аттракционы выше чем деревья этого парка"
     },
     "rct1aa.scenario_text.haunted_harbour": {
         "reference-name": "Haunted Harbour",
@@ -945,7 +945,7 @@
         "reference-park_name": "Haunted Harbour",
         "park_name": "Haunted Harbour",
         "reference-details": "The local authority has agreed to sell nearby land cheaply to this small seaside park, on the condition that certain rides are preserved",
-        "details": "The local authority has agreed to sell nearby land cheaply to this small seaside park, on the condition that certain rides are preserved"
+        "details": "Местные власти продали дешёвую землю этому маленькому парку, с условием, что некоторые аттракционы нужно сохранить"
     },
     "rct1aa.scenario_text.hydro_hills": {
         "reference-name": "Hydro Hills",
@@ -953,7 +953,7 @@
         "reference-park_name": "Hydro Hills",
         "park_name": "Hydro Hills",
         "reference-details": "A series of stepped lakes form the basis for this new park",
-        "details": "A series of stepped lakes form the basis for this new park"
+        "details": "Этот парк будет построен среди нескольких озёр"
     },
     "rct1aa.scenario_text.jolly_jungle": {
         "reference-name": "Jolly Jungle",
@@ -961,7 +961,7 @@
         "reference-park_name": "Jolly Jungle",
         "park_name": "Jolly Jungle",
         "reference-details": "Deep in the jungle lies a large area of land ready to be turned into a theme park",
-        "details": "Deep in the jungle lies a large area of land ready to be turned into a theme park"
+        "details": "Глубоко в джунглях лежит большая площадь, которая готова к превращению в парк"
     },
     "rct1aa.scenario_text.magic_quarters": {
         "reference-name": "Magic Quarters",
@@ -969,7 +969,7 @@
         "reference-park_name": "Magic Quarters",
         "park_name": "Magic Quarters",
         "reference-details": "A large area of land has been cleared and partially themed ready for you to develop into a landscaped theme park",
-        "details": "A large area of land has been cleared and partially themed ready for you to develop into a landscaped theme park"
+        "details": "Большая площадь земли была очищена и украшена для вас, чтобы вы разработали здесь парк"
     },
     "rct1aa.scenario_text.mineral_park": {
         "reference-name": "Mineral Park",
@@ -977,7 +977,7 @@
         "reference-park_name": "Mineral Park",
         "park_name": "Mineral Park",
         "reference-details": "Turn this abandoned stone quarry into a place to attract thrill-seeking tourists",
-        "details": "Turn this abandoned stone quarry into a place to attract thrill-seeking tourists"
+        "details": "Превратите эту заброшенный карьер в место, привлекающее экстремальных туристов"
     },
     "rct1aa.scenario_text.pickle_park": {
         "reference-name": "Pickle Park",
@@ -985,7 +985,7 @@
         "reference-park_name": "Pickle Park",
         "park_name": "Pickle Park",
         "reference-details": "The local authority will not allow any kind of advertising or promotion, so this park must succeed by reputation only",
-        "details": "The local authority will not allow any kind of advertising or promotion, so this park must succeed by reputation only"
+        "details": "Местные власти запретили всю рекламу, так что парк должен выжить лишь на своей репутации"
     },
     "rct1aa.scenario_text.roman_village": {
         "reference-name": "Roman Village",
@@ -993,7 +993,7 @@
         "reference-park_name": "Roman Village",
         "park_name": "Roman Village",
         "reference-details": "Develop this Roman-themed park by adding rides and roller coasters",
-        "details": "Develop this Roman-themed park by adding rides and roller coasters"
+        "details": "Улучшите состояние этого парка с римской тематикой, добавив новые аттракционы"
     },
     "rct1aa.scenario_text.rotting_heights": {
         "reference-name": "Rotting Heights",
@@ -1001,7 +1001,7 @@
         "reference-park_name": "Rotting Heights",
         "park_name": "Rotting Heights",
         "reference-details": "Overgrown and dilapidated, can you resurrect this once-great amusement park?",
-        "details": "Overgrown and dilapidated, can you resurrect this once-great amusement park?"
+        "details": "Этот заброшенный парк разваливается. Сможете ли вы его оживить?"
     },
     "rct1aa.scenario_text.sprightly_park": {
         "reference-name": "Sprightly Park",
@@ -1009,7 +1009,7 @@
         "reference-park_name": "Sprightly Park",
         "park_name": "Sprightly Park",
         "reference-details": "This elderly park has many historical rides but is badly in debt",
-        "details": "This elderly park has many historical rides but is badly in debt"
+        "details": "В этом старом парке много аттракционов с исторической значимостью, но он в глубоких долгах"
     },
     "rct1aa.scenario_text.swamp_cove": {
         "reference-name": "Swamp Cove",
@@ -1017,7 +1017,7 @@
         "reference-park_name": "Swamp Cove",
         "park_name": "Swamp Cove",
         "reference-details": "Built partly on a series of small islands, this park already has a pair of large roller coasters as its centrepiece",
-        "details": "Built partly on a series of small islands, this park already has a pair of large roller coasters as its centrepiece"
+        "details": "Этот парк, построенный на нескольких маленьких островах, уже имеет пару больших аттракционов, привлекающих людей"
     },
     "rct1aa.scenario_text.three_monkeys_park": {
         "reference-name": "Three Monkeys Park",
@@ -1025,7 +1025,7 @@
         "reference-park_name": "Three Monkeys Park",
         "park_name": "Three Monkeys Park",
         "reference-details": "Central to this large developing park is a giant triple-track racing/duelling steel coaster",
-        "details": "Central to this large developing park is a giant triple-track racing/duelling steel coaster"
+        "details": "Центром этого большого развивающегося парка является гигантский трёх-трековый гоночный аттракцион"
     },
     "rct1aa.scenario_text.thunderstorm_park": {
         "reference-name": "Thunderstorm Park",
@@ -1033,7 +1033,7 @@
         "reference-park_name": "Thunderstorm Park",
         "park_name": "Thunderstorm Park",
         "reference-details": "The weather is so wet here that a giant pyramid has been built to allow some rides to be built under cover",
-        "details": "The weather is so wet here that a giant pyramid has been built to allow some rides to be built under cover"
+        "details": "Погода здесь настолько мокрая, что мы построили для вас огромную пирамиду - вы можете строить под ней аттракционы"
     },
     "rct1aa.scenario_text.urban_park": {
         "reference-name": "Urban Park",
@@ -1041,7 +1041,7 @@
         "reference-park_name": "Urban Park",
         "park_name": "Urban Park",
         "reference-details": "A tiny park has done a deal with the nearby town to allow expansion through the town itself",
-        "details": "A tiny park has done a deal with the nearby town to allow expansion through the town itself"
+        "details": "Маленький парк совершил сделку с близлежащим городом, и теперь он может расширяться на территорию самого города"
     },
     "rct1aa.scenario_text.utopia_park": {
         "reference-name": "Utopia Park",
@@ -1049,7 +1049,7 @@
         "reference-park_name": "Utopia",
         "park_name": "Utopia",
         "reference-details": "An oasis in the middle of the desert provides an unusual opportunity to build an amusement park",
-        "details": "An oasis in the middle of the desert provides an unusual opportunity to build an amusement park"
+        "details": "Оазис в середине пустыни - необычная возможность построить парк"
     },
     "rct1aa.scenario_text.whispering_cliffs": {
         "reference-name": "Whispering Cliffs",
@@ -1057,47 +1057,47 @@
         "reference-park_name": "Whispering Cliffs",
         "park_name": "Whispering Cliffs",
         "reference-details": "Develop the seaside cliffs into a thriving amusement park",
-        "details": "Develop the seaside cliffs into a thriving amusement park"
+        "details": "Сделайте из обрыва на берегу моря успешный парк"
     },
     "rct1aa.scenery_wall.glass_wall": {
         "reference-name": "Glass Wall",
-        "name": "Стена"
+        "name": "Стеклянная стена"
     },
     "rct1aa.scenery_wall.wooden_post_wall_1": {
         "reference-name": "Wooden Post Wall",
-        "name": "Деревянная стена"
+        "name": "Стена из деревянных столбов"
     },
     "rct1aa.scenery_wall.wooden_post_wall_2": {
         "reference-name": "Wooden Post Wall",
-        "name": "Деревянная стена"
+        "name": "Стена из деревянных столбов"
     },
     "rct1aa.terrain_edge.grey": {
         "reference-name": "Stucco (Grey)",
-        "name": "Stucco (Grey)"
+        "name": "Штукатурка (серая)"
     },
     "rct1aa.terrain_edge.red": {
         "reference-name": "Stucco (Red)",
-        "name": "Stucco (Red)"
+        "name": "Штукатурка (красная)"
     },
     "rct1aa.terrain_edge.yellow": {
         "reference-name": "Stucco (Yellow)",
-        "name": "Stucco (Yellow)"
+        "name": "Штукатурка (жёлтая)"
     },
     "rct1aa.terrain_surface.roof_red": {
         "reference-name": "Roof (Red)",
-        "name": "Roof (Red)"
+        "name": "Крыша (красная)"
     },
     "rct1beta.terrain_edge.brick": {
         "reference-name": "Brick (Brown)",
-        "name": "Brick (Brown)"
+        "name": "Кирпич (коричневый)"
     },
     "rct1beta.terrain_edge.rock": {
         "reference-name": "Rock (Brown)",
-        "name": "Rock (Brown)"
+        "name": "Камень (коричневый)"
     },
     "rct1beta.terrain_surface.wildflowers": {
         "reference-name": "Wildflowers",
-        "name": "Wildflowers"
+        "name": "Дикие цветы"
     },
     "rct1dlc.scenario_text.fort_anachronism": {
         "reference-name": "Fort Anachronism",
@@ -1109,91 +1109,91 @@
     },
     "rct1ll.footpath_railings.bamboo": {
         "reference-name": "Bamboo Railings (Yellow)",
-        "name": "Bamboo Railings (Yellow)"
+        "name": "Бамбуковые рельсы (жёлтые)"
     },
     "rct1ll.footpath_railings.space": {
         "reference-name": "Space Style Railings (Grey)",
-        "name": "Space Style Railings (Grey)"
+        "name": "Космические рельсы (серые)"
     },
     "rct1ll.footpath_surface.tiles_green": {
         "reference-name": "Green and Brown Tiled Footpath",
-        "name": "Green and Brown Tiled Footpath"
+        "name": "Зелёно-коричневая плитка"
     },
     "rct1ll.footpath_surface.tiles_red": {
         "reference-name": "Red and Brown Tiled Footpath",
-        "name": "Red and Brown Tiled Footpath"
+        "name": "Красно-коричневая плитка"
     },
     "rct1ll.ride.4_across_inverted_trains": {
         "reference-name": "4-across Inverted Roller Coaster Trains",
-        "name": "Перевёрнутые горки",
+        "name": "Перевернутый поезд (шириной в 4)",
         "reference-description": "Suspended trains in which riders sit in rows",
-        "description": "Пассажиры сидят под треком и несутся по огромным кольцам с переворотами и падениями.",
+        "description": "Подвисной поезд, пассажиры которого сидят в ряд",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1ll.ride.air_powered_trains": {
         "reference-name": "Air Powered Vertical Coaster Trains",
-        "name": "Воздушные горки",
+        "name": "Вертикальные поезда с воздушным питанием",
         "reference-description": "Air-powered launched roller coaster trains",
-        "description": "После воздушного запуска поезд устремляется на вертикальный трек и затем падает с другой стороны и возвращается на станцию.",
+        "description": "Поезда для аттракционов, запускаемые воздухом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct1ll.ride.coaster_boats": {
         "reference-name": "Coaster Boats",
-        "name": "Лодки-горки",
+        "name": "Лодки",
         "reference-description": "Boat-shaped roller coaster cars",
-        "description": "Вагончки в виде лодок",
+        "description": "Машины для аттракционов в виде лодок",
         "reference-capacity": "6 passengers per boat",
         "capacity": "6 пассажиров"
     },
     "rct1ll.ride.face_off_cars": {
         "reference-name": "Face-off Cars",
-        "name": "Инвертные Горки",
+        "name": "Машины \"лицом-к-лицу\"",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
-        "description": "Люди сидят парами друг напротив друга.",
+        "description": "Люди сидят парами друг напротив друга, проходя резкие петли и перевороты",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1ll.ride.hypercoaster_trains": {
         "reference-name": "Hypercoaster Trains",
         "name": "Гипергорки",
         "reference-description": "Comfortable trains with only lap bar restraints",
-        "description": "Высокие прямые горки с глубокими падениями и большой скоростью, ремни только на колени.",
+        "description": "Комфортабельные поезда с безопасностью для ног.",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct1ll.ride.inverted_hairpin_cars": {
         "reference-name": "Four-seater Cars",
-        "name": "Обратные поворот. горки",
+        "name": "Четырёхместные машины",
         "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
-        "description": "Отдельные вагончики едут по зигзагообразному треку с разворотами и падениями",
+        "description": "Машины созданные для треков с резкими поворотами и падениями",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct1ll.ride.jet_skis": {
         "reference-name": "Jet Skis",
-        "name": "Скутеры",
+        "name": "Гидроциклы",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
-        "description": "Водные скутеры на одного человека.",
+        "description": "Гидроциклы для одного человека, управляемые самими пассажирами",
         "reference-capacity": "1 rider per vehicle",
-        "capacity": "1 чел"
+        "capacity": "1 пассажир на машину"
     },
     "rct1ll.ride.rafts": {
         "reference-name": "Rafts",
-        "name": "Рафтинг",
+        "name": "Плоты",
         "reference-description": "Raft-shaped boats built for flat river tracks",
-        "description": "Люди плывут по каналу на деревянных плотах.",
+        "description": "Лодки в форме плотов, созданные для плоских речных треков",
         "reference-capacity": "4 passengers per raft",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на плот"
     },
     "rct1ll.ride.steam_trains_american": {
         "reference-name": "American Style Steam Trains",
         "name": "Американский паровоз",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct1ll.scenario_text.alton_towers": {
         "reference-name": "Alton Towers",
@@ -1209,7 +1209,7 @@
         "reference-park_name": "Arid Heights",
         "park_name": "Arid Heights",
         "reference-details": "Free of any financial limits, your challenge is to develop this desert park while keeping the guests happy",
-        "details": "Free of any financial limits, your challenge is to develop this desert park while keeping the guests happy"
+        "details": "У вас нет финансовый ограничений - развивайте этот пустынный парк, и убедитесь что ваши гости довольны"
     },
     "rct1ll.scenario_text.blackpool_pleasure_beach": {
         "reference-name": "Blackpool Pleasure Beach",
@@ -1225,7 +1225,7 @@
         "reference-park_name": "Crater Lake",
         "park_name": "Crater Lake",
         "reference-details": "A large lake in an ancient crater is the setting for this park",
-        "details": "A large lake in an ancient crater is the setting for this park"
+        "details": "Большое озеро в центре древнего кратера станет местоположением этого парка"
     },
     "rct1ll.scenario_text.crazy_craters": {
         "reference-name": "Crazy Craters",
@@ -1233,7 +1233,7 @@
         "reference-park_name": "Crazy Craters",
         "park_name": "Crazy Craters",
         "reference-details": "In a far-off world where money is not needed, you must build an entertainment centre to keep the people happy",
-        "details": "In a far-off world where money is not needed, you must build an entertainment centre to keep the people happy"
+        "details": "В далёком мире, где не существует денег, вы обязаны строить развлечения для людей"
     },
     "rct1ll.scenario_text.dragons_cove": {
         "reference-name": "Dragon’s Cove",
@@ -1241,7 +1241,7 @@
         "reference-park_name": "Dragon’s Cove",
         "park_name": "Dragon’s Cove",
         "reference-details": "This sea-side cove is the setting for this coaster-building challenge",
-        "details": "This sea-side cove is the setting for this coaster-building challenge"
+        "details": "Эта морская бухта бросает вам вызов: постройте здесь парк"
     },
     "rct1ll.scenario_text.dusty_desert": {
         "reference-name": "Dusty Desert",
@@ -1249,7 +1249,7 @@
         "reference-park_name": "Dusty Desert",
         "park_name": "Dusty Desert",
         "reference-details": "Five coasters require completion in this desert park",
-        "details": "Five coasters require completion in this desert park"
+        "details": "Нужно достроить до конца пять аттракционов в этом пустынном парке"
     },
     "rct1ll.scenario_text.frightmare_hills": {
         "reference-name": "Frightmare Hills",
@@ -1257,7 +1257,7 @@
         "reference-park_name": "Frightmare Hills",
         "park_name": "Frightmare Hills",
         "reference-details": "A scary park with a giant centrepiece coaster",
-        "details": "A scary park with a giant centrepiece coaster"
+        "details": "Страшный парк с гигантским центральным аттракционом"
     },
     "rct1ll.scenario_text.good_knight_park": {
         "reference-name": "Good Knight Park",
@@ -1265,7 +1265,7 @@
         "reference-park_name": "Good Knight Park",
         "park_name": "Good Knight Park",
         "reference-details": "A castle with a pair of roller coasters needs developing into a larger theme park",
-        "details": "A castle with a pair of roller coasters needs developing into a larger theme park"
+        "details": "Замок с парочкой аттракционов, который нужно разработать в более крупный парк"
     },
     "rct1ll.scenario_text.grand_glacier": {
         "reference-name": "Grand Glacier",
@@ -1273,7 +1273,7 @@
         "reference-park_name": "Grand Glacier",
         "park_name": "Grand Glacier",
         "reference-details": "A glacier-filled valley is yours to develop into a theme park",
-        "details": "A glacier-filled valley is yours to develop into a theme park"
+        "details": "Эта долина с ледниками - ваша, чтобы создать в ней парк"
     },
     "rct1ll.scenario_text.heidepark": {
         "reference-name": "Heide-Park",
@@ -1289,7 +1289,7 @@
         "reference-park_name": "Icarus Park",
         "park_name": "Icarus Park",
         "reference-details": "Develop this alien park to maximise its profit",
-        "details": "Develop this alien park to maximise its profit"
+        "details": "Максимизируйте доходы этого пришельского парка"
     },
     "rct1ll.scenario_text.iceberg_islands": {
         "reference-name": "Iceberg Islands",
@@ -1297,7 +1297,7 @@
         "reference-park_name": "Iceberg Islands",
         "park_name": "Iceberg Islands",
         "reference-details": "A collection of icebergs make a cold setting for this ambitious theme park",
-        "details": "A collection of icebergs make a cold setting for this ambitious theme park"
+        "details": "Набор холодных айсбергов - место для этого амбициозного парка"
     },
     "rct1ll.scenario_text.icicle_worlds": {
         "reference-name": "Icicle Worlds",
@@ -1305,7 +1305,7 @@
         "reference-park_name": "Icicle Worlds",
         "park_name": "Icicle Worlds",
         "reference-details": "An icy landscape needs turning into a thriving theme park",
-        "details": "An icy landscape needs turning into a thriving theme park"
+        "details": "Ледяной ландшафт, который нужно превратить в успешный парк"
     },
     "rct1ll.scenario_text.megaworld_park": {
         "reference-name": "Megaworld Park",
@@ -1313,7 +1313,7 @@
         "reference-park_name": "Megaworld Park",
         "park_name": "Megaworld Park",
         "reference-details": "A giant park already packed full of rides needs improving",
-        "details": "A giant park already packed full of rides needs improving"
+        "details": "Гигантский парк, в котором полно аттракционов. Он нуждается в улучшениях"
     },
     "rct1ll.scenario_text.micro_park": {
         "reference-name": "Micro Park",
@@ -1321,7 +1321,7 @@
         "reference-park_name": "Micro Park",
         "park_name": "Micro Park",
         "reference-details": "Try to create the world’s smallest profitable park",
-        "details": "Try to create the world’s smallest profitable park"
+        "details": "Попробуйте создать самый маленький парк в мире - и получить прибыль"
     },
     "rct1ll.scenario_text.nevermore_park": {
         "reference-name": "Nevermore Park",
@@ -1329,7 +1329,7 @@
         "reference-park_name": "Nevermore Park",
         "park_name": "Nevermore Park",
         "reference-details": "A large park with a novel transportation system around its edge",
-        "details": "A large park with a novel transportation system around its edge"
+        "details": "Большой парк с необычной транспортной системой у его краёв"
     },
     "rct1ll.scenario_text.octagon_park": {
         "reference-name": "Octagon Park",
@@ -1337,7 +1337,7 @@
         "reference-park_name": "Octagon Park",
         "park_name": "Octagon Park",
         "reference-details": "In this large park you must design and build ten large coasters",
-        "details": "In this large park you must design and build ten large coasters"
+        "details": "Постройте 10 больших аттракционов собственного дизайна в этом большом парке"
     },
     "rct1ll.scenario_text.pacifica": {
         "reference-name": "Pacifica",
@@ -1345,7 +1345,7 @@
         "reference-park_name": "Pacifica",
         "park_name": "Pacifica",
         "reference-details": "This large island is all yours to develop as an amusement park",
-        "details": "This large island is all yours to develop as an amusement park"
+        "details": "Превратите весь большой остров в парк развлечений"
     },
     "rct1ll.scenario_text.paradise_pier_2": {
         "reference-name": "Paradise Pier 2",
@@ -1353,7 +1353,7 @@
         "reference-park_name": "Paradise Pier 2",
         "park_name": "Paradise Pier 2",
         "reference-details": "Paradise Pier has expanded its network of walkways over the sea, and your task is to expand the park to use the extra space",
-        "details": "Paradise Pier has expanded its network of walkways over the sea, and your task is to expand the park to use the extra space"
+        "details": "Paradise Pier расширил свою сеть мостов, и ваша задача - расширить сам парк, чтобы использовать это новое пространство"
     },
     "rct1ll.scenario_text.pleasure_island": {
         "reference-name": "Pleasure Island",
@@ -1361,7 +1361,7 @@
         "reference-park_name": "Pleasure Island",
         "park_name": "Pleasure Island",
         "reference-details": "A long thin island makes a challenging setting to build a selection of coasters",
-        "details": "A long thin island makes a challenging setting to build a selection of coasters"
+        "details": "Длинный и узкий остров - сложное место, чтобы строить аттракционы"
     },
     "rct1ll.scenario_text.razor_rocks": {
         "reference-name": "Razor Rocks",
@@ -1369,7 +1369,7 @@
         "reference-park_name": "Razor Rocks",
         "park_name": "Razor Rocks",
         "reference-details": "Your task is to build a massive coaster-filled park in amongst Razor Rocks",
-        "details": "Your task is to build a massive coaster-filled park in amongst Razor Rocks"
+        "details": "Ваша задача - построить огромный парк, заполненный аттракционами, в скалах Razor Rocks"
     },
     "rct1ll.scenario_text.southern_sands": {
         "reference-name": "Southern Sands",
@@ -1377,7 +1377,7 @@
         "reference-park_name": "Southern Sands",
         "park_name": "Southern Sands",
         "reference-details": "A desert park with some cleverly designed coasters is yours to expand",
-        "details": "A desert park with some cleverly designed coasters is yours to expand"
+        "details": "Пустынный парк с несколькими умно-разработанными аттракционами ждёт вашего расширения"
     },
     "rct1ll.scenario_text.sunny_swamps": {
         "reference-name": "Sunny Swamps",
@@ -1385,7 +1385,7 @@
         "reference-park_name": "Sunny Swamps",
         "park_name": "Sunny Swamps",
         "reference-details": "This well-themed amusement park already has several rides, but has plenty of space for expansion",
-        "details": "This well-themed amusement park already has several rides, but has plenty of space for expansion"
+        "details": "У этого стильного парка развлечений уже есть несколько аттракционов, и много места для расширения"
     },
     "rct1ll.scenario_text.terror_town": {
         "reference-name": "Terror Town",
@@ -1393,7 +1393,7 @@
         "reference-park_name": "Terror Town",
         "park_name": "Terror Town",
         "reference-details": "This urban area is all yours to develop into an amusement park",
-        "details": "This urban area is all yours to develop into an amusement park"
+        "details": "Превратите эту городскую область в парк развлечений"
     },
     "rct1ll.scenario_text.thunder_rocks": {
         "reference-name": "Thunder Rocks",
@@ -1401,7 +1401,7 @@
         "reference-park_name": "Thunder Rocks",
         "park_name": "Thunder Rocks",
         "reference-details": "Two large hunks of rock stick out of the sand, upon which the beginnings of a theme park are constructed",
-        "details": "Two large hunks of rock stick out of the sand, upon which the beginnings of a theme park are constructed"
+        "details": "Из земли торчат две больших скалы. Начните строительство своего парка вокруг них."
     },
     "rct1ll.scenario_text.tiny_towers": {
         "reference-name": "Tiny Towers",
@@ -1409,7 +1409,7 @@
         "reference-park_name": "Tiny Towers",
         "park_name": "Tiny Towers",
         "reference-details": "In this tiny park you must finish building the five existing coasters",
-        "details": "In this tiny park you must finish building the five existing coasters"
+        "details": "Закончите строительство пяти существующих аттракционов в этом крошечном парке"
     },
     "rct1ll.scenario_text.urban_jungle": {
         "reference-name": "Urban Jungle",
@@ -1417,7 +1417,7 @@
         "reference-park_name": "Urban Jungle",
         "park_name": "Urban Jungle",
         "reference-details": "A giant abandoned skyscraper is a unique opportunity for a theme park developer",
-        "details": "A giant abandoned skyscraper is a unique opportunity for a theme park developer"
+        "details": "Гигантский заброшенный небоскрёб - уникальная возможность построить парк"
     },
     "rct1ll.scenario_text.venus_ponds": {
         "reference-name": "Venus Ponds",
@@ -1425,7 +1425,7 @@
         "reference-park_name": "Venus Ponds",
         "park_name": "Venus Ponds",
         "reference-details": "On a far-away planet this area of land needs turning into a theme park",
-        "details": "On a far-away planet this area of land needs turning into a theme park"
+        "details": "На далёкой планете существует область земли, которую нужно превратить в парк"
     },
     "rct1ll.scenario_text.vertigo_views": {
         "reference-name": "Vertigo Views",
@@ -1433,7 +1433,7 @@
         "reference-park_name": "Vertigo Views",
         "park_name": "Vertigo Views",
         "reference-details": "This large park already has an excellent hyper-coaster, but your task is to massively increase its profit",
-        "details": "This large park already has an excellent hyper-coaster, but your task is to massively increase its profit"
+        "details": "В этом парке уже есть отличный гипер-аттракцион, но ваша задача - сильно увеличить его доходность"
     },
     "rct1ll.scenario_text.volcania": {
         "reference-name": "Volcania",
@@ -1441,7 +1441,7 @@
         "reference-park_name": "Volcania",
         "park_name": "Volcania",
         "reference-details": "A dormant volcano is the setting of this coaster-building challenge",
-        "details": "A dormant volcano is the setting of this coaster-building challenge"
+        "details": "Испытайте себя, построив парк на спящем вулкане"
     },
     "rct1ll.scenario_text.wacky_warren": {
         "reference-name": "Wacky Warren",
@@ -1449,7 +1449,7 @@
         "reference-park_name": "Wacky Warren",
         "park_name": "Wacky Warren",
         "reference-details": "A park which has much of its footpaths and coasters underground",
-        "details": "A park which has much of its footpaths and coasters underground"
+        "details": "Большая часть троп и аттракционов в этом парке расположены под землей"
     },
     "rct1ll.scenario_text.woodworm_park": {
         "reference-name": "Woodworm Park",
@@ -1457,67 +1457,67 @@
         "reference-park_name": "Woodworm Park",
         "park_name": "Woodworm Park",
         "reference-details": "This historical park is only allowed to build older-styled rides",
-        "details": "This historical park is only allowed to build older-styled rides"
+        "details": "Это исторический парк, и здесь вы можете строить аттракционы только в старом стиле"
     },
     "rct1ll.scenery_wall.medieval_wooden_fence": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1ll.scenery_wall.wooden_fence_brown_snow": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct1ll.terrain_edge.green": {
         "reference-name": "Stucco (Green)",
-        "name": "Stucco (Green)"
+        "name": "Штукатурка (зелёная)"
     },
     "rct1ll.terrain_edge.purple": {
         "reference-name": "Stucco (Purple)",
-        "name": "Stucco (Purple)"
+        "name": "Штукатурка (фиолетовая)"
     },
     "rct1ll.terrain_edge.skyscraper_a": {
         "reference-name": "Skyscraper (A)",
-        "name": "Skyscraper (A)"
+        "name": "Небоскрёб (А)"
     },
     "rct1ll.terrain_edge.skyscraper_b": {
         "reference-name": "Skyscraper (B)",
-        "name": "Skyscraper (B)"
+        "name": "Небоскрёб (Б)"
     },
     "rct1ll.terrain_edge.stone_brown": {
         "reference-name": "Sandstone (Brown)",
-        "name": "Sandstone (Brown)"
+        "name": "Песчаник (коричневый)"
     },
     "rct1ll.terrain_edge.stone_grey": {
         "reference-name": "Sandstone (Grey)",
-        "name": "Sandstone (Grey)"
+        "name": "Песчаник (серый)"
     },
     "rct1ll.terrain_surface.roof_grey": {
         "reference-name": "Roof (Grey)",
-        "name": "Roof (Grey)"
+        "name": "Крыша (серая)"
     },
     "rct1ll.terrain_surface.rust": {
         "reference-name": "Rust",
-        "name": "Rust"
+        "name": "Ржавчина"
     },
     "rct1ll.terrain_surface.wood": {
         "reference-name": "Wood",
-        "name": "Wood"
+        "name": "Дерево"
     },
     "rct2.audio.base.rct2": {
         "reference-name": "Base audio for the game.",
-        "name": "Base audio for the game."
+        "name": "Основное аудио игры."
     },
     "rct2.audio.base.rctc": {
         "reference-name": "Base audio for the game.",
-        "name": "Base audio for the game."
+        "name": "Основное аудио игры."
     },
     "rct2.audio.circus": {
         "reference-name": "Ambient sound effects for the Circus attraction.",
-        "name": "Ambient sound effects for the Circus attraction."
+        "name": "Звуковые эффекты для аттракциона \"Цирк\"."
     },
     "rct2.audio.title": {
         "reference-name": "Title screen music for RollerCoaster Tycoon 2.",
-        "name": "Title screen music for RollerCoaster Tycoon 2."
+        "name": "Музыка главного меню из RollerCoaster Tycoon 2."
     },
     "rct2.footpath_banner.bn1": {
         "reference-name": "Sign",
@@ -1525,15 +1525,15 @@
     },
     "rct2.footpath_banner.bn2": {
         "reference-name": "Jungle Style Sign",
-        "name": "Знак ‘Джунгли’"
+        "name": "Знак стиля Джунгли"
     },
     "rct2.footpath_banner.bn3": {
         "reference-name": "Classical Style Sign",
-        "name": "Знак ‘Классика’"
+        "name": "Знак стиля Классика"
     },
     "rct2.footpath_banner.bn4": {
         "reference-name": "Egyptian Style Sign",
-        "name": "Знак ‘Египет’"
+        "name": "Знак стиля Египет"
     },
     "rct2.footpath_banner.bn5": {
         "reference-name": "Wooden Sign",
@@ -1541,19 +1541,19 @@
     },
     "rct2.footpath_banner.bn6": {
         "reference-name": "Jurassic Style Sign",
-        "name": "Знак ‘Юрский п-д’"
+        "name": "Знак стиля Юрский Период"
     },
     "rct2.footpath_banner.bn7": {
         "reference-name": "Pagoda Style Sign",
-        "name": "Знак ‘Пагода’"
+        "name": "Знак стиля Пагода"
     },
     "rct2.footpath_banner.bn8": {
         "reference-name": "Snow Covered Sign",
-        "name": "Знак ‘Снег’"
+        "name": "Знак (заснеженный)"
     },
     "rct2.footpath_banner.bn9": {
         "reference-name": "Space Style Sign",
-        "name": "Знак ‘Космос’"
+        "name": "Знак стиля Космос"
     },
     "rct2.footpath_item.bench1": {
         "reference-name": "Bench",
@@ -1565,7 +1565,7 @@
     },
     "rct2.footpath_item.benchpl": {
         "reference-name": "Seats",
-        "name": "Лавка"
+        "name": "Кресла"
     },
     "rct2.footpath_item.benchspc": {
         "reference-name": "Bench",
@@ -1573,15 +1573,15 @@
     },
     "rct2.footpath_item.benchstn": {
         "reference-name": "Stone Bench",
-        "name": "Скамейка"
+        "name": "Каменная скамейка"
     },
     "rct2.footpath_item.jumpfnt1": {
         "reference-name": "Jumping Fountains",
-        "name": "Фонтаны"
+        "name": "Прыгающие фонтаны"
     },
     "rct2.footpath_item.jumpsnw1": {
         "reference-name": "Jumping Snowballs",
-        "name": "Снежки"
+        "name": "Прыгающие снежки"
     },
     "rct2.footpath_item.lamp1": {
         "reference-name": "Lamp",
@@ -1601,7 +1601,7 @@
     },
     "rct2.footpath_item.lampdsy": {
         "reference-name": "Daisy Lamp",
-        "name": "Лампа"
+        "name": "Фонарь в форме ромашки"
     },
     "rct2.footpath_item.lamppir": {
         "reference-name": "Lamp",
@@ -1625,79 +1625,79 @@
     },
     "rct2.footpath_item.qtv1": {
         "reference-name": "Queue Line TV",
-        "name": "ТВ Вывеска"
+        "name": "Телевизор для очередей"
     },
     "rct2.footpath_railings.bamboo_black": {
         "reference-name": "Bamboo Railings (Black)",
-        "name": "Bamboo Railings (Black)"
+        "name": "Бамбуковые рельсы (чёрные)"
     },
     "rct2.footpath_railings.bamboo_brown": {
         "reference-name": "Bamboo Railings (Brown)",
-        "name": "Bamboo Railings (Brown)"
+        "name": "Бамбуковые рельсы (коричневые)"
     },
     "rct2.footpath_railings.concrete": {
         "reference-name": "Concrete Railings (Grey-Brown)",
-        "name": "Concrete Railings (Grey-Brown)"
+        "name": "Бетонные рельсы (серо-коричневые)"
     },
     "rct2.footpath_railings.concrete_green": {
         "reference-name": "Concrete Railings (Dark Green)",
-        "name": "Concrete Railings (Dark Green)"
+        "name": "Бетонные рельсы (тёмно-зелёные)"
     },
     "rct2.footpath_railings.space": {
         "reference-name": "Space Style Railings (Red)",
-        "name": "Space Style Railings (Red)"
+        "name": "Космические рельсы (красные)"
     },
     "rct2.footpath_railings.wood": {
         "reference-name": "Wooden Railings",
-        "name": "Wooden Railings"
+        "name": "Деревянные рельсы"
     },
     "rct2.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Rounded)",
-        "name": "Гравий"
+        "name": "Гравий (круглый)"
     },
     "rct2.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Stairs)",
-        "name": "Дорожка"
+        "name": "Сумашедший тротуар (лестница)"
     },
     "rct2.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Rounded)",
-        "name": "Дорожка"
+        "name": "Грязная тропа (круг)"
     },
     "rct2.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Stairs)",
-        "name": "Blue Queue (Stairs)"
+        "name": "Синяя очередь (лестница)"
     },
     "rct2.footpath_surface.queue_green": {
         "reference-name": "Dark Green Queue",
-        "name": "Dark Green Queue"
+        "name": "Тёмно-зелёная очередь"
     },
     "rct2.footpath_surface.queue_red": {
         "reference-name": "Red Queue (Stairs)",
-        "name": "Red Queue (Stairs)"
+        "name": "Красная очередь (лестница)"
     },
     "rct2.footpath_surface.queue_yellow": {
         "reference-name": "Yellow Queue (Stairs)",
-        "name": "Yellow Queue (Stairs)"
+        "name": "Жёлтая очередь (лестница)"
     },
     "rct2.footpath_surface.road": {
         "reference-name": "Road",
-        "name": "Путь"
+        "name": "Дорога"
     },
     "rct2.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Stairs)",
-        "name": "Асфальт"
+        "name": "Асфальт (лестница)"
     },
     "rct2.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Stairs)",
-        "name": "Дорожка"
+        "name": "Коричневый асфальт (лестница)"
     },
     "rct2.footpath_surface.tarmac_green": {
         "reference-name": "Dark Green Tarmac Footpath",
-        "name": "Зелёный асфальт"
+        "name": "Тёмно-зелёный асфальт"
     },
     "rct2.footpath_surface.tarmac_red": {
         "reference-name": "Red Tarmac Footpath (Stairs)",
-        "name": "Red Tarmac Footpath (Stairs)"
+        "name": "Красный асфальт (лестница)"
     },
     "rct2.music.candy": {
         "reference-name": "Candy style",
@@ -1869,7 +1869,7 @@
     },
     "rct2.peep_animations.entertainer_roman": {
         "reference-name": "Roman costume",
-        "name": "Roman costume"
+        "name": "Римский костюм"
     },
     "rct2.peep_animations.entertainer_sheriff": {
         "reference-name": "Sheriff costume",
@@ -1901,77 +1901,77 @@
     },
     "rct2.peep_names.original": {
         "reference-name": "Original peep names",
-        "name": "Original peep names"
+        "name": "Оригинальные имена людей"
     },
     "rct2.ride.4x4": {
         "reference-name": "Monster Trucks",
         "name": "Грузовики",
         "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
-        "description": "Люди катаются на огромных внедорожниках.",
+        "description": "Электрические грузовики с четырёхколесным приводом для подъёма на резких наклонах.",
         "reference-capacity": "2 passengers per truck",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на грузовик"
     },
     "rct2.ride.aml1": {
         "reference-name": "American Style Steam Trains",
         "name": "Американский паровоз",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct2.ride.amt1": {
         "reference-name": "Mine Trains",
-        "name": "Шахтёрские горки",
+        "name": "Шахтёрские поезда",
         "reference-description": "Mine train-themed roller coaster trains",
-        "description": "Горный поезд несется по стальным рельсам, похожим на старинную железную дорогу.",
+        "description": "Поезда для аттракционов, похожие те, что ходят в шахтах",
         "reference-capacity": "2 or 4 passengers per car",
-        "capacity": "2 или 4 пассажира"
+        "capacity": "2 или 4 пассажира на машину"
     },
     "rct2.ride.arrsw1": {
         "reference-name": "Suspended Swinging Cars",
-        "name": "Подвесные вагоны",
+        "name": "Подвесные машины",
         "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-        "description": "Suspended roller coaster train consisting of cars able to swing freely as the train goes around corners",
+        "description": "Подвесной поезд, состоящий из машин, свободно раскачивающихся на резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.arrsw2": {
         "reference-name": "Suspended Swinging Aeroplane Cars",
-        "name": "Аэропланы",
+        "name": "Раскачивающиеся подвесные самолёты",
         "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
-        "description": "Suspended roller coaster train consisting of airplane shaped cars able to swing freely as the train goes around corners",
+        "description": "Подвесной поезд, состоящий из машин-самолётов, свободно раскачивающихся на резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажираpa"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.arrt1": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Штопорные горки",
+        "name": "Штопорные поезда",
         "reference-description": "Roller coaster trains with shoulder restraints",
-        "description": "Небольшие железные горки, где поезда едут по спиралям и кольцам",
+        "description": "Поезда с безопасностью для плеч",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.arrt2": {
         "reference-name": "Hypercoaster Trains",
         "name": "Гипергорки",
         "reference-description": "Comfortable trains with only lap bar restraints",
-        "description": "Высокие прямые горки с глубокими падениями и большой скоростью, ремни только на колени.",
+        "description": "Комфортабельные поезда с безопасностью для ног.",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.arrx": {
         "reference-name": "Multi-Dimension Coaster Trains",
         "name": "Многомерный поезд",
         "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
-        "description": "Вагончики для необыкновенного поезда.",
+        "description": "Машины с сиденьями, которые могут переворачивать пассажиров вверх-ногами.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.atm1": {
         "reference-name": "Cash Machine",
         "name": "Банкомат",
         "reference-description": "An A.T.M. (Cash Machine) for guests to use if they run low on funds",
-        "description": "Банкомат"
+        "description": "Банкомат, где гости могут взять наличные, если таковые у них закончились"
     },
     "rct2.ride.balln": {
         "reference-name": "Balloon Stall",
@@ -1981,11 +1981,11 @@
     },
     "rct2.ride.batfl": {
         "reference-name": "Swinging Cars",
-        "name": "Свинг-вагоны.",
+        "name": "Качающиеся машины",
         "reference-description": "Small cars which swing from the rail above",
-        "description": "Вагончики, качающиеся на рельсе.",
+        "description": "Маленькие машины, качающиеся на подвесном рельсе.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.bboat": {
         "reference-name": "Bumper Boats",
@@ -1993,61 +1993,61 @@
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Маленькие круглые лодочки с моторами управляются пассажирами.",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.bmair": {
         "reference-name": "Flying Roller Coaster Trains",
-        "name": "Летающие горки",
+        "name": "Летающие поезда",
         "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
-        "description": "Люди сидят в удобных креслах и едут по очень сложной трассе, испытывая чувство полёта.",
+        "description": "Комфортабельные сидения, размещённые под треком и дающие непревосходимое чувство полета.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.bmfl": {
         "reference-name": "Floorless Twister Trains",
-        "name": "Горки без пола",
+        "name": "Поезда Твистер без пола",
         "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
-        "description": "Широкие поезда без пола дают пассажирам чувство свободы, когда они едут по извивающейся трассе.",
+        "description": "Широкий поезд с безопасностью для плеч, но без пола, увеличивающий уровень энергии своих пассажиров.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.bmrb": {
         "reference-name": "Hyper-Twister Trains (wide cars)",
-        "name": "Гипер-твистер (широкий)",
+        "name": "Гипер-твистер (широкие машины)",
         "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
-        "description": "Wide 4-across cars with raised seating and simple lap restraints",
+        "description": "Широкие машины, вмещающие 4 человека, с поднятыми сиденьями и простой безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.bmsd": {
         "reference-name": "Twister Trains",
-        "name": "Твистер-коастер",
+        "name": "Твистер-поезд",
         "reference-description": "Spacious trains with shoulder restraints",
-        "description": "Широкие поезда скользят по гладким рельсам со множеством поворотов",
+        "description": "Вместительные поезда с безопасностью для плеч",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.bmsu": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Стоячие горки",
+        "name": "Стоячие поезда Твистер",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
-        "description": "Посетители едут стоя в широких поездах в специальных креплениях.",
+        "description": "Поезд с безопасностью для плеч, предназначенный для езды стоя.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.bmvd": {
         "reference-name": "Six-seater Twister Trains",
-        "name": "Вертикальные горки",
+        "name": "Шестиместные поезда Твистер",
         "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
-        "description": "Широкие вагончики падают по вертикальному треку.",
-        "reference-capacity": "6 passengers per car",
+        "description": "Поезда с широкими машинами, предназначенными для падения с большой высоты.",
+        "reference-capacity": "6 пассажиров на машину",
         "capacity": "6 пассажиров"
     },
     "rct2.ride.bnoodles": {
         "reference-name": "Beef Noodles Stall",
-        "name": "Палатка с лапшой",
+        "name": "Ларёк с лапшой",
         "reference-description": "A stall selling Chinese style beef noodles",
-        "description": "Палатка, где продают лапшу."
+        "description": "Ларёк, где продают лапшу с говядиной в китайском стиле."
     },
     "rct2.ride.bob1": {
         "reference-name": "Bobsleigh Trains",
@@ -2055,21 +2055,21 @@
         "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Поезд состоящий из двухместных вагонов, где пассажиры сидят друг за другом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.burgb": {
         "reference-name": "Burger Bar",
         "name": "Бургер-бар",
         "reference-description": "A burger-shaped building selling burgers",
-        "description": "Бар, где продаются гамбургеры."
+        "description": "Здание в форме бургера, продающее бургеры."
     },
     "rct2.ride.c3d": {
         "reference-name": "3D Cinema",
-        "name": "3D Кино",
+        "name": "3D Кинотеатр",
         "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
-        "description": "Кинотеатр с 3D фильмами в сферическом здании",
+        "description": "Кинотеатр, показывающий 3D фильмы в здании с формой геодезической сферы",
         "reference-capacity": "20 guests",
-        "capacity": "20 чел."
+        "capacity": "20 гостей"
     },
     "rct2.ride.cboat": {
         "reference-name": "Canoes",
@@ -2077,137 +2077,137 @@
         "reference-description": "Long canoes which the passengers paddle themselves",
         "description": "Длинные каноэ, где пассажиры гребут сами",
         "reference-capacity": "2 passengers per canoe",
-        "capacity": "2 чел. на лодку"
+        "capacity": "2 пассажира на каноэ"
     },
     "rct2.ride.chbuild": {
         "reference-name": "Crooked House",
         "name": "Кривой дом",
         "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
-        "description": "Здание с кривыми комнатами и коридорами",
+        "description": "Здание с кривыми комнатами и угловыми коридорами, дизориентирующий своих гостей",
         "reference-capacity": "5 guests",
-        "capacity": "5 чел"
+        "capacity": "5 гостей"
     },
     "rct2.ride.chcks": {
         "reference-name": "Fried Chicken Stall",
-        "name": "Куры-гриль",
+        "name": "Жареная курица",
         "reference-description": "A stall selling tubs of fried chicken",
-        "description": "Палатка, где продают куры-гриль."
+        "description": "Ларёк, где продают жареную курицу вёдрами."
     },
     "rct2.ride.chknug": {
         "reference-name": "Chicken Nuggets Stall",
-        "name": "Куры-гриль",
+        "name": "Наггетсы",
         "reference-description": "A stall selling fried chicken nuggets",
-        "description": "Палатка, где продают куры-гриль."
+        "description": "Ларёк, где продают куриные нагетсы."
     },
     "rct2.ride.chpsh": {
         "reference-name": "Chip Shop",
-        "name": "Картошка",
+        "name": "Картошка фри",
         "reference-description": "A hut selling chips",
-        "description": "Ларек с картошкой"
+        "description": "Ларёк с картошкой фри"
     },
     "rct2.ride.chpsh2": {
         "reference-name": "Chips Stall",
-        "name": "Картошка",
-        "reference-description": "A stall selling chips",
-        "description": "Продажа картошки"
+        "name": "Картошка фри",
+        "reference-description": "A hut selling chips",
+        "description": "Ларёк с картошкой фри"
     },
     "rct2.ride.cindr": {
         "reference-name": "Sujeonggwa Stall",
-        "name": "Рюмочная",
+        "name": "Ларёк Sujeonggwa",
         "reference-description": "A stall selling Korean style Sujeonggwa drinks",
-        "description": "Палатка, где разливают сухое вино."
+        "description": "Ларёк, где продают корейские напитки Sujeonggwa."
     },
     "rct2.ride.circus1": {
         "reference-name": "Circus",
         "name": "Цирк",
         "reference-description": "Circus animal show inside a big-top tent",
-        "description": "Цирковое выступление со зверями",
+        "description": "Цирковое выступление со зверями в большой палатке",
         "reference-capacity": "30 guests",
-        "capacity": "30 чел"
+        "capacity": "30 гостей"
     },
     "rct2.ride.clift1": {
         "reference-name": "Chairlift Cars",
-        "name": "Кресло-лифт",
+        "name": "Кресла для канатки",
         "reference-description": "Open cars for chairlift",
-        "description": "Открытые вагончики",
+        "description": "Открытые кресла для канатной дороги",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.clift2": {
         "reference-name": "Ski-lift Chairs",
         "name": "Лыжные кресла",
         "reference-description": "Open cars for chairlift",
-        "description": "Открытые вагончики",
+        "description": "Открытые машины для канаток",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.cndyf": {
         "reference-name": "Candyfloss Stall",
-        "name": "Кондитерская",
+        "name": "Сахарная вата",
         "reference-description": "A candyfloss shaped building selling pink candyfloss",
-        "description": "Палатка с конфетами"
+        "description": "Ларёк, продающий сахарную вату"
     },
     "rct2.ride.coffs": {
         "reference-name": "Coffee Shop",
         "name": "Кофе",
         "reference-description": "An art-deco style shop selling cups of coffee",
-        "description": "Здесь продают кофе"
+        "description": "Магазин в стиле арт-деко, продающий чашки кофе"
     },
     "rct2.ride.cookst": {
         "reference-name": "Cookie Shop",
         "name": "Печенье",
         "reference-description": "A stall selling giant cookies",
-        "description": "Ларек с печеньем"
+        "description": "Ларёк, продающий гигантское печенье"
     },
     "rct2.ride.cstboat": {
         "reference-name": "Coaster Boats",
-        "name": "Лодки-горки",
+        "name": "Лодки",
         "reference-description": "Boat-shaped roller coaster cars",
-        "description": "Вагончки в виде лодок",
+        "description": "Машины для аттракционов в виде лодок",
         "reference-capacity": "6 passengers per boat",
         "capacity": "6 пассажиров"
     },
     "rct2.ride.ctcar": {
         "reference-name": "Cheshire Cats",
-        "name": "Чешир",
+        "name": "Чеширский кот",
         "reference-description": "Powered cat-shaped vehicles",
         "description": "Машинки в виде котов едут по рельсам",
         "reference-capacity": "2 passengers per cat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на кота"
     },
     "rct2.ride.ding1": {
         "reference-name": "Dinghies",
         "name": "Шлюпки",
         "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
-        "description": "Люди катаются в шлюпках.",
+        "description": "Надувные шлюпки, которые могут плыть по полу- или полностью закрытой трубе.",
         "reference-capacity": "2 passengers per dinghy",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на шлюпку"
     },
     "rct2.ride.dodg1": {
         "reference-name": "Dodgems",
-        "name": "Кар",
+        "name": "Машины для автодрома",
         "reference-description": "Riders bump into each other in self-drive electric dodgems",
-        "description": "Электромобильчики",
+        "description": "Пассажиры сталкиваются друг с другом в этих электрических мини-автомобилях",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел."
+        "capacity": "1 пассажир на машину"
     },
     "rct2.ride.dough": {
         "reference-name": "Doughnut Shop",
-        "name": "Бублики",
+        "name": "Пончики",
         "reference-description": "A stall selling ring-shaped doughnuts",
-        "description": "Палатка с бубликами"
+        "description": "Ларёк, продающий пончики в форме кольца"
     },
     "rct2.ride.drnks": {
         "reference-name": "Drinks Stall",
         "name": "Напитки",
         "reference-description": "A can-shaped stall selling fizzy drinks",
-        "description": "Палатка с напитками"
+        "description": "Ларёк в форме банок, продающий газированные напитки"
     },
     "rct2.ride.enterp": {
         "reference-name": "Enterprise",
         "name": "Энтерпрайз",
         "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
-        "description": "Колесо с подвешенными капсулами вращается с большой скоростью",
+        "description": "Колесо с подвешенными капсулами, которое вращается, а затем наклоняется поддерживающим его рычагом",
         "reference-capacity": "16 passengers",
         "capacity": "16 пассажиров"
     },
@@ -2215,33 +2215,33 @@
         "reference-name": "First Aid Room",
         "name": "Медпункт",
         "reference-description": "A place for sick guests to go for faster recovery",
-        "description": "Комната для заболевших"
+        "description": "Место для быстрого лечения больных гостей"
     },
     "rct2.ride.frnood": {
         "reference-name": "Fried Rice Noodles Stall",
-        "name": "Жареный рис",
+        "name": "Жареные рисовые макароны",
         "reference-description": "A stall selling Chinese style fried rice noodles",
-        "description": "Палатка с жареным рисом"
+        "description": "Ларёк, продающий жареные макароны из риса в китайском стиле"
     },
     "rct2.ride.fsauc": {
         "reference-name": "Flying Saucers",
-        "name": "Тарелочки",
+        "name": "Летающие тарелки",
         "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
-        "description": "Самодвижущиеся машины",
+        "description": "Летающие машины в форме тарелок, которыми свободно управляют пассажиры",
         "reference-capacity": "1 person per car",
-        "capacity": "1 человек"
+        "capacity": "1 человек на машину"
     },
     "rct2.ride.funcake": {
         "reference-name": "Funnel Cake Shop",
-        "name": "Пирожки",
+        "name": "Пирожная",
         "reference-description": "A stall selling funnel cakes",
-        "description": "Палатка с пирожками"
+        "description": "Ларёк, продающий торты и пирожные"
     },
     "rct2.ride.fwh1": {
         "reference-name": "Ferris Wheel",
-        "name": "Колесо",
+        "name": "Колесо обозрения",
         "reference-description": "Rotating big wheel with open chairs",
-        "description": "Большое колесо обозрения",
+        "description": "Большое колесо обозрения с открытыми креслами",
         "reference-capacity": "32 passengers",
         "capacity": "32 пассажира"
     },
@@ -2249,9 +2249,9 @@
         "reference-name": "Roto-Drop",
         "name": "Рото-дроп",
         "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
-        "description": "Ряд кресел загоняют на верх высокой башни и вращают, затем они падают вниз, остановившись внизу на магнитных тормозах.",
+        "description": "Ряд кресел, вращающихся на верху высокой башни, затем падающих вниз, с остановкой на магнитных тормозах.",
         "reference-capacity": "16 passengers",
-        "capacity": "16 пассажиро"
+        "capacity": "16 пассажиров"
     },
     "rct2.ride.golf1": {
         "reference-name": "Mini Golf",
@@ -2263,39 +2263,39 @@
     },
     "rct2.ride.goltr": {
         "reference-name": "Hyper-Twister Trains",
-        "name": "Гипер-твистер",
+        "name": "Поезда гипер-твистер",
         "reference-description": "Spacious trains with simple lap restraints",
-        "description": "Большие поезда с простыми ремнями",
+        "description": "Большие поезда с простой безопасностью для ног",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.gtc": {
         "reference-name": "Ghost Train Cars",
-        "name": "Призрак",
+        "name": "Машины-призраки",
         "reference-description": "Powered monster-shaped cars that run on a ghost train track",
-        "description": "Машинки в виде монстров едут по страшным лабиринтам",
+        "description": "Машины в форме монстров, едущие по призрачным рельсам",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.hatst": {
         "reference-name": "Hat Stall",
         "name": "Шляпы",
         "reference-description": "A souvenir stall selling large foam hats",
-        "description": "Сувенирная палатка со шляпами"
+        "description": "Сувенирный ларёк с большими пенными шляпами"
     },
     "rct2.ride.hchoc": {
         "reference-name": "Hot Chocolate Stall",
         "name": "Горячий шоколад",
         "reference-description": "A stall selling hot chocolate drinks",
-        "description": "Палатка с горячим шоколадом"
+        "description": "Ларёк, продающий напитки из горячего шоколада"
     },
     "rct2.ride.helicar": {
         "reference-name": "Mini Helicopters",
-        "name": "Вертолётики",
+        "name": "Мини-вертолёты",
         "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
-        "description": "Машинки в виде вертолетиков.",
+        "description": "Машины в виде вертолётов, управляемые педалями.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 passengers per car"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.hhbuild": {
         "reference-name": "Haunted House",
@@ -2303,7 +2303,7 @@
         "reference-description": "Large themed building containing scary corridors and spooky rooms",
         "description": "Большое здание со страшными коридорами и комнатами.",
         "reference-capacity": "15 guests",
-        "capacity": "15 чел."
+        "capacity": "15 гостей"
     },
     "rct2.ride.hmaze": {
         "reference-name": "Maze",
@@ -2315,103 +2315,103 @@
     },
     "rct2.ride.hmcar": {
         "reference-name": "Haunted Mansion Cars",
-        "name": "Гонки с призраками",
+        "name": "Машины для домов с приведениями",
         "reference-description": "Small powered cars that run on a ghost train track",
-        "description": "Машинки ездят по многоуровневым трекам в особой обстановке.",
+        "description": "Маленькие электромашины, едующие по призрачным рельсам",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.hotds": {
         "reference-name": "Hot Dog Stall",
         "name": "Хот-доги",
         "reference-description": "A stall selling hot dogs in rolls",
-        "description": "Палатка с хот-догами."
+        "description": "Ларёк с хот-догами."
     },
     "rct2.ride.hskelt": {
         "reference-name": "Spiral Slide",
-        "name": "Спираль",
+        "name": "Горка-спираль",
         "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
-        "description": "Деревянное здание с лестницей и спиральной горкой.",
+        "description": "Деревянное здание с внутренней лестницей и внешней спиральной горкой с матрасами снизу",
         "reference-capacity": "1 person at a time",
-        "capacity": "1 person at a time"
+        "capacity": "1 человек за раз"
     },
     "rct2.ride.icecr1": {
         "reference-name": "Fruity Ices Stall",
-        "name": "Мороженое",
+        "name": "Фруктовый лёд",
         "reference-description": "A themed stall selling fruity ice creams",
-        "description": "Палатка с фруктовым мороженым"
+        "description": "Ларёк, продающий мороженные с фруктовым вкусом"
     },
     "rct2.ride.icecr2": {
         "reference-name": "Ice Cream Cone Stall",
         "name": "Мороженое",
         "reference-description": "A stall selling ice cream cones",
-        "description": "Палатка с мороженым"
+        "description": "Ларёк, продающий мороженный в вафельных стаканчиках"
     },
     "rct2.ride.icetst": {
         "reference-name": "Iced Tea Stall",
-        "name": "Холодный чай",
+        "name": "Ice Tea",
         "reference-description": "A stall selling iced tea drinks",
-        "description": "Палатка с холодным чаем."
+        "description": "Ларёк, продающий ice tea."
     },
     "rct2.ride.infok": {
         "reference-name": "Information Kiosk",
-        "name": "Справка",
+        "name": "Инфо-киоск",
         "reference-description": "A stall where guests can obtain park maps and purchase umbrellas",
-        "description": "Киоск, где гости берут карты и зонтики."
+        "description": "Киоск, где гости могут получить карту парка или купить зонт."
     },
     "rct2.ride.intbob": {
         "reference-name": "6-seater Bobsleighs",
-        "name": "Кружилки",
+        "name": "6-местный бобслей",
         "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
-        "description": "Пассажиры едут в больших бобах, несущихся по полукруглому треку.",
+        "description": "Трёхрядные бобслеи, с местом для двух людей на каждом ряду",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 passengers per car"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.intinv": {
         "reference-name": "Impulse Trains",
-        "name": "Обратно-импульсные горки",
+        "name": "Импульсный поезд",
         "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
-        "description": "Развернутые поезда разгоняются от станции по вертикальному треку, спускаются вниз и забираются на новый подъём.",
+        "description": "Перевернутые поезда для инвертированых импульсных горок.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.intst": {
         "reference-name": "Giga Coaster Trains",
-        "name": "Гига-Горки",
+        "name": "Гига-поезд",
         "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
-        "description": "Гигантские горки с крутыми падениями до 100м.",
+        "description": "Поезда для Гига-аттракционов, способные на плавные падения.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.ivmc1": {
         "reference-name": "Four-seater Cars",
-        "name": "Обратные поворот. горки",
+        "name": "Четырёхместные машины",
         "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
-        "description": "Отдельные вагончики едут по зигзагообразному треку с разворотами и падениями",
+        "description": "Машины созданные для треков с резкими поворотами и падениями",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.jski": {
         "reference-name": "Jet Skis",
-        "name": "Скутеры",
+        "name": "Гидроциклы",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
-        "description": "Водные скутеры на одного человека.",
+        "description": "Гидроциклы для одного человека, управляемые самими пассажирами",
         "reference-capacity": "1 rider per vehicle",
-        "capacity": "1 чел"
+        "capacity": "1 пассажир на машину"
     },
     "rct2.ride.jstar1": {
         "reference-name": "Toboggan Cars",
         "name": "Сани",
         "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
-        "description": "Вагончики в виде саней для горок",
+        "description": "Машины в виде саней с рядовыми сидениями",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.kart1": {
         "reference-name": "Go-Karts",
         "name": "Картинг",
         "reference-description": "Self-drive petrol-engined go-karts",
-        "description": "Карты с бенз. движками",
+        "description": "Бензиновые машины для картинга",
         "reference-capacity": "single-seater",
         "capacity": "одиночные"
     },
@@ -2419,21 +2419,21 @@
         "reference-name": "Lemonade Stall",
         "name": "Лимонад",
         "reference-description": "A stall selling refreshing lemonade drinks",
-        "description": "Палатка с лимонадом"
+        "description": "Ларёк, продающий освежающий лимонад"
     },
     "rct2.ride.lfb1": {
         "reference-name": "Logs",
-        "name": "Ущелье",
+        "name": "Бревна",
         "reference-description": "Log-shaped boats built for running in water channels",
-        "description": "Лодки в виде бревен плывут по каналу, периодически плюхаясь со склонов.",
+        "description": "Машины в виде лодок для плаванья по водным каналам.",
         "reference-capacity": "4 passengers per boat",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.lift1": {
         "reference-name": "Lift Cabin",
-        "name": "Лифт",
+        "name": "Кабина для лифта",
         "reference-description": "Steel lift cabin",
-        "description": "Гости переезжают с уровня на уровень",
+        "description": "Стальная кабина для лифта",
         "reference-capacity": "16 passengers",
         "capacity": "16 пассажиров"
     },
@@ -2441,13 +2441,13 @@
         "reference-name": "Meatball Soup Stall",
         "name": "Фрикадельки",
         "reference-description": "A stall selling Chinese style meatball soup",
-        "description": "Палатка с фрикадельным супом"
+        "description": "Ларёк с фрикадельным супом в китайском стиле"
     },
     "rct2.ride.mcarpet1": {
         "reference-name": "Magic Carpet",
-        "name": "Ковёр",
+        "name": "Волшебный ковёр",
         "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
-        "description": "Большой летающий ковер, двигающийся вверх-вниз.",
+        "description": "Большая машина в стиле летающего ковра, которая циклически движется вверх и вниз на конце 4 рычагов",
         "reference-capacity": "12 passengers",
         "capacity": "12 пассажиров"
     },
@@ -2455,87 +2455,87 @@
         "reference-name": "Articulated Roller Coaster Trains",
         "name": "Сочленённые поезда",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-        "description": "Поезда для горок с короткими вагончиками",
+        "description": "Поезда с короткими машинами в один ряд, с открытой передней частью",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.mgr1": {
         "reference-name": "Merry-Go-Round",
         "name": "Карусель",
         "reference-description": "Traditional rotating carousel with carved wooden horses",
-        "description": "Обычная Карусель с деревянными лошадками",
+        "description": "Традиционная вращающаяся карусель с деревянными лошадками",
         "reference-capacity": "16 passengers",
         "capacity": "16 пассажиров"
     },
     "rct2.ride.monbk": {
         "reference-name": "Bicycles",
-        "name": "Моноциклы",
+        "name": "Велосипеды",
         "reference-description": "Special bicycles that run on a monorail track, propelled by the pedalling of the riders",
-        "description": "Особые велосипеды с педальной тягой едут по стальным рельсам.",
+        "description": "Особые велосипеды, предназначенные для езды по монорельсу. Они двигаются вперёд благодаря движению педалей.",
         "reference-capacity": "1 rider per bicycle",
-        "capacity": "1 человек"
+        "capacity": "1 пассажир на велосипед"
     },
     "rct2.ride.mono1": {
         "reference-name": "Streamlined Monorail Trains",
-        "name": "Моно-паровозики",
+        "name": "Гладкие монорельсовые поезда",
         "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
-        "description": "Вместимые монорельсовые поезда с паровозами",
+        "description": "Вместитильные поезда для монорельсов, с гладкими передними и задними машинами",
         "reference-capacity": "5 or 10 passengers per car",
-        "capacity": "5 или 10 пассажиров"
+        "capacity": "5 или 10 пассажиров на машину"
     },
     "rct2.ride.mono2": {
         "reference-name": "Small Monorail Cars",
-        "name": "Моно-вагончики",
+        "name": "Монорельсовые вагоны",
         "reference-description": "Small monorail cars with open sides",
-        "description": "Мал. монорельсовые вагончики",
+        "description": "Маленькие монорельсовые вагоны с открытыми сторонами",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.mono3": {
         "reference-name": "Retro-style Monorail Trains",
-        "name": "Старинный монорельс",
+        "name": "Монорельс в стиле Ретро",
         "reference-description": "Monorail trains with open cabins",
-        "description": "Монорельсовые поезда",
+        "description": "Монорельсовые поезда с открытой кабиной",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.nemt": {
         "reference-name": "4-across Inverted Roller Coaster Trains",
-        "name": "Перевёрнутые горки",
+        "name": "Перевернутый поезд (шириной в 4)",
         "reference-description": "Suspended trains in which riders sit in rows",
-        "description": "Пассажиры сидят под треком и несутся по огромным кольцам с переворотами и падениями.",
+        "description": "Подвисной поезд, пассажиры которого сидят в ряд",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.nrl": {
         "reference-name": "Steam Trains",
         "name": "Паровозы",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct2.ride.nrl2": {
         "reference-name": "Steam Trains with Covered Cars",
-        "name": "Паровозики с вагончиками",
+        "name": "Паравоз с накрытыми вагонами",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct2.ride.obs1": {
         "reference-name": "Single-deck Cabin",
-        "name": "Смотровая башня",
+        "name": "Одноэтажная кабина",
         "reference-description": "Single-deck rotating observation cabin",
-        "description": "Вращающаяся кабинка поднимается на башню.",
+        "description": "Одноэтажная вращающаяся кабина для башен наблюдения.",
         "reference-capacity": "20 passengers",
         "capacity": "20 пассажиров"
     },
     "rct2.ride.obs2": {
         "reference-name": "Double-deck Cabin",
-        "name": "Наблюдательная башня",
+        "name": "Двухэтажная кабина",
         "reference-description": "Twin-deck rotating observation cabin",
-        "description": "Вращающаяся кабинка поднимается на высокую башню.",
+        "description": "Двухэтажная вращающаяся кабина для башен наблюдения.",
         "reference-capacity": "32 passengers",
         "capacity": "32 пассажира"
     },
@@ -2543,75 +2543,75 @@
         "reference-name": "Pizza Stall",
         "name": "Пицца",
         "reference-description": "A stall selling portions of pizza",
-        "description": "Палатка с пиццей"
+        "description": "Ларёк, продающий пиццу по кусочкам"
     },
     "rct2.ride.pmt1": {
         "reference-name": "Powered Mine Trains",
-        "name": "Рудник",
+        "name": "Электрические шахтёрские поезда",
         "reference-description": "Mine train-themed roller coaster trains that propel themselves",
-        "description": "Шахтёрские поезда несутся по сложному треку.",
+        "description": "Поезда в стиле шахтёрских, которые самостоятельно движутся вперёд.",
         "reference-capacity": "2 or 4 passengers per car",
-        "capacity": "2 или 4 пассажира"
+        "capacity": "2 или 4 пассажира на машину"
     },
     "rct2.ride.popcs": {
         "reference-name": "Popcorn Stall",
         "name": "Попкорн",
         "reference-description": "A stall selling giant buckets of popcorn",
-        "description": "Палатка с Попкорном"
+        "description": "Ларёк, продающий огромные вёдра попкорна"
     },
     "rct2.ride.premt1": {
         "reference-name": "LIM Launched Roller Coaster Trains",
-        "name": "Горки на LIM",
+        "name": "Горки с запуском ЛИМ",
         "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
         "description": "Поезда, разгоняемые от станции линейным индукционным мотором.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.pretst": {
         "reference-name": "Pretzel Stall",
         "name": "Крендели",
         "reference-description": "A stall selling crispy pretzels",
-        "description": "Палатка с кренделями"
+        "description": "Ларёк, продающий хрустящие крендели"
     },
     "rct2.ride.ptct1": {
         "reference-name": "Wooden Roller Coaster Trains",
         "name": "Деревянные поезда",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Деревянные поезда для горок с ремнями на колени",
+        "description": "Деревянные поезда для аттракционов с набитыми сиденьями и безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.ptct2": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater)",
-        "name": "Деревянные поезда (6 мест)",
+        "name": "Деревянные поезда (шестиместные)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Деревянные поезда для Горок с ремнями на колени",
+        "description": "Деревянные поезда для аттракционов с набитыми сиденьями и безопасностью для ног",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.ptct2r": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
-        "name": "Деревянные поезда (6 мест, реверс)",
+        "name": "Деревянные поезда (шестиместные, реверс)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
-        "description": "Деревянные поезда с сидениями и ремнями для ног.",
+        "description": "Деревянные поезда, едущие в обратном направлении: пассажиры смотрят назад.",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.rapboat": {
         "reference-name": "River Rapids Boats",
-        "name": "Перекаты",
+        "name": "Лодки для Речных Порогов",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
-        "description": "Круглые лодки плывут по широкому каналу, попадая на водопады и стремительные перекаты",
+        "description": "Круглые вращающиеся лодки, которые создают всплески во время путешествия по речным порогам",
         "reference-capacity": "8 passengers per boat",
-        "capacity": "8 пассажиров"
+        "capacity": "8 пассажиров на лодку"
     },
     "rct2.ride.rboat": {
         "reference-name": "Rowing Boats",
-        "name": "Лодочки",
+        "name": "Гребные лодки",
         "reference-description": "Rowing boats which passengers row themselves",
-        "description": "Гребные лодки, где пассажиры гребут сами",
+        "description": "Лодки, позволяющие пассажирам грести по воде самим",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на лодку"
     },
     "rct2.ride.rckc": {
         "reference-name": "Rocket Cars",
@@ -2619,101 +2619,101 @@
         "reference-description": "Roller coaster cars themed to look like rockets",
         "description": "Вагончики для горок в виде ракет",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.rcr": {
         "reference-name": "Racing Cars",
-        "name": "Машинки",
+        "name": "Гоночные машины",
         "reference-description": "Powered vehicles in the shape of racing cars",
-        "description": "Гоночные Машинки",
+        "description": "Электромашины, похожие по форме на гоночные",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct2.ride.revcar": {
         "reference-name": "Reverser Cars",
-        "name": "Горки с 4м измерением",
+        "name": "Реверсные машины",
         "reference-description": "Bogied cars capable of turning around on special reversing sections",
-        "description": "Вагончики на деревянных рельсах, меняющие направление на середине трека.",
+        "description": "Машины с отверстием, позволяющим им менять свое направление на предназначенных для этого секциях",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.revf1": {
         "reference-name": "Reverse Freefall Car",
-        "name": "Обратный вагончик",
+        "name": "Машина для реверсивных аттракционов",
         "reference-description": "Large coaster car for the Reverse Freefall Coaster",
-        "description": "Большой вагончик для реверсивных горок",
+        "description": "Большая машина для реверсивных аттракционов",
         "reference-capacity": "8 passengers",
         "capacity": "8 пассажиров"
     },
     "rct2.ride.rftboat": {
         "reference-name": "Rafts",
-        "name": "Рафтинг",
+        "name": "Плоты",
         "reference-description": "Raft-shaped boats built for flat river tracks",
-        "description": "Люди плывут по каналу на деревянных плотах.",
+        "description": "Лодки в форме плотов, созданные для плоских речных треков",
         "reference-capacity": "4 passengers per raft",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на плот"
     },
     "rct2.ride.rsaus": {
         "reference-name": "Roast Sausage Stall",
         "name": "Сосисочная",
         "reference-description": "A stall selling Chinese style roast sausage",
-        "description": "Лавка с сосисками."
+        "description": "Лавка с жареными сосисками в китайском стиле."
     },
     "rct2.ride.sbox": {
         "reference-name": "Soap Boxes",
-        "name": "Мыльные Гонки",
+        "name": "Мыльныицы",
         "reference-description": "Single cars shaped like a soap box",
-        "description": "Гонки на машинках в виде мыльниц по американским горкам.",
+        "description": "Машины в форме мыльниц",
         "reference-capacity": "4 riders per car",
-        "capacity": "4 чел."
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.scht1": {
         "reference-name": "Looping Roller Coaster Trains",
-        "name": "Американские горки",
+        "name": "Поезда для аттракционов с петлями",
         "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
-        "description": "Поезда, способные ездить по вертикальным кольцам.",
+        "description": "Поезда с безопасностью на ноги, способные ездить по вертикальным кольцам.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пасс на вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.sfric1": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Дерев. вагончики",
+        "name": "Деревянные машины с боковым трением",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Вагончики для боковых горок.",
+        "description": "Машины для аттракционов с боковым трением.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.simpod": {
         "reference-name": "Motion Simulator",
-        "name": "Симулятор",
+        "name": "Симулятор движения",
         "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
-        "description": "Люди смотрят фильм внутри симулятора на движущейся основе.",
+        "description": "Пассажиры смотрят фильм внутри симулятора, который наклоняется и передвигается гидравлической основой",
         "reference-capacity": "8 passengers",
         "capacity": "8 пассажиров"
     },
     "rct2.ride.skytr": {
         "reference-name": "Lay-down Cars",
-        "name": "Мини-летающие горки",
+        "name": "Лежачие машины",
         "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
-        "description": "Пассажиры едут лежа в вагончиках по одиночному рельсу, свободно качаясь на поворотах.",
+        "description": "Маленькие подвесные машины, в которых пассажиры лежат лицом вниз и качаются из стороны в сторону",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct2.ride.slcfo": {
         "reference-name": "Face-off Cars",
-        "name": "Инвертные Горки",
+        "name": "Машины \"лицом-к-лицу\"",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
-        "description": "Люди сидят парами друг напротив друга.",
+        "description": "Люди сидят парами друг напротив друга, проходя резкие петли и перевороты",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.slct": {
         "reference-name": "Compact Inverted Coaster Trains",
-        "name": "Компактные горки",
+        "name": "Компактные перевёрнутые поезда",
         "reference-description": "Riders sit in pairs of seats suspended beneath the track",
-        "description": "Люди сидят парами в подвешенных вагончиках.",
+        "description": "Люди сидят парами в подвешенных на треке сиденьях.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.smc1": {
         "reference-name": "Mouse Cars",
@@ -2721,187 +2721,187 @@
         "reference-description": "Individual cars shaped like mice",
         "description": "Машинки в виде мышек",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.smc2": {
         "reference-name": "Mine Cars",
-        "name": "Тележки",
+        "name": "Шахтёрские машины",
         "reference-description": "Individual cars shaped like wooden mine trucks",
-        "description": "Отдельные вагончики в виде тележек",
+        "description": "Отдельные машины в виде деревянных шахтёрских вагонеток",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.smono": {
         "reference-name": "Suspended Monorail Trains",
-        "name": "Подвесные поезда",
+        "name": "Подвесной монорельс",
         "reference-description": "Large capacity monorail train cars",
         "description": "Большие монорельсовые поезда",
         "reference-capacity": "8 passengers per car",
-        "capacity": "8 пассажиров"
+        "capacity": "8 пассажиров на машину"
     },
     "rct2.ride.souvs": {
         "reference-name": "Souvenir Stall",
         "name": "Сувениры",
         "reference-description": "A stall selling souvenir cuddly toys and umbrellas",
-        "description": "Палатка с игрушками и зонтиками"
+        "description": "Лавка, продающая мягкие игрушки и зонтиками"
     },
     "rct2.ride.soybean": {
         "reference-name": "Soybean Milk Stall",
-        "name": "Молочный киоск",
+        "name": "Киоск с соевым молоком",
         "reference-description": "A stall selling cartons of soybean milk",
-        "description": "Палатка с молоком"
+        "description": "Ларёк, продающий соевое молоко в картонных коробках"
     },
     "rct2.ride.spboat": {
         "reference-name": "Splash Boats",
-        "name": "Лодки",
+        "name": "Всплесковые лодки",
         "reference-description": "Large capacity boats, built for water tracks with very steep drops",
-        "description": "Вместительные лодки плывут по широкому каналу при помощи ременного привода.",
+        "description": "Вместительные лодки, построенные для водных треков с очень резкими падениями",
         "reference-capacity": "16 passengers per boat",
-        "capacity": "16 пассажиров"
+        "capacity": "16 пассажиров на лодку"
     },
     "rct2.ride.spcar": {
         "reference-name": "Sports Cars",
         "name": "Спорткары",
         "reference-description": "Powered vehicles in the shape of sports cars",
-        "description": "Машинки в форме спорткаров",
+        "description": "Электромашины в форме спорткаров",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.spdrcr": {
         "reference-name": "Spiral Roller Coaster Trains",
-        "name": "Спиральные горки",
+        "name": "Спиральные поезда",
         "reference-description": "Compact roller coaster trains with cars with in-line seating",
-        "description": "Компактные горки со спиральным лифтом и сиденьями в ряд.",
+        "description": "Компактные поезда с сиденьями, идущими в ряд",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2.ride.sqdst": {
         "reference-name": "Sea Food Stall",
         "name": "Морская еда",
         "reference-description": "A stall selling fried tentacles",
-        "description": "Палатка с морской пищей"
+        "description": "Ларёк, продающий жареные щупальца"
     },
     "rct2.ride.srings": {
         "reference-name": "Space Rings",
-        "name": "Космокольца",
+        "name": "Космические кольца",
         "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
-        "description": "Концентрические кольца позволяют вращаться во всех направлениях",
+        "description": "Концентрические кольца, позволяющие пассажирам вращаться во всех направлениях",
         "reference-capacity": "1 guest per ring",
-        "capacity": "1 чел."
+        "capacity": "1 гость на кольцо"
     },
     "rct2.ride.ssc1": {
         "reference-name": "Launched Freefall Car",
-        "name": "Падение",
+        "name": "Машина для свободного падения",
         "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
-        "description": "Кабинки запускаются на высокую башню и затем падают вниз",
+        "description": "Машина пневматически запускается на верх высокой стальной башни, и затем свободно падает вниз",
         "reference-capacity": "8 passengers",
         "capacity": "8 пассажиров"
     },
     "rct2.ride.starfrdr": {
         "reference-name": "Star Fruit Drink Stall",
-        "name": "Фруктовые напитки",
+        "name": "Напитки из карамболы",
         "reference-description": "A stall selling star fruit drinks",
-        "description": "Палатка фруктовых напитков"
+        "description": "Ларёк, продающий напитки, сделанные из фрукта Карамбола"
     },
     "rct2.ride.steep1": {
         "reference-name": "Horses",
-        "name": "Стиплчез",
+        "name": "Лошади",
         "reference-description": "Single cars shaped like a horse",
-        "description": "Люди едут на машинках в виде лошадей.",
+        "description": "Машины в форме лошадей",
         "reference-capacity": "2 riders per horse",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на лошадь"
     },
     "rct2.ride.steep2": {
         "reference-name": "Motorbikes",
         "name": "Мотоциклы",
         "reference-description": "Single cars shaped like a motorbike",
-        "description": "Пассажиры едут в вагончиках в виде мотоциклов по треку",
+        "description": "Машины, похожие по форме на мотоцикл",
         "reference-capacity": "2 riders per bike",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на мотоцикл"
     },
     "rct2.ride.submar": {
         "reference-name": "Submarines",
         "name": "Подлодки",
         "reference-description": "Riders ride in a submerged submarine through an underwater course",
-        "description": "Люди плавают на подводных лодках",
+        "description": "Подлодка, которая погружается для путешествия по подводной трассе",
         "reference-capacity": "5 passengers per submarine",
-        "capacity": "5 Пассажира"
+        "capacity": "5 пассажиров на машину"
     },
     "rct2.ride.substl": {
         "reference-name": "Sub Sandwich Stall",
-        "name": "Сэндвичи",
+        "name": "Саб-сэндвичи",
         "reference-description": "A stall selling fresh sub sandwiches",
-        "description": "Палатка с сэндвичами."
+        "description": "Ларёк, продающий сэндвичи стиля \"саб\""
     },
     "rct2.ride.sungst": {
         "reference-name": "Sunglasses Stall",
-        "name": "Очки",
+        "name": "Солнечные очки",
         "reference-description": "A stall selling all kinds of sunglasses",
-        "description": "Палатка с очками"
+        "description": "Ларёк, продающий разнообразные солнечные очки"
     },
     "rct2.ride.swans": {
         "reference-name": "Swans",
         "name": "Лебеди",
         "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
-        "description": "Люди катаются в лодках, имеющих форму лебедей.",
+        "description": "Лодки в форме лебедей, передвигающиеся благодаря педалям на переднем ряду",
         "reference-capacity": "4 passengers per boat",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на лодку"
     },
     "rct2.ride.swsh1": {
         "reference-name": "Pirate Ship",
-        "name": "Корабль",
+        "name": "Пиратский корабль",
         "reference-description": "Large swinging pirate ship",
-        "description": "Большой пиратский корабль",
+        "description": "Большой раскачивающийся пиратский корабль",
         "reference-capacity": "16 passengers",
-        "capacity": "16 чел"
+        "capacity": "16 пассажиров"
     },
     "rct2.ride.swsh2": {
         "reference-name": "Swinging Inverter Ship",
-        "name": "Качающийся корабль",
+        "name": "Качающийся перевёрнутый корабль",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
-        "description": "Корабль, прикрепленный к балке с противовесом на другом конце, крутится на 360 градусов.",
+        "description": "Корабль, прикрепленный к балке с противовесом на другом конце, который крутится на 360 градусов.",
         "reference-capacity": "12 passengers",
         "capacity": "12 пассажиров"
     },
     "rct2.ride.thcar": {
         "reference-name": "Air Powered Vertical Coaster Trains",
-        "name": "Воздушные горки",
+        "name": "Вертикальные поезда с воздушным питанием",
         "reference-description": "Air-powered launched roller coaster trains",
-        "description": "После воздушного запуска поезд устремляется на вертикальный трек и затем падает с другой стороны и возвращается на станцию.",
+        "description": "Поезда для аттракционов, запускаемые воздухом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.tlt1": {
         "reference-name": "Toilets",
         "name": "Туалет",
         "reference-description": "Basic toilets housed in a prefabricated concrete building",
-        "description": "Уборная для посетителей парка"
+        "description": "Простые туалеты, находящиеся в сборном бетонном здании"
     },
     "rct2.ride.tlt2": {
         "reference-name": "Toilets",
         "name": "Туалет",
         "reference-description": "Toilets housed in a log cabin style building",
-        "description": "Туалет в деревянном доме"
+        "description": "Туалеты, находящиеся в деревянном здании"
     },
     "rct2.ride.toffs": {
         "reference-name": "Toffee Apple Stall",
-        "name": "Конфеты",
+        "name": "Конфетные яблоки",
         "reference-description": "An apple-shaped stall selling toffee apples on a stick",
-        "description": "Палатка с яблочными конфетами."
+        "description": "Ларёк в форме яблока, продающий яблоки на палочке, покрытые сладостями"
     },
     "rct2.ride.togst": {
         "reference-name": "Stand-up Roller Coaster Trains",
-        "name": "Стоячие горки",
+        "name": "Стоячие поезда",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position",
-        "description": "Кольцевые горки, где люди катаются стоя.",
+        "description": "Поезда, в которых люди едут в стоячей позиции.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.topsp1": {
         "reference-name": "Top Spin",
         "name": "Топ Спин",
         "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
-        "description": "Пассажиры едут в гондоле, подвешенной на большом рычаге, раскачивающемся вперед-назад.",
+        "description": "Пассажиры едут в гондоле, подвешенной на большом рычаге, раскачивающемся вперед-назад и переворачивающимся вверх головой.",
         "reference-capacity": "8 passengers",
         "capacity": "8 пассажиров"
     },
@@ -2909,45 +2909,45 @@
         "reference-name": "Trams",
         "name": "Трамвай",
         "reference-description": "Old-timer replica trams",
-        "description": "Старый трамвай",
+        "description": "Реплика старых трамваев",
         "reference-capacity": "10 passengers per car",
-        "capacity": "10 пасс. на вагон"
+        "capacity": "10 пассажиров на машину"
     },
     "rct2.ride.trike": {
         "reference-name": "Water Tricycles",
-        "name": "Водные трициклы",
+        "name": "Водные велосипеды",
         "reference-description": "Pedal-tricycle with large buoyant wheels",
-        "description": "Педальные трициклы",
+        "description": "Педальные водные велосипеды с тремя большими плавучими колёсами",
         "reference-capacity": "2 passengers per tricycle",
-        "capacity": "2 passengers per tricycle"
+        "capacity": "2 пассажира на велосипед"
     },
     "rct2.ride.truck1": {
         "reference-name": "Pickup Trucks",
         "name": "Грузовики",
         "reference-description": "Powered vehicles in the shape of pickup trucks",
-        "description": "Powered vehicles in the shape of pickup trucks",
+        "description": "Электромашины в форме грузовиков",
         "reference-capacity": "1 passenger per truck",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на грузовик"
     },
     "rct2.ride.tshrt": {
         "reference-name": "T-Shirt Stall",
         "name": "Футболки",
         "reference-description": "A stall selling souvenir T-Shirts",
-        "description": "Палатка с футболками"
+        "description": "Лавка, продающая сувенирные футболки"
     },
     "rct2.ride.twist1": {
         "reference-name": "Twist",
         "name": "Твист",
         "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-        "description": "Люди катаются попарно, сидя в креслах.",
+        "description": "Пары сидений, вращающие пассажиров вокруг концов трёх длинных рычагов.",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
     "rct2.ride.twist2": {
         "reference-name": "Snow Cups",
-        "name": "Снеговик",
+        "name": "Снежные кружки",
         "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
-        "description": "Люди едут парами вокруг снеговика",
+        "description": "Пары сидений, вращающие пассажиров вокруг центрального снеговика",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
@@ -2955,111 +2955,111 @@
         "reference-name": "Twister Cars",
         "name": "Твистер-Кар",
         "reference-description": "Roller coaster cars capable of heartline twists",
-        "description": "Вагончики, способные вращаться",
+        "description": "Машины, способные совершать перевороты в стиле Heartline",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.utcarr": {
         "reference-name": "Twister Cars (starting reversed)",
-        "name": "Твистер-Кар (реверс.)",
+        "name": "Твистер-Кар (реверс)",
         "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
-        "description": "Горки с головокружительным вращением.",
+        "description": "Машины, способные совершать перевороты в стиле Heartline, движущиеся в обратном направлении",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.vcr": {
         "reference-name": "Vintage Cars",
         "name": "Ретрокары",
         "reference-description": "Powered vehicles in the shape of vintage cars",
-        "description": "Люди катаются на старинных автомобильчиках.",
+        "description": "Машины в форме старых автомобилей.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.vekdv": {
         "reference-name": "Vertical Shuttle Cars",
-        "name": "Вертикальный челнок",
+        "name": "Вертикальный шаттл",
         "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
-        "description": "Люди сидят в вагончиках, подвешенных под треком, поднимаются вверх и спускаются по головокружительной трассе.",
+        "description": "Большие машины, в которых пассажиры сидят на сиденьях, подвешенных под треком",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.vekst": {
         "reference-name": "Lay-down Roller Coaster Trains",
-        "name": "Лежачие горки",
+        "name": "Лежачие поезда",
         "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
-        "description": "Люди лежат на специальных ремнях и несутся по крутому треку",
+        "description": "Специальная запряжка держит людей в лежачей позиции, позволяя им ехать либо на спине, либо на животе",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.vekvamp": {
         "reference-name": "Swinging Floorless Cars",
-        "name": "Вагончики",
+        "name": "Раскачивающиеся машины без пола",
         "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
-        "description": "Подвесные вагончики, раскачивающиеся во всех направлениях.",
+        "description": "Подвесные поезда с сиденьями в стиле канатки, раскачивающиеся на резких поворотах",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.vreel": {
         "reference-name": "Virginia Reel Tubs",
-        "name": "Вирджиния",
+        "name": "Трубы \"Вирджиния\"",
         "reference-description": "Circular cars that spin around as they travel along the track",
-        "description": "Круглые вагончики едут по трассе и одновременно крутятся.",
+        "description": "Круглые машины, которые вращаются во время езды.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.wcatc": {
         "reference-name": "Automobile Cars",
         "name": "Автомобили",
         "reference-description": "Roller coaster cars in the shape of automobiles",
-        "description": "Вагончики в виде автомобилей",
+        "description": "Машины в виде автомобилей",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.wmmine": {
         "reference-name": "Mine Cars",
-        "name": "Деревянная Шахта",
+        "name": "Шахтёрские машины",
         "reference-description": "Cars shaped like an old mine cart",
-        "description": "Маленькие вагонетки едут по зигзагообразному деревянному треку.",
+        "description": "Машины в форме старых вагонеток.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.wmouse": {
         "reference-name": "Mouse Cars",
-        "name": "Деревянные мышки",
-        "reference-description": "Individual cars shaped like a mouse",
-        "description": "Маленькие машинки в виде мышек едут по деревянному треку.",
-        "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "name": "Мышки",
+        "reference-description": "Individual cars shaped like mice",
+        "description": "Машинки в виде мышек",
+        "reference-capacity": "4 passengers per car",
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.wmspin": {
         "reference-name": "Spinning Mouse Cars",
-        "name": "Вращающаяся мышка",
+        "name": "Вращающиеся мышки",
         "reference-description": "Mouse-shaped cars that keep gently spinning around to disorientate the riders",
-        "description": "Машинки в виде мышек едут по трассе, слегка вращаясь.",
+        "description": "Машины в форме мышек, нежно вращающиеся для того, чтобы дизориентировать пассажиров",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2.ride.wonton": {
         "reference-name": "Wonton Soup Stall",
-        "name": "Супная",
+        "name": "Вонтон-супная",
         "reference-description": "A stall selling Wonton Soup",
-        "description": "Лоток, где разливают суп."
+        "description": "Ларёк, продающий суп с пельменями \"вонтон\""
     },
     "rct2.ride.zldb": {
         "reference-name": "Ladybird Trains",
         "name": "Божья Коровка",
         "reference-description": "Roller coaster trains with small ladybird-shaped cars",
-        "description": "Поезд с маленькими божьими коровками",
+        "description": "Поезд с машинами в форме маленьких божьих коровок",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.ride.zlog": {
         "reference-name": "Log Trains",
         "name": "Бревна",
         "reference-description": "Roller coaster trains with small log-shaped cars",
-        "description": "Поезда с небольшими вагончиками.",
+        "description": "Поезд с миниатюрными машинами в форме бревна.",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2.scenario_text.alpine_adventures": {
         "reference-name": "Alpine Adventures",
@@ -3067,7 +3067,7 @@
         "reference-park_name": "Alpine Adventures",
         "park_name": "Alpine Adventures",
         "reference-details": "Convert a small mountain ski resort into a snow-themed amusement park",
-        "details": "Превратите горнолыжный курорт в тематический парк развлечений."
+        "details": "Превратите горнолыжный курорт в снежный парк развлечений"
     },
     "rct2.scenario_text.amity_airfield": {
         "reference-name": "Amity Airfield",
@@ -3075,7 +3075,7 @@
         "reference-park_name": "Amity Airfield",
         "park_name": "Amity Airfield",
         "reference-details": "Build a flying-themed amusement park in this abandoned airport",
-        "details": "Постройте парк на территории заброшенного аэродрома."
+        "details": "Постройте парк с летающими аттракционами на территории заброшенного аэропорта"
     },
     "rct2.scenario_text.botany_breakers": {
         "reference-name": "Botany Breakers",
@@ -3083,7 +3083,7 @@
         "reference-park_name": "Botany Breakers",
         "park_name": "Botany Breakers",
         "reference-details": "Your challenge is to build a high-profit park on this paradise island",
-        "details": "Вы должны построить прибыльный парк на этом райском острове."
+        "details": "Вы должны построить прибыльный парк на этом райском острове"
     },
     "rct2.scenario_text.build_your_own_six_flags_belgium": {
         "reference-name": "Build your own Six Flags Belgium",
@@ -3091,7 +3091,7 @@
         "reference-park_name": "Six Flags Belgium",
         "park_name": "Six Flags Belgium",
         "reference-details": "Build your own version of this European Six Flags park",
-        "details": "Постройте свою версию европейского парка Six Flags."
+        "details": "Постройте свою версию этого европейского парка Six Flags"
     },
     "rct2.scenario_text.build_your_own_six_flags_great_adventure": {
         "reference-name": "Build your own Six Flags Great Adventure",
@@ -3099,7 +3099,7 @@
         "reference-park_name": "Six Flags Great Adventure",
         "park_name": "Six Flags Great Adventure",
         "reference-details": "Use your design skills to recreate this Six Flags park",
-        "details": "Восстановите этот парк Six Flags."
+        "details": "Используйте свои навыки, чтобы воссоздать этот парк Six Flags"
     },
     "rct2.scenario_text.build_your_own_six_flags_holland": {
         "reference-name": "Build your own Six Flags Holland",
@@ -3107,7 +3107,7 @@
         "reference-park_name": "Six Flags Holland",
         "park_name": "Six Flags Holland",
         "reference-details": "Build this European Six Flags park the way you want to",
-        "details": "Постройте этот европейский парк Six Flags."
+        "details": "Постройте этот европейский парк Six Flags так, как вы хотите"
     },
     "rct2.scenario_text.build_your_own_six_flags_magic_mountain": {
         "reference-name": "Build your own Six Flags Magic Mountain",
@@ -3115,23 +3115,23 @@
         "reference-park_name": "Six Flags Magic Mountain",
         "park_name": "Six Flags Magic Mountain",
         "reference-details": "Create your own version of this massive Six Flags park",
-        "details": "Постройте собственную версию парка Six Flags."
+        "details": "Постройте собственную версию этого огромного парка Six Flags"
     },
     "rct2.scenario_text.build_your_own_six_flags_over_texas": {
         "reference-name": "Build your own Six Flags over Texas",
-        "name": "Постройте свой парк Six Flags over Texas.",
+        "name": "Постройте свой парк Six Flags over Texas",
         "reference-park_name": "Six Flags over Texas",
         "park_name": "Six Flags over Texas",
         "reference-details": "Starting from scratch, build the rides in this Six Flags park",
-        "details": "Постройте аттракционы в этом парке Six Flags."
+        "details": "Начните с нуля, и постройте аттракционы этого парка Six Flags"
     },
     "rct2.scenario_text.build_your_own_six_flags_park": {
         "reference-name": "Build your own Six Flags Park",
-        "name": "Постройте Парк Six Flags",
+        "name": "Постройте свой парк Six Flags",
         "reference-park_name": "Six Flags",
         "park_name": "Six Flags",
         "reference-details": "Build your own design of Six Flags park - either build rides from other Six Flags parks or design and build your own rides",
-        "details": "Постройте собственный парк Six Flags. Вы можете строить собственные аттракционы."
+        "details": "Создайте свой собственный дизайн парка Six Flags, либо используя аттракционы из других парков Six Flags, либо создавая свои"
     },
     "rct2.scenario_text.bumbly_bazaar": {
         "reference-name": "Bumbly Bazaar",
@@ -3139,7 +3139,7 @@
         "reference-park_name": "Bumbly Bazaar",
         "park_name": "Bumbly Bazaar",
         "reference-details": "Starting with a small market bazaar, your challenge is to increase the profit from shops and stalls by building rides and roller coasters to attract more customers",
-        "details": "Вы должны добиться увеличения прибыли небольшого базара за счет строительства аттракционов и привлечения покупателей."
+        "details": "Начните свою работу в маленьком базаре, и увеличьте прибыль от его магазинов, строя привлекающие новых покупателей аттракционы"
     },
     "rct2.scenario_text.crazy_castle": {
         "reference-name": "Crazy Castle",
@@ -3147,7 +3147,7 @@
         "reference-park_name": "Crazy Castle",
         "park_name": "Crazy Castle",
         "reference-details": "You have inherited a large castle. Your job is to convert it into a small theme park.",
-        "details": "Вы унаследовали большой замок. Превратите его в уютный тематический парк."
+        "details": "Вы унаследовали большой замок. Ваша задача - превратить его в маленький парк"
     },
     "rct2.scenario_text.dusty_greens": {
         "reference-name": "Dusty Greens",
@@ -3155,7 +3155,7 @@
         "reference-park_name": "Dusty Greens",
         "park_name": "Dusty Greens",
         "reference-details": "Situated near a highway junction in the desert, Dusty Greens is an opportunity to develop a small golf resort into a thriving theme park",
-        "details": "Вам предлагается превратить небольшое поле для гольфа Дасти Гринз в тематический парк развлечений."
+        "details": "Небольшой гольф-курорт Dusty Greens расположен на перекрёстке шоссе в пустыне. У вас есть возможность превратить его в успешный парк"
     },
     "rct2.scenario_text.electric_fields": {
         "reference-name": "Electric Fields",
@@ -3163,7 +3163,7 @@
         "reference-park_name": "Electric Fields",
         "park_name": "Electric Fields",
         "reference-details": "You have inherited a small farm, and your challenge is to build a small theme park amongst the fields and farm buildings",
-        "details": "Вы унаследовали небольшую ферму и теперь должны построить тематический парк среди полей и лесов."
+        "details": "Вы унаследовали небольшую ферму, и ваша задача - создать маленький парк среди её полей и зданий"
     },
     "rct2.scenario_text.extreme_heights": {
         "reference-name": "Extreme Heights",
@@ -3171,7 +3171,7 @@
         "reference-park_name": "Extreme Heights",
         "park_name": "Extreme Heights",
         "reference-details": "Free of financial restrictions, your challenge is to expand this desert park to attract people seeking the ultimate thrills",
-        "details": "Финансовых ограничений нет. Вы должны расширить пустынный парк и привлечь туристов."
+        "details": "Финансовых ограничений нет. Вы должны расширить этот пустынный парк и привлечь туристов-экстремалов"
     },
     "rct2.scenario_text.factory_capers": {
         "reference-name": "Factory Capers",
@@ -3179,7 +3179,7 @@
         "reference-park_name": "Factory Capers",
         "park_name": "Factory Capers",
         "reference-details": "An abandoned factory complex is an opportunity to build a mechanical-themed amusement park",
-        "details": "Заброшенный промышленный комплекс - отличное место для строительство парка развлечений."
+        "details": "Заброшенный промышленный комплекс - отличное место для строительство парка развлечений с механическим оформлением"
     },
     "rct2.scenario_text.fungus_woods": {
         "reference-name": "Fungus Woods",
@@ -3187,7 +3187,7 @@
         "reference-park_name": "Fungus Woods",
         "park_name": "Fungus Woods",
         "reference-details": "Restricted to only older-style wooden rides, your challenge is to build a thriving theme park in Fungus Woods",
-        "details": "Задача - построить парк развлеченийв Грибном Лесу, используя только деревянные аттракционы."
+        "details": "Постройте успешный парк в лесах Fungus Woods с ограничением - только деревянные аттракционы"
     },
     "rct2.scenario_text.ghost_town": {
         "reference-name": "Ghost Town",
@@ -3195,7 +3195,7 @@
         "reference-park_name": "Ghost Town",
         "park_name": "Ghost Town",
         "reference-details": "Hired by a large amusement park chain, your task is to build them a giant roller coaster park around an abandoned mining town",
-        "details": "Ваша задача - построить гигантский парк американских горок вокруг заброшенного шахтерского городка."
+        "details": "Большая сеть парков наняла вас, чтобы построить огромный парк аттракционов вокруг заброшенного шахтёрского города"
     },
     "rct2.scenario_text.gravity_gardens": {
         "reference-name": "Gravity Gardens",
@@ -3203,7 +3203,7 @@
         "reference-park_name": "Gravity Gardens",
         "park_name": "Gravity Gardens",
         "reference-details": "Your challenge is to build a roller coaster park in the beautiful Gravity Gardens. No other rides, just roller coasters!",
-        "details": "Ваша задача - построить парк аттракционов в прекрасных Висячих Садах. Стройте только американские горки!"
+        "details": "Ваша задача - построить парк аттракционов в прекрасных садах Gravity Gardens. Стройте только американские горки!"
     },
     "rct2.scenario_text.infernal_views": {
         "reference-name": "Infernal Views",
@@ -3211,7 +3211,7 @@
         "reference-park_name": "Infernal Views",
         "park_name": "Infernal Views",
         "reference-details": "A park nestled precariously on lava rock with streams of magma",
-        "details": "Парк, расположенный на скале из застывшей лавы."
+        "details": "Парк, аккуратно расположеный на камне из застывшей лавы, с текущими из него потоками магмы"
     },
     "rct2.scenario_text.lucky_lake": {
         "reference-name": "Lucky Lake",
@@ -3219,7 +3219,7 @@
         "reference-park_name": "Lucky Lake",
         "park_name": "Lucky Lake",
         "reference-details": "With unlimited funds but a challenging lake location, this park will be a challenge to expand and manage",
-        "details": "Этот парк станет настоящим испытанием для самого опытного менеджера."
+        "details": "Несмотря на ограниченные финансы, будет непросто построить и расширить парк вокруг этого озера"
     },
     "rct2.scenario_text.rainbow_summit": {
         "reference-name": "Rainbow Summit",
@@ -3227,7 +3227,7 @@
         "reference-park_name": "Rainbow Summit",
         "park_name": "Rainbow Summit",
         "reference-details": "Built on a hillside, this park is forbidden from building anything tall. Can you expand the park and make it successful?",
-        "details": "В этом парке нельзя строить ничего высокого. Попробуйте сделать этот парк успешным."
+        "details": "В этом парке, построенном на холме, запрещено строить высокие аттракционы. Сможете ли вы расширить его и сделать его успешным?"
     },
     "rct2.scenario_text.six_flags_belgium": {
         "reference-name": "Six Flags Belgium",
@@ -3235,7 +3235,7 @@
         "reference-park_name": "Six Flags Belgium",
         "park_name": "Six Flags Belgium",
         "reference-details": "Try your hand at running and improving this Six Flags park",
-        "details": "Попробуйте свои силы на этом парке Six Flags."
+        "details": "Попробуйте управлять этим парком Six Flags и расширить его"
     },
     "rct2.scenario_text.six_flags_great_adventure": {
         "reference-name": "Six Flags Great Adventure",
@@ -3243,7 +3243,7 @@
         "reference-park_name": "Six Flags Great Adventure",
         "park_name": "Six Flags Great Adventure",
         "reference-details": "Build the missing Six Flags rides, or create your own designs to improve the park! But don’t forget your ultimate aim: to attract more guests to the park!",
-        "details": "Постройте недостающие аттракционы, или создайте парк по собственному плану! Но не забудьте - вы должны привлечь как можно больше гостей!"
+        "details": "Постройте недостающие аттракционы, или создайте свои собственные дизайны для улучшения парка! Но не забудьте свою главную цель - привлечь ещё больше гостей в этот парк!"
     },
     "rct2.scenario_text.six_flags_holland": {
         "reference-name": "Six Flags Holland",
@@ -3251,7 +3251,7 @@
         "reference-park_name": "Six Flags Holland",
         "park_name": "Six Flags Holland",
         "reference-details": "Try your hand at running and improving this Six Flags park",
-        "details": "Попробуйте свои силы на этом парке Six Flags."
+        "details": "Попробуйте управлять этим парком Six Flags и расширить его"
     },
     "rct2.scenario_text.six_flags_magic_mountain": {
         "reference-name": "Six Flags Magic Mountain",
@@ -3259,7 +3259,7 @@
         "reference-park_name": "Six Flags Magic Mountain",
         "park_name": "Six Flags Magic Mountain",
         "reference-details": "Build the missing Six Flags rides, or create your own designs to improve the park! But don’t forget your ultimate aim: to repay your loan while keeping the park value up!",
-        "details": "Постройте недостающие аттракционы, или создайте собственный парк! Но не забудьте - вы должны выплатить кредит!"
+        "details": "Постройте недостающие аттракционы, или создайте свои собственные дизайны для улучшения парка! Но не забудьте свою главную цель - расплатиться с банком, не теряя стоимости парка!"
     },
     "rct2.scenario_text.six_flags_over_texas": {
         "reference-name": "Six Flags over Texas",
@@ -3267,7 +3267,7 @@
         "reference-park_name": "Six Flags over Texas",
         "park_name": "Six Flags over Texas",
         "reference-details": "Build the missing Six Flags rides, or create your own designs to improve the park! But don’t forget your ultimate aim: to attract more guests to the park!",
-        "details": "Постройте недостающие аттракционы, или создайте парк по собственному плану! Но не забудьте - вы должны привлечь как можно больше гостей!"
+        "details": "Постройте недостающие аттракционы, или создайте свои собственные дизайны для улучшения парка! Но не забудьте свою главную цель - привлечь ещё больше гостей в этот парк!"
     },
     "rct2.scenario_text.tycoon_park": {
         "reference-name": "Tycoon Park",
@@ -3279,95 +3279,95 @@
     },
     "rct2.scenery_group.scgabstr": {
         "reference-name": "Abstract Theming",
-        "name": "Абстракция"
+        "name": "Абстратная тема"
     },
     "rct2.scenery_group.scgcandy": {
         "reference-name": "Giant Candy Theming",
-        "name": "Конфета"
+        "name": "Тема \"огромные конфеты\""
     },
     "rct2.scenery_group.scgclass": {
         "reference-name": "Classical/Roman Theming",
-        "name": "Рим"
+        "name": "Классическая/римская тема"
     },
     "rct2.scenery_group.scgegypt": {
         "reference-name": "Egyptian Theming",
-        "name": "Египет"
+        "name": "Египетская тема"
     },
     "rct2.scenery_group.scgfence": {
         "reference-name": "Fences and Walls",
-        "name": "Ограды и стены"
+        "name": "Заборы и стены"
     },
     "rct2.scenery_group.scggardn": {
         "reference-name": "Gardens",
-        "name": "Клумба"
+        "name": "Сады"
     },
     "rct2.scenery_group.scggiant": {
         "reference-name": "Giant Garden Theming",
-        "name": "Гигантский Сад"
+        "name": "Тема \"огромный сад\""
     },
     "rct2.scenery_group.scghallo": {
         "reference-name": "Creepy Theming",
-        "name": "Страшилки"
+        "name": "Тема \"ужасы\""
     },
     "rct2.scenery_group.scgindus": {
         "reference-name": "Mechanical Theming",
-        "name": "Техника"
+        "name": "Механическая тема"
     },
     "rct2.scenery_group.scgjungl": {
         "reference-name": "Jungle Theming",
-        "name": "Джунгли"
+        "name": "Тема \"джунгли\""
     },
     "rct2.scenery_group.scgjuras": {
         "reference-name": "Jurassic Theming",
-        "name": "Юрский Парк"
+        "name": "Тема \"юрский период\""
     },
     "rct2.scenery_group.scgmart": {
         "reference-name": "Martian Theming",
-        "name": "Марс"
+        "name": "Марсианская тема"
     },
     "rct2.scenery_group.scgmedie": {
         "reference-name": "Medieval Theming",
-        "name": "Средневековье"
+        "name": "Средневековая тема"
     },
     "rct2.scenery_group.scgmine": {
         "reference-name": "Mine Theming",
-        "name": "Рудник"
+        "name": "Шахтёрская тема"
     },
     "rct2.scenery_group.scgorien": {
         "reference-name": "Pagoda Theming",
-        "name": "Пагода"
+        "name": "Тема \"пагода\""
     },
     "rct2.scenery_group.scgpathx": {
         "reference-name": "Signs and Items for Footpaths",
-        "name": "Знаки для дорожек"
+        "name": "Знаки и объекты для троп"
     },
     "rct2.scenery_group.scgpirat": {
         "reference-name": "Pirates Theming",
-        "name": "Пираты"
+        "name": "Пиратская тема"
     },
     "rct2.scenery_group.scgshrub": {
         "reference-name": "Shrubs and Ornaments",
-        "name": "Кусты и Орнаменты"
+        "name": "Кусты и орнаменты"
     },
     "rct2.scenery_group.scgsixfl": {
         "reference-name": "Six Flags Theming",
-        "name": "Шесть Флагов"
+        "name": "Тема \"Six Flags\""
     },
     "rct2.scenery_group.scgsnow": {
         "reference-name": "Snow and Ice Theming",
-        "name": "Снег и Лед"
+        "name": "Снежная тема"
     },
     "rct2.scenery_group.scgspace": {
         "reference-name": "Space Theming",
-        "name": "Космос"
+        "name": "Космическая тема"
     },
     "rct2.scenery_group.scgspook": {
         "reference-name": "Spooky Theming",
-        "name": "Страшилки"
+        "name": "Тема \"страх\""
     },
     "rct2.scenery_group.scgsport": {
         "reference-name": "Sports Theming",
-        "name": "Спорт"
+        "name": "Спортивная тема"
     },
     "rct2.scenery_group.scgtrees": {
         "reference-name": "Trees",
@@ -3375,7 +3375,7 @@
     },
     "rct2.scenery_group.scgurban": {
         "reference-name": "Urban Theming",
-        "name": "Город"
+        "name": "Городская тема"
     },
     "rct2.scenery_group.scgwalls": {
         "reference-name": "Walls and Roofs",
@@ -3383,39 +3383,39 @@
     },
     "rct2.scenery_group.scgwater": {
         "reference-name": "Water Feature Theming",
-        "name": "Водная Тема"
+        "name": "Водная тема"
     },
     "rct2.scenery_group.scgwond": {
         "reference-name": "Wonderland Theming",
-        "name": "Чудесная Тема"
+        "name": "Тема \"страна чудес\""
     },
     "rct2.scenery_group.scgwwest": {
         "reference-name": "Wild West Theming",
-        "name": "Дикий Запад"
+        "name": "Тема \"дикий запад\""
     },
     "rct2.scenery_large.badrack": {
         "reference-name": "Badminton Racket",
-        "name": "Ракетка"
+        "name": "Ракетка для бадминтона"
     },
     "rct2.scenery_large.genstore": {
         "reference-name": "General Store",
-        "name": "Лавка"
+        "name": "Магазин общего назначения"
     },
     "rct2.scenery_large.glthent": {
         "reference-name": "‘Goliath’ Sign",
-        "name": "‘Goliath’ знак"
+        "name": "Знак \"Голиаф\""
     },
     "rct2.scenery_large.mdsaent": {
         "reference-name": "‘Medusa’ Sign",
-        "name": "Знак ‘Medusa’"
+        "name": "Знак \"Медуза\""
     },
     "rct2.scenery_large.nitroent": {
         "reference-name": "‘Nitro’ Sign",
-        "name": "Знак ‘Нитро’"
+        "name": "Знак \"Нитро\""
     },
     "rct2.scenery_large.prship": {
         "reference-name": "Pirate Ship",
-        "name": "Корабль"
+        "name": "Пиратский корабль"
     },
     "rct2.scenery_large.sah": {
         "reference-name": "House",
@@ -3427,7 +3427,7 @@
     },
     "rct2.scenery_large.sah3": {
         "reference-name": "Tenement",
-        "name": "Дом"
+        "name": "Квартирный дом"
     },
     "rct2.scenery_large.saloon": {
         "reference-name": "Saloon",
@@ -3439,11 +3439,11 @@
     },
     "rct2.scenery_large.scol": {
         "reference-name": "Roman Colosseum",
-        "name": "Колизей"
+        "name": "Римский колизей"
     },
     "rct2.scenery_large.sct": {
         "reference-name": "Tent",
-        "name": "Тент"
+        "name": "Палатка"
     },
     "rct2.scenery_large.sdn1": {
         "reference-name": "Dinosaur",
@@ -3459,11 +3459,11 @@
     },
     "rct2.scenery_large.sgp": {
         "reference-name": "Giant Pumpkin",
-        "name": "Тыква"
+        "name": "Огромная тыква"
     },
     "rct2.scenery_large.shs1": {
         "reference-name": "Terraced House",
-        "name": "Особняк"
+        "name": "Дом с террасой"
     },
     "rct2.scenery_large.shs2": {
         "reference-name": "House",
@@ -3471,7 +3471,7 @@
     },
     "rct2.scenery_large.sip": {
         "reference-name": "Ice Palace",
-        "name": "Дворец"
+        "name": "Ледяной дворец"
     },
     "rct2.scenery_large.smb": {
         "reference-name": "Martian Building",
@@ -3479,11 +3479,11 @@
     },
     "rct2.scenery_large.smh1": {
         "reference-name": "Mine Hut",
-        "name": "Хибара"
+        "name": "Шахтёрская хижина"
     },
     "rct2.scenery_large.smh2": {
         "reference-name": "Mine Hut",
-        "name": "Хибара"
+        "name": "Шахтёрская хижина"
     },
     "rct2.scenery_large.smn1": {
         "reference-name": "Mine Shaft",
@@ -3491,7 +3491,7 @@
     },
     "rct2.scenery_large.sob": {
         "reference-name": "Office Block",
-        "name": "Офис"
+        "name": "Офисный квартал"
     },
     "rct2.scenery_large.soh1": {
         "reference-name": "House",
@@ -3515,27 +3515,27 @@
     },
     "rct2.scenery_large.spyr": {
         "reference-name": "Pyramid",
-        "name": "Башня"
+        "name": "Пирамида"
     },
     "rct2.scenery_large.ssh": {
         "reference-name": "Space Capsule",
-        "name": "Капсула"
+        "name": "Космическая капсула"
     },
     "rct2.scenery_large.ssig1": {
         "reference-name": "Scrolling Sign",
-        "name": "Знак"
+        "name": "Прокручивающийся знак"
     },
     "rct2.scenery_large.ssig2": {
         "reference-name": "3D Sign",
-        "name": "3D Знак"
+        "name": "3D знак"
     },
     "rct2.scenery_large.ssig3": {
         "reference-name": "Vertical 3D Sign",
-        "name": "3D вывеска"
+        "name": "Вертикальный 3D знак"
     },
     "rct2.scenery_large.ssig4": {
         "reference-name": "3D Sign",
-        "name": "3D Знак"
+        "name": "3D знак"
     },
     "rct2.scenery_large.ssk1": {
         "reference-name": "Skeleton",
@@ -3547,7 +3547,7 @@
     },
     "rct2.scenery_large.ssr": {
         "reference-name": "Space Rocket",
-        "name": "Ракета"
+        "name": "Космическая ракета"
     },
     "rct2.scenery_large.sst": {
         "reference-name": "Satellite",
@@ -3571,7 +3571,7 @@
     },
     "rct2.scenery_large.sth": {
         "reference-name": "Town Hall",
-        "name": "Ратуша"
+        "name": "Мэрия"
     },
     "rct2.scenery_large.svlc": {
         "reference-name": "Volcano",
@@ -3579,7 +3579,7 @@
     },
     "rct2.scenery_large.tavern": {
         "reference-name": "Tavern",
-        "name": "Кабак"
+        "name": "Таверна"
     },
     "rct2.scenery_large.wwbank": {
         "reference-name": "Bank",
@@ -3587,11 +3587,11 @@
     },
     "rct2.scenery_small.allsort1": {
         "reference-name": "Candy",
-        "name": "Пирог"
+        "name": "Конфета"
     },
     "rct2.scenery_small.allsort2": {
         "reference-name": "Candy",
-        "name": "Пирог"
+        "name": "Конфета"
     },
     "rct2.scenery_small.badshut": {
         "reference-name": "Shuttlecock",
@@ -3603,47 +3603,47 @@
     },
     "rct2.scenery_small.ball1": {
         "reference-name": "American Football",
-        "name": "Футбольный мяч"
+        "name": "Американский футбольный мяч"
     },
     "rct2.scenery_small.ball2": {
         "reference-name": "American Football",
-        "name": "Мяч"
+        "name": "Американский футбольный мяч"
     },
     "rct2.scenery_small.ball3": {
         "reference-name": "Football",
-        "name": "Мяч"
+        "name": "Футбольный мяч"
     },
     "rct2.scenery_small.ball4": {
         "reference-name": "Tennis Ball",
-        "name": "Мяч"
+        "name": "Тенисный мяч"
     },
     "rct2.scenery_small.beanst1": {
         "reference-name": "Giant Beanstalk",
-        "name": "Стебель"
+        "name": "Огромный стебель"
     },
     "rct2.scenery_small.beanst2": {
         "reference-name": "Giant Beanstalk",
-        "name": "Стебель"
+        "name": "Огромный стебель"
     },
     "rct2.scenery_small.brbase": {
         "reference-name": "Base Block",
-        "name": "База"
+        "name": "Базовый блок"
     },
     "rct2.scenery_small.brbase2": {
         "reference-name": "Base Block",
-        "name": "База"
+        "name": "Базовый блок"
     },
     "rct2.scenery_small.brbase3": {
         "reference-name": "Base Block",
-        "name": "База"
+        "name": "Базовый блок"
     },
     "rct2.scenery_small.brcrrf1": {
         "reference-name": "Curved Roof",
-        "name": "Крыша"
+        "name": "Крыша с изгибом"
     },
     "rct2.scenery_small.brcrrf2": {
         "reference-name": "Curved Roof",
-        "name": "Крыша"
+        "name": "Крыша с изгибом"
     },
     "rct2.scenery_small.buttfly": {
         "reference-name": "Butterfly",
@@ -3651,11 +3651,11 @@
     },
     "rct2.scenery_small.carrot": {
         "reference-name": "Giant Carrot",
-        "name": "Морковь"
+        "name": "Огромная морковь"
     },
     "rct2.scenery_small.chbbase": {
         "reference-name": "Checkerboard Block",
-        "name": "Шахматы"
+        "name": "Блок шахматной доски"
     },
     "rct2.scenery_small.chest1": {
         "reference-name": "Treasure Chest",
@@ -3667,7 +3667,7 @@
     },
     "rct2.scenery_small.chocroof": {
         "reference-name": "Chocolate Bar",
-        "name": "Шоколадница"
+        "name": "Шоколадная плитка"
     },
     "rct2.scenery_small.cnballs": {
         "reference-name": "Cannon Balls",
@@ -3675,7 +3675,7 @@
     },
     "rct2.scenery_small.cndyrk1": {
         "reference-name": "Candy Stick",
-        "name": "Конфета"
+        "name": "Конфетная палочка"
     },
     "rct2.scenery_small.cog1": {
         "reference-name": "Cogwheel",
@@ -3711,63 +3711,63 @@
     },
     "rct2.scenery_small.colagum": {
         "reference-name": "Cola Candy",
-        "name": "Кола"
+        "name": "Конфета со вкусом колы"
     },
     "rct2.scenery_small.corroof": {
         "reference-name": "Corrugated Steel Roof",
-        "name": "Рифлёная крыша"
+        "name": "Рифлёная стальная крыша"
     },
     "rct2.scenery_small.corroof2": {
         "reference-name": "Corrugated Steel Base",
-        "name": "Рифлёная база"
+        "name": "Рифлёное стальное основание"
     },
     "rct2.scenery_small.cwbcrv32": {
         "reference-name": "Curved Wall",
-        "name": "Стена"
+        "name": "Стена с изгибом"
     },
     "rct2.scenery_small.cwbcrv33": {
         "reference-name": "Curved Block",
-        "name": "Кривой блок"
+        "name": "Блок с изгибом"
     },
     "rct2.scenery_small.cwfcrv32": {
         "reference-name": "Curved Wall",
-        "name": "Стена"
+        "name": "Стена с изгибом"
     },
     "rct2.scenery_small.cwfcrv33": {
         "reference-name": "Curved Block",
-        "name": "Кривой блок"
+        "name": "Блок с изгибом"
     },
     "rct2.scenery_small.fern1": {
         "reference-name": "Giant Fern",
-        "name": "Куст"
+        "name": "Огромный куст"
     },
     "rct2.scenery_small.fire1": {
         "reference-name": "Flames",
-        "name": "Огонь"
+        "name": "Пламя"
     },
     "rct2.scenery_small.georoof1": {
         "reference-name": "Glass Roof",
-        "name": "Крыша"
+        "name": "Стеклянная крыша"
     },
     "rct2.scenery_small.georoof2": {
         "reference-name": "Glass Roof",
-        "name": "Крыша"
+        "name": "Стеклянная крыша"
     },
     "rct2.scenery_small.ggrs1": {
         "reference-name": "Giant Grass",
-        "name": "Трава"
+        "name": "Огромная трава"
     },
     "rct2.scenery_small.hang1": {
         "reference-name": "Gallows",
-        "name": "Эшафот"
+        "name": "Виселица"
     },
     "rct2.scenery_small.helmet1": {
         "reference-name": "American Football Helmet",
-        "name": "Футбольный шлем"
+        "name": "Шлем для американского футбола"
     },
     "rct2.scenery_small.icecube": {
         "reference-name": "Ice Cube",
-        "name": "Лёд"
+        "name": "Ледяной куб"
     },
     "rct2.scenery_small.igroof": {
         "reference-name": "Igloo Roof",
@@ -3775,23 +3775,23 @@
     },
     "rct2.scenery_small.jbean1": {
         "reference-name": "Jellybean",
-        "name": "Желе"
+        "name": "Жевательная конфета"
     },
     "rct2.scenery_small.jelbab1": {
         "reference-name": "Jelly Baby",
-        "name": "Желе"
+        "name": "Жевательная конфета"
     },
     "rct2.scenery_small.jeldrop1": {
         "reference-name": "Fruit Drop",
-        "name": "Фрукт"
+        "name": "Фруктовая конфета"
     },
     "rct2.scenery_small.jeldrop2": {
         "reference-name": "Fruit Drop",
-        "name": "Фрукт"
+        "name": "Фруктовая конфета"
     },
     "rct2.scenery_small.jngroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.lolly1": {
         "reference-name": "Lollypop",
@@ -3799,15 +3799,15 @@
     },
     "rct2.scenery_small.mallow1": {
         "reference-name": "Marshmallow",
-        "name": "Мальва"
+        "name": "Маршмэллоу"
     },
     "rct2.scenery_small.mallow2": {
         "reference-name": "Marshmallow",
-        "name": "Мальва"
+        "name": "Маршмэллоу"
     },
     "rct2.scenery_small.minroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.mint1": {
         "reference-name": "Mint",
@@ -3815,43 +3815,43 @@
     },
     "rct2.scenery_small.mment1": {
         "reference-name": "Ornamental Structure",
-        "name": "Конструкция"
+        "name": "Орнамент"
     },
     "rct2.scenery_small.mment2": {
         "reference-name": "Ornamental Structure",
-        "name": "Конструкция"
+        "name": "Орнамент"
     },
     "rct2.scenery_small.mment3": {
         "reference-name": "Ornamental Structure",
-        "name": "Конструкция"
+        "name": "Орнамент"
     },
     "rct2.scenery_small.pagroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.pipe32": {
         "reference-name": "Pipe Section",
-        "name": "Труба"
+        "name": "Секция трубы"
     },
     "rct2.scenery_small.pipe32j": {
         "reference-name": "Pipe Section",
-        "name": "Труба"
+        "name": "Секция трубы"
     },
     "rct2.scenery_small.pipe8": {
         "reference-name": "Pipe Section",
-        "name": "Труба"
+        "name": "Секция трубы"
     },
     "rct2.scenery_small.pirflag": {
         "reference-name": "Pirate Flag",
-        "name": "Флаг"
+        "name": "Пиратский флаг"
     },
     "rct2.scenery_small.pirroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.pirroof2": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.prcan": {
         "reference-name": "Cannon",
@@ -3859,67 +3859,67 @@
     },
     "rct2.scenery_small.romroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.romroof2": {
         "reference-name": "Plinth",
-        "name": "Пост"
+        "name": "Плинтус"
     },
     "rct2.scenery_small.roof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof10": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof11": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof12": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof13": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof14": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof2": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof3": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof4": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof5": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof6": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof7": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof8": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.roof9": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.sktbase": {
         "reference-name": "Block",
@@ -3931,11 +3931,11 @@
     },
     "rct2.scenery_small.sktdw": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_small.sktdw2": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_small.smskull": {
         "reference-name": "Skull",
@@ -3943,11 +3943,11 @@
     },
     "rct2.scenery_small.snail": {
         "reference-name": "Snail",
-        "name": "Мидия"
+        "name": "Улитка"
     },
     "rct2.scenery_small.spcroof1": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.spider1": {
         "reference-name": "Spider",
@@ -3955,51 +3955,51 @@
     },
     "rct2.scenery_small.stbase": {
         "reference-name": "Steel Block",
-        "name": "Блок"
+        "name": "Стальной блок"
     },
     "rct2.scenery_small.stlbaset": {
         "reference-name": "Steel Block",
-        "name": "Блок"
+        "name": "Стальной блок"
     },
     "rct2.scenery_small.stldw": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_small.stldw2": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_small.sumrf": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "rct2.scenery_small.suppleg1": {
         "reference-name": "Pole",
-        "name": "Шест"
+        "name": "Столб"
     },
     "rct2.scenery_small.suppleg2": {
         "reference-name": "Pole",
-        "name": "Шест"
+        "name": "Столб"
     },
     "rct2.scenery_small.suppw1": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "rct2.scenery_small.suppw2": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "rct2.scenery_small.suppw3": {
         "reference-name": "Support Structure",
-        "name": "Поддержка"
+        "name": "Структура поддержки"
     },
     "rct2.scenery_small.tac": {
         "reference-name": "Arizona Cypress Tree",
-        "name": "Аризонский Кипарис"
+        "name": "Аризонский кипарис"
     },
     "rct2.scenery_small.tal": {
         "reference-name": "Alligator Shaped Tree",
-        "name": "Куст в форме крокодила"
+        "name": "Дерево в форме крокодила"
     },
     "rct2.scenery_small.tap": {
         "reference-name": "Aleppo Pine Tree",
@@ -4011,19 +4011,19 @@
     },
     "rct2.scenery_small.tas1": {
         "reference-name": "Candy Tree",
-        "name": "Дерево"
+        "name": "Конфетное дерево"
     },
     "rct2.scenery_small.tas2": {
         "reference-name": "Candy Tree",
-        "name": "Дерево"
+        "name": "Конфетное дерево"
     },
     "rct2.scenery_small.tas3": {
         "reference-name": "Candy Tree",
-        "name": "Дерево"
+        "name": "Конфетное дерево"
     },
     "rct2.scenery_small.tas4": {
         "reference-name": "Candy",
-        "name": "Пирог"
+        "name": "Конфета"
     },
     "rct2.scenery_small.tb1": {
         "reference-name": "White Bishop",
@@ -4039,7 +4039,7 @@
     },
     "rct2.scenery_small.tbn": {
         "reference-name": "Bone",
-        "name": "Прах"
+        "name": "Кость"
     },
     "rct2.scenery_small.tbn1": {
         "reference-name": "Bones",
@@ -4071,11 +4071,11 @@
     },
     "rct2.scenery_small.tbw": {
         "reference-name": "Broken Wheel",
-        "name": "Стена"
+        "name": "Сломанное колесо"
     },
     "rct2.scenery_small.tcb": {
         "reference-name": "Club Shaped Tree",
-        "name": "Дерево"
+        "name": "Дерево в форме трефа"
     },
     "rct2.scenery_small.tcc": {
         "reference-name": "Chinese Cedar Tree",
@@ -4095,7 +4095,7 @@
     },
     "rct2.scenery_small.tcfs": {
         "reference-name": "Snow-covered Caucasian Fir Tree",
-        "name": "Заснеженная Кавказская Ель"
+        "name": "Заснеженная кавказская ель"
     },
     "rct2.scenery_small.tcj": {
         "reference-name": "Common Juniper Tree",
@@ -4115,7 +4115,7 @@
     },
     "rct2.scenery_small.tco": {
         "reference-name": "Common Oak Tree",
-        "name": "яДуб"
+        "name": "Дуб"
     },
     "rct2.scenery_small.tcrp": {
         "reference-name": "Corsican Pine Tree",
@@ -4123,7 +4123,7 @@
     },
     "rct2.scenery_small.tct": {
         "reference-name": "Cabbage Tree",
-        "name": "Дерево"
+        "name": "Капустное дерево"
     },
     "rct2.scenery_small.tct1": {
         "reference-name": "Castle Tower",
@@ -4135,15 +4135,15 @@
     },
     "rct2.scenery_small.tcy": {
         "reference-name": "Common Yew Tree",
-        "name": "Обычный Тис"
+        "name": "Тис"
     },
     "rct2.scenery_small.tdf": {
         "reference-name": "Dolphin Fountain",
-        "name": "Дельфин"
+        "name": "Фонтан-дельфин"
     },
     "rct2.scenery_small.tdm": {
         "reference-name": "Diamond Shaped Tree",
-        "name": "Ромбовое дерево"
+        "name": "Дерево в форме бубна"
     },
     "rct2.scenery_small.tdn4": {
         "reference-name": "Dinosaur",
@@ -4155,15 +4155,15 @@
     },
     "rct2.scenery_small.tdt1": {
         "reference-name": "Dead Tree",
-        "name": "Дерево"
+        "name": "Мёртвое дерево"
     },
     "rct2.scenery_small.tdt2": {
         "reference-name": "Dead Tree",
-        "name": "Дерево"
+        "name": "Мёртвое дерево"
     },
     "rct2.scenery_small.tdt3": {
         "reference-name": "Dead Tree",
-        "name": "Дерево"
+        "name": "Мёртвое дерево"
     },
     "rct2.scenery_small.teepee1": {
         "reference-name": "Tepee",
@@ -4171,7 +4171,7 @@
     },
     "rct2.scenery_small.tef": {
         "reference-name": "Elephant Fountain",
-        "name": "Фонтан"
+        "name": "Фонтан-слон"
     },
     "rct2.scenery_small.tel": {
         "reference-name": "European Larch Tree",
@@ -4183,27 +4183,27 @@
     },
     "rct2.scenery_small.tep": {
         "reference-name": "Egyptian Column",
-        "name": "Колонна"
+        "name": "Египетская колонна"
     },
     "rct2.scenery_small.terb": {
         "reference-name": "Stone Block",
-        "name": "Блок"
+        "name": "Каменный блок"
     },
     "rct2.scenery_small.ters": {
         "reference-name": "Ruined Statue",
-        "name": "Статуя"
+        "name": "Разрушенная статуя"
     },
     "rct2.scenery_small.tes1": {
         "reference-name": "Egyptian Statue",
-        "name": "Статуя"
+        "name": "Египетская статуя"
     },
     "rct2.scenery_small.tf1": {
         "reference-name": "Fruit Tree",
-        "name": "Дерево"
+        "name": "Фруктовое дерево"
     },
     "rct2.scenery_small.tf2": {
         "reference-name": "Fruit Tree",
-        "name": "Дерево"
+        "name": "Фруктовое дерево"
     },
     "rct2.scenery_small.tg1": {
         "reference-name": "Gardens",
@@ -4291,31 +4291,31 @@
     },
     "rct2.scenery_small.tgc1": {
         "reference-name": "Sculpture",
-        "name": "Статуя"
+        "name": "Скульптура"
     },
     "rct2.scenery_small.tgc2": {
         "reference-name": "Sculpture",
-        "name": "Статуя"
+        "name": "Скульптура"
     },
     "rct2.scenery_small.tge1": {
         "reference-name": "Geometric Sculpture",
-        "name": "Скульптура"
+        "name": "Геометрическая скульптура"
     },
     "rct2.scenery_small.tge2": {
         "reference-name": "Geometric Sculpture",
-        "name": "Скульптура"
+        "name": "Геометрическая скульптура"
     },
     "rct2.scenery_small.tge3": {
         "reference-name": "Geometric Sculpture",
-        "name": "Скульптура"
+        "name": "Геометрическая скульптура"
     },
     "rct2.scenery_small.tge4": {
         "reference-name": "Geometric Sculpture",
-        "name": "Скульптура"
+        "name": "Геометрическая скульптура"
     },
     "rct2.scenery_small.tge5": {
         "reference-name": "Geometric Sculpture",
-        "name": "Скульптура"
+        "name": "Геометрическая скульптура"
     },
     "rct2.scenery_small.tgg": {
         "reference-name": "Gong",
@@ -4339,7 +4339,7 @@
     },
     "rct2.scenery_small.tgs": {
         "reference-name": "Giraffe Statue",
-        "name": "Жираф"
+        "name": "Статуя жирафа"
     },
     "rct2.scenery_small.tgs1": {
         "reference-name": "Grave Stone",
@@ -4371,11 +4371,11 @@
     },
     "rct2.scenery_small.thrs": {
         "reference-name": "Horseman Statue",
-        "name": "Всадник"
+        "name": "Статуя всадника"
     },
     "rct2.scenery_small.tht": {
         "reference-name": "Heart Shaped Tree",
-        "name": "Дерево"
+        "name": "Дерево в форме червей"
     },
     "rct2.scenery_small.tic": {
         "reference-name": "Incense Cedar Tree",
@@ -4411,11 +4411,11 @@
     },
     "rct2.scenery_small.tjp1": {
         "reference-name": "Plant",
-        "name": "Куст"
+        "name": "Растение"
     },
     "rct2.scenery_small.tjp2": {
         "reference-name": "Plant",
-        "name": "Куст"
+        "name": "Растение"
     },
     "rct2.scenery_small.tjt1": {
         "reference-name": "Tree",
@@ -4451,11 +4451,11 @@
     },
     "rct2.scenery_small.tk3": {
         "reference-name": "White King",
-        "name": "Король"
+        "name": "Белый король"
     },
     "rct2.scenery_small.tk4": {
         "reference-name": "Black King",
-        "name": "Король"
+        "name": "Чёрный король"
     },
     "rct2.scenery_small.tl0": {
         "reference-name": "Tree",
@@ -4515,43 +4515,43 @@
     },
     "rct2.scenery_small.tmj": {
         "reference-name": "Junk",
-        "name": "Блок"
+        "name": "Мусор"
     },
     "rct2.scenery_small.tml": {
         "reference-name": "Logs",
-        "name": "Лага"
+        "name": "Брёвна"
     },
     "rct2.scenery_small.tmm1": {
         "reference-name": "Graveyard Monument",
-        "name": "Памятник"
+        "name": "Кладбищенский памятник"
     },
     "rct2.scenery_small.tmm2": {
         "reference-name": "Graveyard Monument",
-        "name": "Памятник"
+        "name": "Кладбищенский памятник"
     },
     "rct2.scenery_small.tmm3": {
         "reference-name": "Graveyard Monument",
-        "name": "Памятник"
+        "name": "Кладбищенский памятник"
     },
     "rct2.scenery_small.tmo1": {
         "reference-name": "Martian Object",
-        "name": "Предмет с Марса"
+        "name": "Марсианский объект"
     },
     "rct2.scenery_small.tmo2": {
         "reference-name": "Martian Object",
-        "name": "Предмет с Марса"
+        "name": "Марсианский объект"
     },
     "rct2.scenery_small.tmo3": {
         "reference-name": "Martian Object",
-        "name": "Предмет с Марса"
+        "name": "Марсианский объект"
     },
     "rct2.scenery_small.tmo4": {
         "reference-name": "Martian Object",
-        "name": "Предмет с Марса"
+        "name": "Марсианский объект"
     },
     "rct2.scenery_small.tmo5": {
         "reference-name": "Martian Object",
-        "name": "Предмет с Марса"
+        "name": "Марсианский объект"
     },
     "rct2.scenery_small.tmp": {
         "reference-name": "Monkey-Puzzle Tree",
@@ -4559,7 +4559,7 @@
     },
     "rct2.scenery_small.tms1": {
         "reference-name": "Toadstool",
-        "name": "Поганка"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tmw": {
         "reference-name": "Wheels",
@@ -4579,7 +4579,7 @@
     },
     "rct2.scenery_small.tntroof1": {
         "reference-name": "Canvas Roof",
-        "name": "Брез. крыша"
+        "name": "Брезентовая крыша"
     },
     "rct2.scenery_small.toh1": {
         "reference-name": "House",
@@ -4627,11 +4627,11 @@
     },
     "rct2.scenery_small.tp1": {
         "reference-name": "White Pawn",
-        "name": "Пешка"
+        "name": "Белая пешка"
     },
     "rct2.scenery_small.tp2": {
         "reference-name": "Black Pawn",
-        "name": "Пешка"
+        "name": "Чёрная пешка"
     },
     "rct2.scenery_small.tpm": {
         "reference-name": "Palm Tree",
@@ -4639,27 +4639,27 @@
     },
     "rct2.scenery_small.tq1": {
         "reference-name": "White Queen",
-        "name": "Ферзь"
+        "name": "Белый ферзь"
     },
     "rct2.scenery_small.tq2": {
         "reference-name": "Black Queen",
-        "name": "Ферзь"
+        "name": "Чёрный ферзь"
     },
     "rct2.scenery_small.tqf": {
         "reference-name": "Cupid Fountains",
-        "name": "Купидон"
+        "name": "Фонтан-купидон"
     },
     "rct2.scenery_small.tr1": {
         "reference-name": "White Rook",
-        "name": "Ладья"
+        "name": "Белая ладья"
     },
     "rct2.scenery_small.tr2": {
         "reference-name": "Black Rook",
-        "name": "Ладья"
+        "name": "Чёрная ладья"
     },
     "rct2.scenery_small.trc": {
         "reference-name": "Roman Column",
-        "name": "Колонна"
+        "name": "Римская колонна"
     },
     "rct2.scenery_small.trf": {
         "reference-name": "Red Fir Tree",
@@ -4679,7 +4679,7 @@
     },
     "rct2.scenery_small.trms": {
         "reference-name": "Roman Statue",
-        "name": "Статуя"
+        "name": "Римская статуя"
     },
     "rct2.scenery_small.tropt1": {
         "reference-name": "Tree",
@@ -4687,7 +4687,7 @@
     },
     "rct2.scenery_small.trws": {
         "reference-name": "Roman Statue",
-        "name": "Статуя"
+        "name": "Римская статуя"
     },
     "rct2.scenery_small.ts0": {
         "reference-name": "Tree",
@@ -4707,7 +4707,7 @@
     },
     "rct2.scenery_small.ts4": {
         "reference-name": "Ornamental Tree",
-        "name": "Дерево"
+        "name": "Фигурное дерево"
     },
     "rct2.scenery_small.ts5": {
         "reference-name": "Ornamental Tree",
@@ -4715,7 +4715,7 @@
     },
     "rct2.scenery_small.ts6": {
         "reference-name": "Ornamental Tree",
-        "name": "Дерево"
+        "name": "Фигурное дерево"
     },
     "rct2.scenery_small.tsb": {
         "reference-name": "Silver Birch Tree",
@@ -4731,31 +4731,31 @@
     },
     "rct2.scenery_small.tscp": {
         "reference-name": "Space Capsule",
-        "name": "Капсула"
+        "name": "Космическая капсула"
     },
     "rct2.scenery_small.tsd": {
         "reference-name": "Spade Shaped Tree",
-        "name": "Дерево"
+        "name": "Дерево в форме пики"
     },
     "rct2.scenery_small.tsf1": {
         "reference-name": "Giant Snowflake",
-        "name": "Снежинка"
+        "name": "Огромная снежинка"
     },
     "rct2.scenery_small.tsf2": {
         "reference-name": "Giant Snowflake",
-        "name": "Снежинка"
+        "name": "Огромная снежинка"
     },
     "rct2.scenery_small.tsf3": {
         "reference-name": "Giant Snowflake",
-        "name": "Снежинка"
+        "name": "Огромная снежинка"
     },
     "rct2.scenery_small.tsg": {
         "reference-name": "Swamp Goo",
-        "name": "Липучка"
+        "name": "Болото"
     },
     "rct2.scenery_small.tsh": {
         "reference-name": "Horse Statue",
-        "name": "Лошадка"
+        "name": "Статуя-лошадь"
     },
     "rct2.scenery_small.tsh0": {
         "reference-name": "Bush",
@@ -4795,7 +4795,7 @@
     },
     "rct2.scenery_small.tsnb": {
         "reference-name": "Snowball",
-        "name": "Снежный ком"
+        "name": "Снежок"
     },
     "rct2.scenery_small.tsnc": {
         "reference-name": "Log Cabin",
@@ -4819,31 +4819,31 @@
     },
     "rct2.scenery_small.tsq": {
         "reference-name": "Squirrel Shaped Tree",
-        "name": "Беличье дерево"
+        "name": "Дерево в форме белки"
     },
     "rct2.scenery_small.tst1": {
         "reference-name": "Toadstool",
-        "name": "Мухомор"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tst2": {
         "reference-name": "Toadstool",
-        "name": "Мухомор"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tst3": {
         "reference-name": "Toadstool",
-        "name": "Мухомор"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tst4": {
         "reference-name": "Toadstool",
-        "name": "Мухомор"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tst5": {
         "reference-name": "Toadstool",
-        "name": "Мухомор"
+        "name": "Гриб"
     },
     "rct2.scenery_small.tstd": {
         "reference-name": "Dolphins Statue",
-        "name": "Дельфины"
+        "name": "Статуя-дельфин"
     },
     "rct2.scenery_small.tt1": {
         "reference-name": "Roman Temple",
@@ -4859,7 +4859,7 @@
     },
     "rct2.scenery_small.tus": {
         "reference-name": "Unicorn Statue",
-        "name": "Единорог"
+        "name": "Статуя-единорог"
     },
     "rct2.scenery_small.tvl": {
         "reference-name": "Voss’s Laburnam Tree",
@@ -4887,7 +4887,7 @@
     },
     "rct2.scenery_small.tww": {
         "reference-name": "Weeping Willow Tree",
-        "name": "Плакучая Ива"
+        "name": "Плакучая ива"
     },
     "rct2.scenery_small.wag1": {
         "reference-name": "Wagon",
@@ -4903,7 +4903,7 @@
     },
     "rct2.scenery_small.wdbase": {
         "reference-name": "Wooden Block",
-        "name": "Блок"
+        "name": "Деревянный блок"
     },
     "rct2.scenery_small.wdiag": {
         "reference-name": "Fountain",
@@ -4923,35 +4923,35 @@
     },
     "rct2.scenery_wall.wallbb16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbb32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbb33": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbb34": {
         "reference-name": "Stone Wall",
-        "name": "Стена"
+        "name": "Каменная стена"
     },
     "rct2.scenery_wall.wallbb8": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbr16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbr32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbr8": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallbrdr": {
         "reference-name": "Doorway",
@@ -4963,15 +4963,15 @@
     },
     "rct2.scenery_wall.wallcb16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcb32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcb8": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcbdr": {
         "reference-name": "Doorway",
@@ -4979,7 +4979,7 @@
     },
     "rct2.scenery_wall.wallcbpc": {
         "reference-name": "Portcullis Door",
-        "name": "Дверь"
+        "name": "Решётчатая дверь"
     },
     "rct2.scenery_wall.wallcbwn": {
         "reference-name": "Window",
@@ -4987,15 +4987,15 @@
     },
     "rct2.scenery_wall.wallcf16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcf32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcf8": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcfar": {
         "reference-name": "Wall Arch",
@@ -5007,7 +5007,7 @@
     },
     "rct2.scenery_wall.wallcfpc": {
         "reference-name": "Portcullis Door",
-        "name": "Дверь"
+        "name": "Решётчатая дверь"
     },
     "rct2.scenery_wall.wallcfwn": {
         "reference-name": "Window",
@@ -5015,35 +5015,35 @@
     },
     "rct2.scenery_wall.wallco16": {
         "reference-name": "Corrugated Steel Wall",
-        "name": "Рифлёная стена"
+        "name": "Рифлёная стальная стена"
     },
     "rct2.scenery_wall.wallcw32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcx32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcy32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallcz32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallgl16": {
         "reference-name": "Glass Wall",
-        "name": "Стена"
+        "name": "Стеклянная стена"
     },
     "rct2.scenery_wall.wallgl32": {
         "reference-name": "Glass Wall",
-        "name": "Стена"
+        "name": "Стеклянная стена"
     },
     "rct2.scenery_wall.wallgl8": {
         "reference-name": "Glass Wall",
-        "name": "Стена"
+        "name": "Стеклянная стена"
     },
     "rct2.scenery_wall.wallig16": {
         "reference-name": "Igloo Wall",
@@ -5055,11 +5055,11 @@
     },
     "rct2.scenery_wall.walljb16": {
         "reference-name": "Jellybean Wall",
-        "name": "Стена"
+        "name": "Конфетная стена"
     },
     "rct2.scenery_wall.walljn32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.walllt32": {
         "reference-name": "Steel Latticework",
@@ -5067,15 +5067,15 @@
     },
     "rct2.scenery_wall.wallmm16": {
         "reference-name": "Railings",
-        "name": "Ограда"
+        "name": "Перила"
     },
     "rct2.scenery_wall.wallmm17": {
         "reference-name": "Railings",
-        "name": "Ограда"
+        "name": "Перила"
     },
     "rct2.scenery_wall.wallmn32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallnt32": {
         "reference-name": "Tennis Net Wall",
@@ -5087,123 +5087,123 @@
     },
     "rct2.scenery_wall.wallpg32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallpost": {
         "reference-name": "Post",
-        "name": "Пост"
+        "name": "Столб"
     },
     "rct2.scenery_wall.wallpr32": {
         "reference-name": "Rigging",
-        "name": "Снасти"
+        "name": "Такелаж"
     },
     "rct2.scenery_wall.wallpr33": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallpr34": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallpr35": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallrh32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallrk32": {
         "reference-name": "Rock Wall",
-        "name": "Стена"
+        "name": "Каменная стена"
     },
     "rct2.scenery_wall.wallrs16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallrs32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallrs8": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallsc16": {
         "reference-name": "Railings",
-        "name": "Ограда"
+        "name": "Перила"
     },
     "rct2.scenery_wall.wallsign": {
         "reference-name": "Scrolling Sign",
-        "name": "Знак"
+        "name": "Прокручивающийся знак"
     },
     "rct2.scenery_wall.wallsk16": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallsk32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallsp32": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallst16": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_wall.wallst32": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_wall.wallst8": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_wall.wallstfn": {
         "reference-name": "Steel Fence",
-        "name": "Забор"
+        "name": "Стальной забор"
     },
     "rct2.scenery_wall.wallstwn": {
         "reference-name": "Steel Wall",
-        "name": "Стена"
+        "name": "Стальная стена"
     },
     "rct2.scenery_wall.walltn32": {
         "reference-name": "Poles",
-        "name": "Столб"
+        "name": "Столбы"
     },
     "rct2.scenery_wall.walltxgt": {
         "reference-name": "‘Texas Giant’ Sign",
-        "name": "Знак ‘Техас’"
+        "name": "Знак \"Техасский Гигант\""
     },
     "rct2.scenery_wall.wallu132": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallu232": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wallwd16": {
         "reference-name": "Wooden Wall",
-        "name": "Стена"
+        "name": "Деревянная стена"
     },
     "rct2.scenery_wall.wallwd32": {
         "reference-name": "Wooden Wall",
-        "name": "Стена"
+        "name": "Деревянная стена"
     },
     "rct2.scenery_wall.wallwd33": {
         "reference-name": "Wooden Wall",
-        "name": "Стена"
+        "name": "Деревянная стена"
     },
     "rct2.scenery_wall.wallwd8": {
         "reference-name": "Wooden Wall",
-        "name": "Стена"
+        "name": "Деревянная стена"
     },
     "rct2.scenery_wall.wallwdps": {
         "reference-name": "Wooden Post Fence",
-        "name": "Забор"
+        "name": "Забор из деревянных столбов"
     },
     "rct2.scenery_wall.wallwf32": {
         "reference-name": "Waterfall",
@@ -5211,31 +5211,31 @@
     },
     "rct2.scenery_wall.wbr1": {
         "reference-name": "Brick Wall",
-        "name": "Стена"
+        "name": "Кирпичная стена"
     },
     "rct2.scenery_wall.wbr1a": {
         "reference-name": "Brick Wall",
-        "name": "Стена"
+        "name": "Кирпичная стена"
     },
     "rct2.scenery_wall.wbr2": {
         "reference-name": "Stone Wall",
-        "name": "Стена"
+        "name": "Каменная стена"
     },
     "rct2.scenery_wall.wbr2a": {
         "reference-name": "Stone Wall",
-        "name": "Стена"
+        "name": "Каменная стена"
     },
     "rct2.scenery_wall.wbr3": {
         "reference-name": "Stone Wall",
-        "name": "Стена"
+        "name": "Каменная стена"
     },
     "rct2.scenery_wall.wbrg": {
         "reference-name": "Brick Wall",
-        "name": "Стенка"
+        "name": "Кирпичная стена"
     },
     "rct2.scenery_wall.wbw": {
         "reference-name": "Bone Fence",
-        "name": "Забор"
+        "name": "Забор из костей"
     },
     "rct2.scenery_wall.wc1": {
         "reference-name": "Castle Wall",
@@ -5259,11 +5259,11 @@
     },
     "rct2.scenery_wall.wc14": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wc15": {
         "reference-name": "Wall",
-        "name": "Блок"
+        "name": "Стена"
     },
     "rct2.scenery_wall.wc16": {
         "reference-name": "Fence",
@@ -5271,11 +5271,11 @@
     },
     "rct2.scenery_wall.wc17": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct2.scenery_wall.wc18": {
         "reference-name": "Wooden Post Wall",
-        "name": "Деревянная стена"
+        "name": "Забор из деревянных столбов"
     },
     "rct2.scenery_wall.wc2": {
         "reference-name": "Castle Wall",
@@ -5283,7 +5283,7 @@
     },
     "rct2.scenery_wall.wc3": {
         "reference-name": "Roman Column Wall",
-        "name": "Римская стена"
+        "name": "Римская стена-колонна"
     },
     "rct2.scenery_wall.wc4": {
         "reference-name": "Castle Wall",
@@ -5311,11 +5311,11 @@
     },
     "rct2.scenery_wall.wch": {
         "reference-name": "Conifer Hedge",
-        "name": "Изгородь"
+        "name": "Хвойная изгородь"
     },
     "rct2.scenery_wall.wchg": {
         "reference-name": "Conifer Hedge",
-        "name": "Изгородь"
+        "name": "Хвойная изгородь"
     },
     "rct2.scenery_wall.wcw1": {
         "reference-name": "Playing Card Wall",
@@ -5327,31 +5327,31 @@
     },
     "rct2.scenery_wall.wew": {
         "reference-name": "Egyptian Wall",
-        "name": "Стена"
+        "name": "Египетская стена"
     },
     "rct2.scenery_wall.wfw1": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct2.scenery_wall.wfwg": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct2.scenery_wall.wgw2": {
         "reference-name": "Glass Wall",
-        "name": "Стена"
+        "name": "Стеклянная стена"
     },
     "rct2.scenery_wall.whg": {
         "reference-name": "Hedge",
-        "name": "Забор"
+        "name": "Растительная ограда"
     },
     "rct2.scenery_wall.whgg": {
         "reference-name": "Hedge",
-        "name": "Забор"
+        "name": "Растительная ограда"
     },
     "rct2.scenery_wall.wjf": {
         "reference-name": "Jungle Fence",
-        "name": "Забор"
+        "name": "Забор в стиле джунглей"
     },
     "rct2.scenery_wall.wmf": {
         "reference-name": "Mesh Fence",
@@ -5363,11 +5363,11 @@
     },
     "rct2.scenery_wall.wmw": {
         "reference-name": "Martian Wall",
-        "name": "Стена"
+        "name": "Марсианская стена"
     },
     "rct2.scenery_wall.wmww": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct2.scenery_wall.wpf": {
         "reference-name": "Fence",
@@ -5379,23 +5379,23 @@
     },
     "rct2.scenery_wall.wpw1": {
         "reference-name": "Wooden Post Wall",
-        "name": "Деревянная стена"
+        "name": "Стена из деревянных столбов"
     },
     "rct2.scenery_wall.wpw2": {
         "reference-name": "Wooden Post Wall",
-        "name": "Деревянная стена"
+        "name": "Стена из деревянных столбов"
     },
     "rct2.scenery_wall.wpw3": {
         "reference-name": "Wooden Fence",
-        "name": "Забор"
+        "name": "Деревянный забор"
     },
     "rct2.scenery_wall.wrw": {
         "reference-name": "Roman Wall",
-        "name": "Стена"
+        "name": "Стена в римском стиле"
     },
     "rct2.scenery_wall.wrwa": {
         "reference-name": "Roman Wall",
-        "name": "Стена"
+        "name": "Стена в римском стиле"
     },
     "rct2.scenery_wall.wsw": {
         "reference-name": "Railings",
@@ -5415,139 +5415,139 @@
     },
     "rct2.scenery_wall.wwtw": {
         "reference-name": "Tall Wooden Fence",
-        "name": "Высокий забор"
+        "name": "Высокий деревянный забор"
     },
     "rct2.scenery_wall.wwtwa": {
         "reference-name": "Wooden Fence Wall",
-        "name": "Деревянный забор"
+        "name": "Забор из деревянных столбов"
     },
     "rct2.station.abstract": {
         "reference-name": "Abstract",
-        "name": "Abstract"
+        "name": "Абстракция"
     },
     "rct2.station.canvas_tent": {
         "reference-name": "Canvas Tent",
-        "name": "Canvas Tent"
+        "name": "Палатка"
     },
     "rct2.station.castle_brown": {
         "reference-name": "Castle (Brown)",
-        "name": "Castle (Brown)"
+        "name": "Замок (коричневый)"
     },
     "rct2.station.castle_grey": {
         "reference-name": "Castle (Grey)",
-        "name": "Castle (Grey)"
+        "name": "Замок (серый)"
     },
     "rct2.station.classical": {
         "reference-name": "Classical / Roman",
-        "name": "Classical / Roman"
+        "name": "Классика / Рим"
     },
     "rct2.station.jungle": {
         "reference-name": "Jungle",
-        "name": "Jungle"
+        "name": "Джунгли"
     },
     "rct2.station.log": {
         "reference-name": "Log Cabin",
-        "name": "Log Cabin"
+        "name": "Изба"
     },
     "rct2.station.pagoda": {
         "reference-name": "Pagoda",
-        "name": "Pagoda"
+        "name": "Пагода"
     },
     "rct2.station.plain": {
         "reference-name": "Plain",
-        "name": "Plain"
+        "name": "Стандартный"
     },
     "rct2.station.snow": {
         "reference-name": "Snow / Ice",
-        "name": "Snow / Ice"
+        "name": "Снег/лёд"
     },
     "rct2.station.space": {
         "reference-name": "Space",
-        "name": "Space"
+        "name": "Космос"
     },
     "rct2.station.wooden": {
         "reference-name": "Wooden",
-        "name": "Wooden"
+        "name": "Дерево"
     },
     "rct2.terrain_edge.ice": {
         "reference-name": "Ice",
-        "name": "Ice"
+        "name": "Лёд"
     },
     "rct2.terrain_edge.rock": {
         "reference-name": "Rock",
-        "name": "Rock"
+        "name": "Камень"
     },
     "rct2.terrain_edge.wood_black": {
         "reference-name": "Wood (black)",
-        "name": "Wood (black)"
+        "name": "Дерево (чёрное)"
     },
     "rct2.terrain_edge.wood_red": {
         "reference-name": "Wood (red)",
-        "name": "Wood (red)"
+        "name": "Дерево (красное)"
     },
     "rct2.terrain_surface.chequerboard": {
         "reference-name": "Chequerboard",
-        "name": "Chequerboard"
+        "name": "Шахматная доска"
     },
     "rct2.terrain_surface.dirt": {
         "reference-name": "Dirt",
-        "name": "Dirt"
+        "name": "Грязь"
     },
     "rct2.terrain_surface.grass": {
         "reference-name": "Grass",
-        "name": "Grass"
+        "name": "Трава"
     },
     "rct2.terrain_surface.grass_clumps": {
         "reference-name": "Grass Clumps",
-        "name": "Grass Clumps"
+        "name": "Куски травы"
     },
     "rct2.terrain_surface.grid_green": {
         "reference-name": "Grid (Green)",
-        "name": "Grid (Green)"
+        "name": "Сетка (зелёная)"
     },
     "rct2.terrain_surface.grid_purple": {
         "reference-name": "Grid (Purple)",
-        "name": "Grid (Purple)"
+        "name": "Сетка (фиолетовая)"
     },
     "rct2.terrain_surface.grid_red": {
         "reference-name": "Grid (Red)",
-        "name": "Grid (Red)"
+        "name": "Сетка (красная)"
     },
     "rct2.terrain_surface.grid_yellow": {
         "reference-name": "Grid (Yellow)",
-        "name": "Grid (Yellow)"
+        "name": "Сетка (жёлтая)"
     },
     "rct2.terrain_surface.ice": {
         "reference-name": "Ice",
-        "name": "Ice"
+        "name": "Лёд"
     },
     "rct2.terrain_surface.martian": {
         "reference-name": "Martian",
-        "name": "Martian"
+        "name": "Марсианская"
     },
     "rct2.terrain_surface.rock": {
         "reference-name": "Rock",
-        "name": "Rock"
+        "name": "Камень"
     },
     "rct2.terrain_surface.sand": {
         "reference-name": "Sand",
-        "name": "Sand"
+        "name": "Песок"
     },
     "rct2.terrain_surface.sand_brown": {
         "reference-name": "Sand (Brown)",
-        "name": "Sand (Brown)"
+        "name": "Песок (коричневый)"
     },
     "rct2.terrain_surface.sand_red": {
         "reference-name": "Sand (Red)",
-        "name": "Sand (Red)"
+        "name": "Песок (красный)"
     },
     "rct2.water.wtrcyan": {
         "reference-name": "Natural Water",
-        "name": "Простая вода"
+        "name": "Натуральная вода"
     },
     "rct2.water.wtrgreen": {
         "reference-name": "Acid Green Water",
-        "name": "Яд.-зелёная вода"
+        "name": "Кислотно-зелёная вода"
     },
     "rct2.water.wtrgrn": {
         "reference-name": "Green Water",
@@ -5555,19 +5555,19 @@
     },
     "rct2.water.wtrorng": {
         "reference-name": "Orange Water",
-        "name": "Рыжая вода"
+        "name": "Оранжевая вода"
     },
     "rct2dlc.footpath_item.litterpa": {
         "reference-name": "Panda Litter Bin",
-        "name": "Panda Litter Bin"
+        "name": "Мусорка-панда"
     },
     "rct2dlc.ride.zpanda": {
         "reference-name": "Panda Trains",
-        "name": "Panda Trains",
+        "name": "Поезда-панды",
         "reference-description": "Roller coaster trains with cuddly panda cars",
-        "description": "Roller coaster trains with cuddly panda cars",
+        "description": "Поезда для аттракционов с мягкими машинами в форме панд",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 passenger per car"
+        "capacity": "1 пассажир на машину"
     },
     "rct2dlc.scenario_text.panda_world": {
         "reference-name": "Panda World",
@@ -5575,23 +5575,23 @@
         "reference-park_name": "Panda World",
         "park_name": "Panda World",
         "reference-details": "Add more rides and attract more people to this panda-themed park",
-        "details": "Add more rides and attract more people to this panda-themed park"
+        "details": "Добавьте аттракционов и привлеките больше людей в этот панда-парк"
     },
     "rct2dlc.scenery_group.scgpanda": {
         "reference-name": "Panda Theming",
-        "name": "Panda Theming"
+        "name": "Тема \"панда\""
     },
     "rct2dlc.scenery_small.bigpanda": {
         "reference-name": "Giant Panda",
-        "name": "Giant Panda"
+        "name": "Огромная панда"
     },
     "rct2dlc.scenery_small.pandagr": {
         "reference-name": "Bamboo Shoots",
-        "name": "Bamboo Shoots"
+        "name": "Бамбуковый стебель"
     },
     "rct2dlc.water.wtrpink": {
         "reference-name": "Pink Water",
-        "name": "Pink Water"
+        "name": "Розовая вода"
     },
     "rct2tt.footpath_item.firhydrt": {
         "reference-name": "Fire Hydrant",
@@ -5603,11 +5603,11 @@
     },
     "rct2tt.footpath_railings.balustrade": {
         "reference-name": "Balustrade",
-        "name": "Balustrade"
+        "name": "Балюстрада"
     },
     "rct2tt.footpath_railings.circuitboard": {
         "reference-name": "Circuit Board Railings",
-        "name": "Circuit Board Railings"
+        "name": "Перила в стиле компьютерной платы"
     },
     "rct2tt.footpath_railings.circuitboard_invisible": {
         "reference-name": "Sky Walk",
@@ -5615,31 +5615,31 @@
     },
     "rct2tt.footpath_railings.medieval": {
         "reference-name": "Medieval Railings",
-        "name": "Medieval Railings"
+        "name": "Средневековые перила"
     },
     "rct2tt.footpath_railings.pavement": {
         "reference-name": "Iron Railings",
-        "name": "Iron Railings"
+        "name": "Железные перила"
     },
     "rct2tt.footpath_railings.rainbow": {
         "reference-name": "Rainbow Railings",
-        "name": "Rainbow Railings"
+        "name": "Радужные перила"
     },
     "rct2tt.footpath_railings.rocky": {
         "reference-name": "Jungle Railings",
-        "name": "Jungle Railings"
+        "name": "Перила в стиле \"джунгли\""
     },
     "rct2tt.footpath_surface.circuitboard": {
         "reference-name": "Circuit Footpath",
-        "name": "Тропа"
+        "name": "Тропа в стиле компьютерной платы"
     },
     "rct2tt.footpath_surface.medieval": {
         "reference-name": "Wooden Footpath",
-        "name": "Дорожка"
+        "name": "Деревянная тропа"
     },
     "rct2tt.footpath_surface.mosaic": {
         "reference-name": "Mosaic Footpath",
-        "name": "Дорожка"
+        "name": "Тропа в стиле мозайки"
     },
     "rct2tt.footpath_surface.pavement": {
         "reference-name": "Pavement",
@@ -5647,675 +5647,675 @@
     },
     "rct2tt.footpath_surface.queue_circuitboard": {
         "reference-name": "Circuit Queue",
-        "name": "Circuit Queue"
+        "name": "Очередь в стиле компьютерной платы"
     },
     "rct2tt.footpath_surface.queue_pavement": {
         "reference-name": "Pavement Queue",
-        "name": "Pavement Queue"
+        "name": "Тротуар для очереди"
     },
     "rct2tt.footpath_surface.queue_rainbow": {
         "reference-name": "Rainbow Queue",
-        "name": "Rainbow Queue"
+        "name": "Радужная очередь"
     },
     "rct2tt.footpath_surface.rainbow": {
         "reference-name": "Rainbow Footpath",
-        "name": "Дорожка"
+        "name": "Радужная тропа"
     },
     "rct2tt.footpath_surface.rocky": {
         "reference-name": "Rocky Footpath",
-        "name": "Дорожка"
+        "name": "Каменная тропа"
     },
     "rct2tt.park_entrance.1920sent": {
         "reference-name": "Roaring Twenties Park Entrance",
-        "name": "Вход в парк двадцатых годов"
+        "name": "Вход в парк в стиле двадцатых годов"
     },
     "rct2tt.park_entrance.futurent": {
         "reference-name": "Futuristic Park Entrance",
-        "name": "Футуристический вход"
+        "name": "Футуристический вход в парк"
     },
     "rct2tt.park_entrance.gldyrent": {
         "reference-name": "Rock ’n’ Roll Park Entrance",
-        "name": "Вход рок-н-ролл"
+        "name": "Вход в парк в стиле рок-н-ролл"
     },
     "rct2tt.park_entrance.jurasent": {
         "reference-name": "Prehistoric Entrance",
-        "name": "Доисторический вход"
+        "name": "Доисторический вход в парк"
     },
     "rct2tt.park_entrance.medientr": {
         "reference-name": "Dark Age Entrance",
-        "name": "Средневек. вход"
+        "name": "Средневековый вход в парк"
     },
     "rct2tt.park_entrance.mythentr": {
         "reference-name": "Mythological Entrance",
-        "name": "Mythological Entrance"
+        "name": "Мифический вход в парк"
     },
     "rct2tt.ride.1920racr": {
         "reference-name": "1920s Racing Cars",
-        "name": "Машинки 1920гг",
+        "name": "Машинки 1920 годов",
         "reference-description": "1920s race car themed go-karts",
-        "description": "Люди гоняются друг с другом на машинках в стиле 20х",
+        "description": "Гоночные машины в стиле 1920 годов",
         "reference-capacity": "Single-seater",
         "capacity": "Одиночные"
     },
     "rct2tt.ride.1920sand": {
         "reference-name": "Art Deco Food Stall",
-        "name": "Палатка Арт-Деко",
+        "name": "Лавка арт-деко",
         "reference-description": "A stall selling noodles and fresh Lemonade",
-        "description": "Палатка с лапшой и свежим лимонадом."
+        "description": "Лавка, продающая лапшу и свежий лимонад."
     },
     "rct2tt.ride.1960tsrt": {
         "reference-name": "Flower Power T-Shirts",
-        "name": "Рубашки с цветами",
+        "name": "Майки с цветами",
         "reference-description": "Stall selling T-shirts with a flower motif",
-        "description": "Палатка, в которой продаются рубашки."
+        "description": "Лавка, в которой продаются майки с цветными узорами."
     },
     "rct2tt.ride.barnstrm": {
         "reference-name": "Barnstorming Trains",
-        "name": "Гастрольные горки",
+        "name": "Штурмовой поезд",
         "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster, in the shape of double decker aeroplanes",
-        "description": "Кабинки подвешены, горки допускают вращение и резкие падения.",
+        "description": "Перевернутые кабинки для инвертированых импульсных горок в форме самолётов",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 человека в вагоне"
+        "capacity": "4 человека на машину"
     },
     "rct2tt.ride.battrram": {
         "reference-name": "Battering Ram Trains",
-        "name": "Таранные горки",
+        "name": "Таранный поезд",
         "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
-        "description": "Небольшие горки на стальном рельсе со спиральным подъёмом и вагончиками с сидениями в ряд.",
+        "description": "Компактные поезда с сиденьями, идущими в ряд, оформленными под тараны из тёмных веков",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 человек в вагоне"
+        "capacity": "6 человек на машину"
     },
     "rct2tt.ride.blckdeth": {
         "reference-name": "Black Death Trains",
-        "name": "Чёрная Смерть",
+        "name": "Поезда \"чёрная смерть\"",
         "reference-description": "Rat-shaped trains consisting of 2-seater cars where the riders are behind each other",
-        "description": "Кабинки в виде крыс едут по извилистому треку без рельсов и колес.",
+        "description": "Поезда в виде крыс, с двухвестными машинами, где пассажиры сидят друг за другом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 человека в кабинке"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.bmvoctps": {
         "reference-name": "Blob from Outer Space",
-        "name": "Падение из космоса",
+        "name": "Клякса из космоса",
         "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
-        "description": "Вращающаяся наблюдательная кабина, поднимающаяся вверх по башне.",
+        "description": "Вращающаяся наблюдательная кабина, похожая на кляксу из плохого sci-fi фильма",
         "reference-capacity": "20 passengers",
         "capacity": "20 пассажиров"
     },
     "rct2tt.ride.cavmncar": {
         "reference-name": "Caveman Cars",
-        "name": "Пещ. машины",
+        "name": "Пещерные машины",
         "reference-description": "Self-drive go-karts in Stone Age style",
-        "description": "Люди гоняются на стильных машинках",
+        "description": "Машины для картинга в стиле каменного века",
         "reference-capacity": "Single-seater",
         "capacity": "Одиночные"
     },
     "rct2tt.ride.cerberus": {
         "reference-name": "Cerberus Trains",
-        "name": "Горки Цербер",
+        "name": "Поезда \"Цербер\"",
         "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
-        "description": "Сидя в удобном поезде, люди наслаждаются плавными спусками и парением над горами.",
+        "description": "Просторный поест с простой безопасностью на ноги, с машинами в форме многоголовой собаки из Подземелья",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 человека в вагоне"
+        "capacity": "4 человека на машину"
     },
     "rct2tt.ride.cyclopsx": {
         "reference-name": "Cyclops Dodgems",
-        "name": "Циклоп",
+        "name": "Машины-циклопы",
         "reference-description": "Riders drive the Eye of a Giant Cyclops",
-        "description": "Люди управляют машинками в форме глаз.",
+        "description": "Машина в форме глаза гигантского циклопа",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел. в машине"
+        "capacity": "1 человек на машину"
     },
     "rct2tt.ride.dinoeggs": {
         "reference-name": "Dinosaur Egg Ride",
-        "name": "Динозавр",
+        "name": "Яйцо динозавра",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
-        "description": "Люди крутятся вокруг двигающегося динозавра.",
+        "description": "Тематические парные сиденья, вращающиеся вокруг движущейся мамы-динозавра",
         "reference-capacity": "18 passengers",
-        "capacity": "18 человек"
+        "capacity": "18 пассажиров"
     },
     "rct2tt.ride.dragnfly": {
         "reference-name": "Dragonfly Cars",
-        "name": "Стрекоза",
+        "name": "Машины-стрекозы",
         "reference-description": "Dragonfly-shaped cars which swing from the rail above",
-        "description": "Люди едут по рельсу в подвешенных, раскачивающихся кабинках.",
+        "description": "Машины в форме стрекозы, подвешенные на рельсе сверху",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 чел. в кабинке"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.figtknit": {
         "reference-name": "Fighting Knights Dodgems",
-        "name": "Рыцари",
+        "name": "Рыцарские машины",
         "reference-description": "Riders joust on horse-themed dodgems",
-        "description": "Люди катаются в машинках в виде лошадей",
+        "description": "Машины для автодрома в виде лошадей, на которых люди играют в дуэль",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел."
+        "capacity": "1 человек на машину"
     },
     "rct2tt.ride.flalmace": {
         "reference-name": "Mace Ride",
         "name": "Булавы",
         "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
-        "description": "Люди сидят в кресле, вращающемся вокруг шеста.",
+        "description": "Стилизованное кресло, прикрепленное к моторизированному вращающемуся рычагу",
         "reference-capacity": "1 guest per chair",
-        "capacity": "1 чел. в кресле"
+        "capacity": "1 гость на кресло"
     },
     "rct2tt.ride.flwrpowr": {
         "reference-name": "Flower Power Dodgems",
-        "name": "Цветок",
+        "name": "Цветочная сила",
         "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
-        "description": "Небольшие цветочные шлюпки с моторчиками управляются пассажирами",
+        "description": "Свободно-управляемые машины на воздушной подушке в форме цветов",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 человек"
+        "capacity": "1 пассажир на машину"
     },
     "rct2tt.ride.flygboat": {
         "reference-name": "Flying Boats",
-        "name": "Парящая лодка",
+        "name": "Летающие лодки",
         "reference-description": "Roller coaster cars shaped like flying boats",
-        "description": "Кабинка в виде летающей лодки катится по стремительному треку, иногда падая в воду",
+        "description": "Машины для аттракционов в форме летающих лодок",
         "reference-capacity": "6 passengers per boat",
-        "capacity": "6 пасс. в лодке"
+        "capacity": "6 пассажиров на лодку"
     },
     "rct2tt.ride.funhouse": {
         "reference-name": "Fun House",
-        "name": "Домик",
+        "name": "Весёлый дом",
         "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
-        "description": "Здание с анимированными стенами и полом дезориентирует людей",
+        "description": "Здание с анимированными стенами и полом, которые дезориентируют гуляющих там людей",
         "reference-capacity": "5 guests",
-        "capacity": "5 чел."
+        "capacity": "5 гостей"
     },
     "rct2tt.ride.ganstrcr": {
         "reference-name": "Gangster Cars",
-        "name": "Горки гангстеров",
+        "name": "Бандитские машины",
         "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
-        "description": "Машинки в стиле 1920х проезжают по головокружительной трассе.",
+        "description": "Машины в стиле 1920х, используещие линейные индукци",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел. в кабине"
+        "capacity": "4 пассажиров на машину"
     },
     "rct2tt.ride.gintspdr": {
         "reference-name": "B-Movie Giant Spider Ride",
-        "name": "Паук",
+        "name": "Огромный паук",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
-        "description": "Люди катаются парами вокруг большого паука.",
+        "description": "Парные сиденья, вращающиеся вокруг огромного паука, как в плохом фильме",
         "reference-capacity": "18 passengers",
-        "capacity": "18 человек"
+        "capacity": "18 пассажиров"
     },
     "rct2tt.ride.halofmrs": {
         "reference-name": "Hall of Mirrors",
-        "name": "Холл зеркал",
+        "name": "Комната смеха",
         "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
-        "description": "Здание с кривыми зеркалами, искажающими изображение",
+        "description": "Здание с кривыми зеркалами, искажающими отражения гостей",
         "reference-capacity": "5 guests",
-        "capacity": "5 чел."
+        "capacity": "5 гостей"
     },
     "rct2tt.ride.harpiesx": {
         "reference-name": "Harpies Trains",
-        "name": "Гарпии",
+        "name": "Поезда-гарпии",
         "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
-        "description": "Люди едут в лежачем положении по извилистой трассе с переворотами.",
+        "description": "Поезда в форме мифологических птицеподобных существ, держащие своих пассажиров в особых ограничителях в лежачем положении на спине или лицом в землю",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел в кабинке"
+        "capacity": "4 пассажира на машину"
     },
     "rct2tt.ride.hotrodxx": {
         "reference-name": "Hot Rod Trains",
-        "name": "Горки-Хотрод",
+        "name": "Поезда \"Hot Rod\"",
         "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
-        "description": "После ускоряющего толчка поезд разгоняется по вертикальному треку и опускается вниз на станцию.",
+        "description": "Поезда, запускаемые воздушным толчком, в форме машин \"Hot Rod\"",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 чел. в кабинке"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.hoverbke": {
         "reference-name": "Hover Bikes",
         "name": "Ховербайки",
         "reference-description": "Futuristic bike-shaped single vehicles",
-        "description": "Люди сидят в футуристических байках и едут по монорельсу",
+        "description": "Футуристические машины в форме мотоциклов",
         "reference-capacity": "2 riders per vehicle",
-        "capacity": "2 чел. в машине"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.hovercar": {
         "reference-name": "Hover Cars",
         "name": "Ховеркары",
         "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
-        "description": "С помощью мощных магнитов создаётся иллюзия парящих машин",
+        "description": "Иллюзия футуристических летающих машин, созданная через технологию магнитной левитации",
         "reference-capacity": "1 passenger per car",
-        "capacity": "1 пассажир"
+        "capacity": "1 пассажир на машину"
     },
     "rct2tt.ride.hovrbord": {
         "reference-name": "Hoverboards",
         "name": "Ховерборд",
         "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
-        "description": "Люди едут на фантастических раскачивающихся досках",
+        "description": "Футуристический ховерборд, свободно раскачивающийся из стороны в сторону на резких поворотах",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 чел. в кабинке"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.jetpackx": {
         "reference-name": "Jet Pack Booster",
-        "name": "Бустер",
+        "name": "Реактивный рюкзак",
         "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
-        "description": "Люди сидят в машине, запускаемой по вертикальному треку",
+        "description": "Большая машина в форме реактивного рюкзака для реверсивных аттракицонов",
         "reference-capacity": "8 passengers per car",
-        "capacity": "8 человек"
+        "capacity": "8 пассажиров на машину"
     },
     "rct2tt.ride.jetplane": {
         "reference-name": "Jet Plane Cars",
-        "name": "Горки-Самолет",
+        "name": "Реактивный самолёт",
         "reference-description": "Roller coaster cars in the shape of jet planes",
-        "description": "Небольшие горки с отдельными кабинками и плавными перепадами.",
+        "description": "Поезда в форме самолётов",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел. в вагоне"
+        "capacity": "4 пассажира на машину"
     },
     "rct2tt.ride.jousting": {
         "reference-name": "Jousting Knights",
-        "name": "Рыцарские горки",
+        "name": "Сражающиеся рыцари",
         "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
-        "description": "Люди сидят на лошадях и едут по монорельсу.",
+        "description": "Машины в форме лошадей с рыцарем",
         "reference-capacity": "2 riders per vehicle",
-        "capacity": "2 чел. на лошадь"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.medisoup": {
         "reference-name": "Witches Brew Soup",
-        "name": "Супчик",
+        "name": "Ведьмин суп",
         "reference-description": "A stall selling a thick broth-style soup",
-        "description": "Палатка, где продают суп."
+        "description": "Лавка, продающая крепкий бульон"
     },
     "rct2tt.ride.mgr2": {
         "reference-name": "Double Deck Carousel",
-        "name": "Двойная Карусель",
+        "name": "Двухэтажная карусель",
         "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
-        "description": "Классическая карусель с деревянными лошадками",
+        "description": "Традиционная закрытая двухэтажная карусель с деревянными лошадками",
         "reference-capacity": "32 passengers",
-        "capacity": "32 человека"
+        "capacity": "32 пассажира"
     },
     "rct2tt.ride.microbus": {
         "reference-name": "MicroBus Ride",
-        "name": "Микробус",
+        "name": "Микро-автобус",
         "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
-        "description": "Люди смотрят кино внутри подвижной кабины, крутящейся на гидравл. рычаге",
+        "description": "Симулятор движения в стиле Цветочной Силы, вращающийся на гидравлическом рычаге и показывающий пассажирам фильм",
         "reference-capacity": "8 passengers",
-        "capacity": "8 человек"
+        "capacity": "8 пассажирво"
     },
     "rct2tt.ride.mktstal1": {
         "reference-name": "Toffee Apple Market Stall",
-        "name": "Палатка с конфетами",
+        "name": "Ларёк с конфетными яблоками",
         "reference-description": "A themed stall selling sticky toffee apples",
-        "description": "Палатка, где продают ириски."
+        "description": "Стилизованный ларёк, продающий яблоки покрытые сладостями"
     },
     "rct2tt.ride.mktstal2": {
         "reference-name": "Lemonade Market Stall",
-        "name": "Палатка с Лимонадом",
+        "name": "Ларёк с лимонадом",
         "reference-description": "A themed stall selling old style, fresh lemonade.",
-        "description": "Палатка, продающая лимонад."
+        "description": "Стилизованный ларёк, продающий свежий лимонад"
     },
     "rct2tt.ride.moonjuce": {
         "reference-name": "Moon Juice",
-        "name": "Лунный Сок",
+        "name": "Лунная газировка",
         "reference-description": "A stall selling the latest soft drinks",
-        "description": "Палатка с напитками"
+        "description": "Ларёк, продающий новомодные газированные напитки"
     },
     "rct2tt.ride.mythosea": {
         "reference-name": "Neptune’s Seafood Stall",
-        "name": "Палатка Нептуна",
+        "name": "Лавка Нептуна",
         "reference-description": "A stall selling Neptune’s salty treats",
-        "description": "Палатка с угощениями от Нептуна"
+        "description": "Лавка, продающая солёные угощения от Нептуна"
     },
     "rct2tt.ride.neptunex": {
         "reference-name": "Neptune Ride",
         "name": "Нептун",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
-        "description": "Люди катаются парами вокруг статуи Нептуна.",
+        "description": "Стилизованные сиденья, вращающиеся вокруг движущейся статуи Нептуна",
         "reference-capacity": "18 passengers",
-        "capacity": "18 человек"
+        "capacity": "18 пассажиров"
     },
     "rct2tt.ride.oakbarel": {
         "reference-name": "Oak Barrels",
-        "name": "Дубовая Бочка",
+        "name": "Дубовые бочки",
         "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
-        "description": "Дубовые Бочки плывут по широкому каналу, попадая в водопады и стремнины",
+        "description": "Дубовые бочки, вращающиеся и плескающиеся плывя по речным порогам",
         "reference-capacity": "8 passengers per boat",
-        "capacity": "8 чел. в лодке"
+        "capacity": "8 пассажиров на лодку"
     },
     "rct2tt.ride.pegasusx": {
         "reference-name": "Pegasus Cars",
-        "name": "Пегас",
+        "name": "Машины \"Пегас\"",
         "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
-        "description": "Машинки в форме Пегасов едут по треку",
+        "description": "Электрические машины в форме пегасов",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 чел. в кабине"
+        "capacity": "2 человека на машину"
     },
     "rct2tt.ride.polchase": {
         "reference-name": "Police Car Trains",
-        "name": "Горки-Погоня",
+        "name": "Полицейские машины",
         "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
-        "description": "Круговые горки. Люди едут сидя.",
+        "description": "Поезда с безопасностью для ног, способные к езде по вертикальным петлям и стилизованные под полицейские машины",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел. в кабине"
+        "capacity": "4 пассажира на машину"
     },
     "rct2tt.ride.policecr": {
         "reference-name": "Police Cars",
-        "name": "Полиция",
+        "name": "Полицейские машины",
         "reference-description": "1920s-themed police cars run on wooden tracks, turning around on special reversing sections",
-        "description": "Полицейские машины 1920х едут по деревянному треку",
+        "description": "Полицейские машины стиля 1920х на деревянном треке, разворачивающиеся в обратном направлении на особых секциях",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 чел в машине"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2tt.ride.pterodac": {
         "reference-name": "Pterodactyl Trains",
-        "name": "Птеродактиль",
+        "name": "Поезда-птеродактили",
         "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
-        "description": "Люди сидят в удобных креслах под треком и несутся по головокружительной трассе",
+        "description": "Комфортные сиденья подвешенные снизу трека, дающие восхитительное ощущения доисторического полёта",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел в кабинке"
+        "capacity": "4 пассажира на машину"
     },
     "rct2tt.ride.raptorxx": {
         "reference-name": "Racing Raptors",
-        "name": "Раптор Рейсерс",
+        "name": "Гонки рапторов",
         "reference-description": "Separate raptor-shaped vehicles",
-        "description": "Люди сидят на машинках-Рапторах и едут по монорельсу",
+        "description": "Машины в форме рапторов",
         "reference-capacity": "2 riders per vehicle",
-        "capacity": "2 чел. в машине"
+        "capacity": "2 пассажира на машину"
     },
     "rct2tt.ride.rivrstyx": {
         "reference-name": "River Styx boats",
-        "name": "Стикс",
+        "name": "Лодки реки Стикс",
         "reference-description": "Boats with an Underworld theme, built for flat river tracks",
-        "description": "Лодки, спокойно плывущие по речке.",
+        "description": "Лодки, стилизованные под тему Подземелья, предназначенные для плоских речных трековы",
         "reference-capacity": "4 passengers per raft",
-        "capacity": "4 чел. в рафте"
+        "capacity": "4 пассажира на плот"
     },
     "rct2tt.ride.schoolbs": {
         "reference-name": "School Bus Trams",
-        "name": "Автобус",
+        "name": "Школьный автобус-трамвай",
         "reference-description": "Miniature trams themed to look like North American school buses",
-        "description": "Старый жёлтый автобус",
+        "description": "Миниатюрные трамваи, стилизованные под американские школьные автобусы",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 человек"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2tt.ride.seaplane": {
         "reference-name": "Suspended Seaplane Cars",
-        "name": "Акваплан",
+        "name": "Подвесные гидросамолеты",
         "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
-        "description": "Подвесные раскачивающиеся вагончики",
+        "description": "Подвесные поезда, состоящие из машин в форме гидросамолётов, свободно раскачивающиеся на резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел. в кабинке"
+        "capacity": "4 пассажира на машину"
     },
     "rct2tt.ride.softoyst": {
         "reference-name": "Soft Toy Stall",
-        "name": "Игрушки",
+        "name": "Ларёк с игрушками",
         "reference-description": "A stall selling a cute soft toy dinosaur",
-        "description": "Палатка с динозавриками"
+        "description": "Лавка, продающая милых и мягких плюшевых динозавров"
     },
     "rct2tt.ride.spokprsn": {
         "reference-name": "Haunted Jail House",
-        "name": "Тюрьма",
+        "name": "Призрачная тюрьма",
         "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
-        "description": "Здание с опасными преступниками, которые пугают добропорядочных прохожих.",
+        "description": "Здание с манекенами заключенных, пугающих проходящих через него людей",
         "reference-capacity": "16 guests",
-        "capacity": "16 чел."
+        "capacity": "16 гостей"
     },
     "rct2tt.ride.stamphrd": {
         "reference-name": "Stampeding Herd Trains",
-        "name": "Стадные горки",
+        "name": "Стадо",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
-        "description": "Круговые горки с вагончиками в виде динозавров.",
+        "description": "Поезда для езды стоя, стилизированные под стадо динозавров",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 чел. в вагоне"
     },
     "rct2tt.ride.telepter": {
         "reference-name": "Teleporter Cabin",
-        "name": "Лифт",
+        "name": "Телепорт",
         "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
-        "description": "Люди переезжают вверх-вниз с уровня на уровень.",
+        "description": "Футуристическая кабина для лифта, дающая иллюзию телепортации",
         "reference-capacity": "16 passengers",
-        "capacity": "16 человек"
+        "capacity": "16 пассажиров"
     },
     "rct2tt.ride.timemach": {
         "reference-name": "Time Machine",
-        "name": "Время",
+        "name": "Машина времени",
         "reference-description": "Guests sit in a specially designed sphere, and experience the illusion of time travel",
-        "description": "Люди сидят в специальной сфере и путешествуют во времени.",
+        "description": "Сфера с особым дизайном, симулирующим путешествие во времени",
         "reference-capacity": "1 guest per time machine",
-        "capacity": "1 человек"
+        "capacity": "1 гость на машину времени"
     },
     "rct2tt.ride.tommygun": {
         "reference-name": "Tommy Gun Ride",
-        "name": "Томми-Ган",
+        "name": "Томми-ган",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
-        "description": "Люди сидят попарно и вращаются вокруг большого автомата.",
+        "description": "Стилизованные парные сиденья, вращающиеся вокруг большой реплики автомата Томми-ган",
         "reference-capacity": "18 passengers",
-        "capacity": "18 человек"
+        "capacity": "18 пассажиров"
     },
     "rct2tt.ride.trebucht": {
         "reference-name": "Trebuchet Ride",
         "name": "Катапульта",
         "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
-        "description": "Люди качаются в подвешенных вагончиках в стиле осадных орудий.",
+        "description": "Вагон в стиле оружия из тёмных веков, подвешенный на двух больших рычагах",
         "reference-capacity": "8 passengers",
-        "capacity": "8 человек"
+        "capacity": "8 пассажиров"
     },
     "rct2tt.ride.tricatop": {
         "reference-name": "Triceratops Dodgems",
-        "name": "Трицерапторы",
+        "name": "Машинки-трицератопсы",
         "reference-description": "Riders lock horns with each other in triceratops dodgems",
-        "description": "Люди катаются в маленьких электромобильчиках.",
+        "description": "Бодающиеся машинки в стиле трицератопса",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел. в машине"
+        "capacity": "1 человек на машину"
     },
     "rct2tt.ride.trilobte": {
         "reference-name": "Trilobite Boats",
-        "name": "Трилобиты",
+        "name": "Лодки-трилобиты",
         "reference-description": "Trilobite-shaped roller coaster cars",
-        "description": "Лодки в форме трилобитов несутся по головокружительному треку с падениями в воду.",
+        "description": "Машины в форме трилобитов",
         "reference-capacity": "6 passengers per boat",
-        "capacity": "6 чел в лодке"
+        "capacity": "6 пассажиров на лодку"
     },
     "rct2tt.ride.valkyrie": {
         "reference-name": "Valkyries Trains",
-        "name": "Валькирии",
+        "name": "Поезда-Валькирии",
         "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
-        "description": "Широкие вагончики спускаются по отвесному треку с участками свободного падения",
+        "description": "Поезда в стиле Валкирий с экстра-широкими машинами, построенные для вертикального падения",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 человек"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2tt.ride.zeplelin": {
         "reference-name": "Airship Themed Monorail Trains",
-        "name": "Монорельсовый поезд",
+        "name": "Поезда-дирижабли",
         "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
-        "description": "Вместительный монорельсовый поезд с вагончиками.",
+        "description": "Вместитильные поезда для монорельсов, с гладкими передними и задними машинами",
         "reference-capacity": "8 passengers per car",
-        "capacity": "8 чел. в вагоне"
+        "capacity": "8 пассажиров на машину"
     },
     "rct2tt.scenario_text.alcatraz": {
         "reference-name": "Alcatraz",
-        "name": "Алкатрас",
+        "name": "Alcatraz",
         "reference-park_name": "Alcatraz",
-        "park_name": "Алкатрас",
+        "park_name": "Alcatraz",
         "reference-details": "The infamous Prison Island - whose population once swelled with bootleggers and racketeers - is now up for sale. You’ve decided to convert it into a top tourist attraction, and money is no object",
-        "details": "Безымянный тюремный остров, чье население раньше составляли контрабандисты и рэкетиры, сейчас выставлен на продажу. Вы решили превратить его в туристическую достопримечательность."
+        "details": "Печально известный Тюремный Остров, переполненный преступниками, был выставлен на продажу. Вы решили превратить его в туристический рай, и деньги для вас - не проблема"
     },
     "rct2tt.scenario_text.animatronic_antics": {
         "reference-name": "Animatronic Antics",
-        "name": "Студия Абсурда",
+        "name": "Animatronic Antics",
         "reference-park_name": "Animatronic Antics",
-        "park_name": "Студия Абсурда",
+        "park_name": "Animatronic Antics",
         "reference-details": "You have been given the task of running and improving an existing theme park, which has been built on an old film set. Build a tribute to the pioneering stop-motion animators who first brought mythical creatures to life on the silver screen.",
-        "details": "Вам поставили задачу улучшить существующий тематический парк, построенный на месте старой киностудии. Сделайте акцент на мифических существах, которых оживили пионеры анимации."
+        "details": "Вам поставили задачу улучшить существующий парк, построенный на месте старой киносъёмки. Создайте монумент пионерам покадровых анимаций, которые впервые оживили мифических существ на экранах кинотеатров."
     },
     "rct2tt.scenario_text.cliffside_castle": {
         "reference-name": "Cliffside Castle",
-        "name": "Замок на Скале",
+        "name": "Cliffside Castle",
         "reference-park_name": "Cliffside Castle",
-        "park_name": "Замок на Скале",
+        "park_name": "Cliffside Castle",
         "reference-details": "Local members of the battle re-enactment society are rather serious about their hobby. They’ve entrusted you with the job of constructing a Dark Age theme park on the grounds of Cliffside Castle.",
-        "details": "Члены местного исторического клуба серьезно увлечены своим хобби. Они уговаривают вас построить Парк развлечений на средневековую тематику на территории Старинного Замка."
+        "details": "Участники местного сообщества реконструкции исторических битв настолько увлечены своим хобби, что доверили вам строительство парка на средневековую тему на территории замка Cliffside Castle."
     },
     "rct2tt.scenario_text.coastersaurus": {
         "reference-name": "Coastersaurus",
-        "name": "Брегозавр",
+        "name": "Coastersaurus",
         "reference-park_name": "Coastersaurus",
-        "park_name": "Брегозавр",
+        "park_name": "Coastersaurus",
         "reference-details": "You’ve been given the task of constructing a Jurassic era theme park. To optimize your visitors’ access to the exotic plant and animal exhibits, you will need to build rides going over and into the valley.",
-        "details": "Вам поставили задачу построить парк развлечений Юрского Периода. Для оптимизации доступа посетителей к экзотическим растениям и животным вам придется соорудить аттракционы, катающие людей по территории."
+        "details": "Вам поставили задачу построить парк развлечений на тему юрского периода. Для оптимизации доступа посетителей к экзотическим растениям и животным вам придется соорудить аттракционы над и под землёй этой долины."
     },
     "rct2tt.scenario_text.crater_carnage": {
         "reference-name": "Crater Carnage",
-        "name": "Кратер",
+        "name": "Crater Carnage",
         "reference-park_name": "Crater Carnage",
-        "park_name": "Кратер",
+        "park_name": "Crater Carnage",
         "reference-details": "You own a dusty old meteor crater. In the true entrepreneurial spirit, you’ve decided to construct an asteroid theme park and convert your seemingly worthless land into a sizeable fortune.",
-        "details": "Вы владеете старым метеоритным кратером. И решаете превратить дешевую бесполезную землю в процветающее предприятие, построив тематический парк."
+        "details": "Вы владеете старым метеоритным кратером. В духе истинного предпренимателя, вы решаете построить парк в космическом стиле, превратив эту \"никчёмную\" землю в огромный капитал."
     },
     "rct2tt.scenario_text.extraterrestrial_extravaganza": {
         "reference-name": "Extraterrestrial Extravaganza",
-        "name": "Фантастическая Феерия",
+        "name": "Extraterrestrial Extravaganza",
         "reference-park_name": "Extraterrestrial Extravaganza",
-        "park_name": "Фантастическая Феерия",
+        "park_name": "Extraterrestrial Extravaganza",
         "reference-details": "Life has been discovered on a distant planet Build an alien theme park to cash in on the unprecedented wave of interest.",
-        "details": "На отдаленной планете была открыта жизнь. Постройте инопланетный тематический парк, чтобы заработать на сенсации."
+        "details": "На отдаленной планете была открыта жизнь. Постройте инопланетный парк, чтобы заработать на сенсации."
     },
     "rct2tt.scenario_text.gemini_city": {
         "reference-name": "Gemini City",
-        "name": "Геминеи",
+        "name": "Gemini City",
         "reference-park_name": "Gemini City",
-        "park_name": "Геминеи",
+        "park_name": "Gemini City",
         "reference-details": "Show off your inventive, utopian vision of the future - come up with a futuristic park design that incorporates state-of-the-art attractions.",
-        "details": "Покажите свое видение будущего - постройте тематический парк футуристической направленности с потрясающими аттракционами."
+        "details": "Покажите свое видение утопии будущего - придумайте футуристический дизайн для парка, включающий новейшие аттракционы."
     },
     "rct2tt.scenario_text.metropolis": {
         "reference-name": "Metropolis",
-        "name": "Метрополис",
+        "name": "Metropolis",
         "reference-park_name": "Metropolis",
-        "park_name": "Метрополис",
+        "park_name": "Metropolis",
         "reference-details": "You own an empty lot near the low-rise part of town. To squeeze the most out of your urban property, build a skyscraper theme park inspired by the soaring art deco architecture of the twenties.",
-        "details": "Вы владеете пустырём в одном из районов города. Чтобы выжать из своей земли максимум, постройте парк развлечений в виде небоскрёба в духе двадцатых годов."
+        "details": "Вы владеете пустырём в низко-застроеном районе города. Чтобы выжать из своей земли максимум, постройте парк-небоскрёб в духе двадцатых годов."
     },
     "rct2tt.scenario_text.mythological_madness": {
         "reference-name": "Mythological Madness",
-        "name": "Мифическое Безумство",
+        "name": "Mythological Madness",
         "reference-park_name": "Mythological Madness",
-        "park_name": "Мифическое Безумство",
+        "park_name": "Mythological Madness",
         "reference-details": "You own an island of particular archaeological value. You’ve decided to fund its preservation by constructing a theme park based on the area’s rich Mythological heritage.",
-        "details": "Вы владеете островом, имеющим особое археологическое значение. И решили построить парк развлечений, основанный на богатом мифологическом наследии острова."
+        "details": "Вы владеете островом, имеющим особое археологическое значение. Вы решили обеспечить его безопасность средствами, полученными от парка на тему мифов этого острова."
     },
     "rct2tt.scenario_text.rock_n_roll_revival": {
         "reference-name": "Rock ‘n’ Roll Revival",
-        "name": "Рок-н-Ролл Жив",
+        "name": "Rock ‘n’ Roll Revival",
         "reference-park_name": "Rock ‘n’ Roll Revival",
-        "park_name": "Рок-н-Ролл Жив",
+        "park_name": "Rock ‘n’ Roll Revival",
         "reference-details": "This aging theme park has seen better days. Help the owner give it a retro rock ‘n’ roll makeover and turn the place into a successful venue.",
-        "details": "Этот чудесный парк видел и лучшие дни. Помогите его владельцу улучшить дела и превратить парк в процветающее предприятие."
+        "details": "Этот стареющий парк видел лучшие дни. Помогите его владельцу с ретро-стилизацией рок-н-ролл и превратите его в прибыльную локацию."
     },
     "rct2tt.scenario_text.rocky_rambles": {
         "reference-name": "Rocky Rambles",
-        "name": "Деревня",
+        "name": "Rocky Rambles",
         "reference-park_name": "Rocky Rambles",
-        "park_name": "Деревня",
+        "park_name": "Rocky Rambles",
         "reference-details": "To thwart the highway developers and preserve the mysterious ancient stone circles, you will need to construct a Stone Age theme park and turn a profit. However, attracting visitors may pose a challenge, as the terrain is a tad inhospitable.",
-        "details": "Чтобы помешать дорожным строителям и сохранить таинственные каменные круги, вам придётся построить тематический парк каменного века и получить с него прибыль. Однако, местность вам досталась не особо гостеприимная."
+        "details": "Чтобы помешать дорожным строителям и сохранить таинственные каменные круги, вам придётся построить парк в стиле каменного века и получить с него прибыль. Однако, привлекать гостей будет сложно: местность вам досталась не особо гостеприимная."
     },
     "rct2tt.scenario_text.schneider_shores": {
         "reference-name": "Schneider Shores",
-        "name": "Кубок Шнайдера",
+        "name": "Schneider Shores",
         "reference-park_name": "Schneider Shores",
-        "park_name": "Кубок Шнайдера",
+        "park_name": "Schneider Shores",
         "reference-details": "The 75th anniversary of your grandfather’s Schneider Cup victory is coming up in a few years. You’re going to honour his achievement by building a theme park based on the famous seaplane race.",
-        "details": "Через несколько лет наступает 75я годовщина завоевания вашим дедушкой Кубка Шнайдера. Вы собираетесь отметить его достижение, построив тематический парк, посвящённый гонкам на гидросамолетах."
+        "details": "Через несколько лет наступает 75я годовщина завоевания вашим дедушкой Кубка Шнайдера. Вы собираетесь отметить его достижение, построив парк, посвящённый этой знаменитой гонке на гидросамолетах."
     },
     "rct2tt.scenario_text.sherwood_forest": {
         "reference-name": "Sherwood Forest",
-        "name": "Шервудский Лес",
+        "name": "Sherwood Forest",
         "reference-park_name": "Sherwood Forest",
-        "park_name": "Шервудский Лес",
+        "park_name": "Sherwood Forest",
         "reference-details": "To liberate wealth from the rich and distribute it to the needy, you and your Merry Men have decided to build a theme park in Sherwood Forest.",
         "details": "Чтобы отобрать деньги у богатых и отдать их беднякам, вы и ваши друзья-разбойники решили построить парк развлечений в Шервудском Лесу."
     },
     "rct2tt.scenario_text.woodstock": {
         "reference-name": "Woodstock",
-        "name": "Цветник",
+        "name": "Woodstock",
         "reference-park_name": "Woodstock",
-        "park_name": "Цветник",
+        "park_name": "Woodstock",
         "reference-details": "A large annual music festival takes place on your land. Build a hip theme park to keep the free-spirited audience entertained.",
-        "details": "На вашей земле проводится ежегодный музыкальный фестиваль. Постройте людям парк развлечений в духе музыки и свободы."
+        "details": "На вашей земле пройдет ежегодный музыкальный фестиваль. Постройте модный парк, чтобы развлечь этот контингент со свободным духом."
     },
     "rct2tt.scenery_group.scg1920s": {
         "reference-name": "Roaring Twenties Theming",
-        "name": "Двадцатые Годы"
+        "name": "Тема двадцатых"
     },
     "rct2tt.scenery_group.scg1920w": {
         "reference-name": "Roaring Twenties Wall Sets",
-        "name": "Детали стен 20х годов"
+        "name": "Стены двадцатых"
     },
     "rct2tt.scenery_group.scg1960s": {
         "reference-name": "Rock ’n’ Roll Theming",
-        "name": "Рок-н-Ролл"
+        "name": "Тема \"Рок-н-Ролл\""
     },
     "rct2tt.scenery_group.scgfutur": {
         "reference-name": "Future Theming",
-        "name": "Будущее"
+        "name": "Тема \"Будущее\""
     },
     "rct2tt.scenery_group.scgjurra": {
         "reference-name": "Prehistoric Theming",
-        "name": "Доисторический Мир"
+        "name": "Доисторическая тема"
     },
     "rct2tt.scenery_group.scgmediv": {
         "reference-name": "Dark Age Theming",
-        "name": "Средневековье"
+        "name": "Средневековая тема"
     },
     "rct2tt.scenery_group.scgmytho": {
         "reference-name": "Mythological Theming",
-        "name": "Мифология"
+        "name": "Мифологическая тема"
     },
     "rct2tt.scenery_large.1950scar": {
         "reference-name": "1950s Car",
-        "name": "Авто 1950"
+        "name": "Машина 1950 года"
     },
     "rct2tt.scenery_large.4x4diner": {
         "reference-name": "Period Diner",
-        "name": "Закусочная"
+        "name": "Старая забегаловка"
     },
     "rct2tt.scenery_large.4x4gmant": {
         "reference-name": "Giant Mangrove Tree",
-        "name": "Манговое дерево"
+        "name": "Огромное манговое дерево"
     },
     "rct2tt.scenery_large.4x4stnhn": {
         "reference-name": "Stone Age Temple",
-        "name": "Древний храм"
+        "name": "Храм каменных веков"
     },
     "rct2tt.scenery_large.4x4trpit": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_large.4x4volca": {
         "reference-name": "Volcano with small trees",
-        "name": "Вулкан с деревьями"
+        "name": "Вулкан с маленькими деревьями"
     },
     "rct2tt.scenery_large.alencrsh": {
         "reference-name": "UFO Crash Site",
-        "name": "Упавший НЛО"
+        "name": "Место падения НЛО"
     },
     "rct2tt.scenery_large.alnstr08": {
         "reference-name": "Alien Structure Large",
-        "name": "Космическая структура"
+        "name": "Пришельская структура (большая)"
     },
     "rct2tt.scenery_large.alnstr09": {
         "reference-name": "Alien Structure Large",
-        "name": "Космическая структура"
+        "name": "Пришельская структура (большая)"
     },
     "rct2tt.scenery_large.alnstr10": {
         "reference-name": "Alien Structure Large",
-        "name": "Космическая структура"
+        "name": "Пришельская структура (большая)"
     },
     "rct2tt.scenery_large.alnstr11": {
         "reference-name": "Alien Skylight Large",
-        "name": "Инопланетная крыша"
+        "name": "Пришельский проектор (большой)"
     },
     "rct2tt.scenery_large.artdec25": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Угол Арт-Деко с окнами"
+        "name": "Угол арт-деко с окнами"
     },
     "rct2tt.scenery_large.artdec26": {
         "reference-name": "Art Deco Corner with Railings",
-        "name": "Угол Арт-Деко с оградой"
+        "name": "Угол арт-деко с оградой"
     },
     "rct2tt.scenery_large.artdec27": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Верхний угол Арт-Деко"
+        "name": "Верхняя секция угла арт-деко"
     },
     "rct2tt.scenery_large.ashnymph": {
         "reference-name": "Ash Tree with Nymphs",
@@ -6327,7 +6327,7 @@
     },
     "rct2tt.scenery_large.bigdrums": {
         "reference-name": "Giant Drum Kit",
-        "name": "Барабан"
+        "name": "Огромный барабан"
     },
     "rct2tt.scenery_large.caventra": {
         "reference-name": "Cave Entrance",
@@ -6335,159 +6335,159 @@
     },
     "rct2tt.scenery_large.corns2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Деталь дворца"
+        "name": "Угол римского дворца"
     },
     "rct2tt.scenery_large.corvs2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Деталь дворца"
+        "name": "Угол римского дворца"
     },
     "rct2tt.scenery_large.cratr2x2": {
         "reference-name": "Small Meteor Crater",
-        "name": "Кратер"
+        "name": "Малый метеоритный кратер"
     },
     "rct2tt.scenery_large.cratr4x4": {
         "reference-name": "Large Meteor Crater",
-        "name": "Кратер"
+        "name": "Большой метеоритный кратер"
     },
     "rct2tt.scenery_large.crsss2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Деталь дворца"
+        "name": "Перекрёсток римского дворца"
     },
     "rct2tt.scenery_large.crsvs2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Деталь дворца"
+        "name": "Перекрёсток римского дворца"
     },
     "rct2tt.scenery_large.cyclopss": {
         "reference-name": "Cyclops Statue",
-        "name": "Циклоп"
+        "name": "Статуя циклопа"
     },
     "rct2tt.scenery_large.feastabl": {
         "reference-name": "Feast Table",
-        "name": "Стол"
+        "name": "Стол для пира"
     },
     "rct2tt.scenery_large.footprnt": {
         "reference-name": "Giant Dinosaur Footprint",
-        "name": "След динозавра"
+        "name": "Огромный след динозавра"
     },
     "rct2tt.scenery_large.forbidft": {
         "reference-name": "Forbidden Fruit Tree",
-        "name": "Запретный плод"
+        "name": "Дерево запретных плодов"
     },
     "rct2tt.scenery_large.futsky20": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_large.futsky22": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_large.futsky24": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_large.futsky25": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_large.futsky26": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_large.futsky28": {
         "reference-name": "Sandstone Walkway T-Junction",
-        "name": "Деталь небоскрёба"
+        "name": "Т-перекрёсток на тропе из песчаника"
     },
     "rct2tt.scenery_large.futsky30": {
         "reference-name": "Sandstone Walkway Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Угол на тропе из песчаника"
     },
     "rct2tt.scenery_large.futsky31": {
         "reference-name": "Sandstone Walkway Cross Section",
-        "name": "Деталь небоскрёба"
+        "name": "Перекрёсток на тропе из песчаника"
     },
     "rct2tt.scenery_large.futsky32": {
         "reference-name": "Sandstone Walkway End Section",
-        "name": "Деталь небоскрёба"
+        "name": "Конечная секция тропы из песчаника"
     },
     "rct2tt.scenery_large.gbeetlex": {
         "reference-name": "1950s Car",
-        "name": "Машина"
+        "name": "Машина 1950 года"
     },
     "rct2tt.scenery_large.ghotrod1": {
         "reference-name": "Hot Rod Car",
-        "name": "Машина"
+        "name": "Машина \"Hot Rod\""
     },
     "rct2tt.scenery_large.ghotrod2": {
         "reference-name": "Hot Rod Car",
-        "name": "Машина"
+        "name": "Машина \"Hot Rod\""
     },
     "rct2tt.scenery_large.gschlbus": {
         "reference-name": "School Bus",
-        "name": "Автобус"
+        "name": "Школьный автобус"
     },
     "rct2tt.scenery_large.hadesxxx": {
         "reference-name": "Hades Statue",
-        "name": "Гадес"
+        "name": "Статуя Аида"
     },
     "rct2tt.scenery_large.histfix1": {
         "reference-name": "Alien Historical Structures",
-        "name": "Инопланетные конструкции"
+        "name": "Историческая структура пришельцев"
     },
     "rct2tt.scenery_large.histfix2": {
         "reference-name": "Alien Historical Structures",
-        "name": "Инопланетные конструкции"
+        "name": "Историческая структура пришельцев"
     },
     "rct2tt.scenery_large.hodshut1": {
         "reference-name": "Robin Hood’s Hut",
-        "name": "Хижина Робина"
+        "name": "Хижина Робин-Гуда"
     },
     "rct2tt.scenery_large.hodshut2": {
         "reference-name": "Robin Hood’s Hut",
-        "name": "Хижина Робина"
+        "name": "Хижина Робин-Гуда"
     },
     "rct2tt.scenery_large.hrbwal07": {
         "reference-name": "Harbour Wall Corner Piece",
-        "name": "Деталь гавани"
+        "name": "Угол стены гавани"
     },
     "rct2tt.scenery_large.hrbwal08": {
         "reference-name": "Harbour Wall Corner Piece",
-        "name": "Деталь гавани"
+        "name": "Угол стены гавани"
     },
     "rct2tt.scenery_large.hrbwal09": {
         "reference-name": "Harbour Wall with Dock",
-        "name": "Деталь гавани"
+        "name": "Стена гавани с доком"
     },
     "rct2tt.scenery_large.hrbwal11": {
         "reference-name": "Harbour Dock",
-        "name": "Док"
+        "name": "Док (гавань)"
     },
     "rct2tt.scenery_large.jailxx17": {
         "reference-name": "Prison Door",
-        "name": "Дверь"
+        "name": "Тюремная дверь"
     },
     "rct2tt.scenery_large.jailxx18": {
         "reference-name": "Prison Water Tower",
-        "name": "Водяная башня"
+        "name": "Тюремная водяная башня"
     },
     "rct2tt.scenery_large.jetplan1": {
         "reference-name": "Jet Aeroplane",
-        "name": "Самолёт"
+        "name": "Реактивный самолёт"
     },
     "rct2tt.scenery_large.jetplan2": {
         "reference-name": "Jet Aeroplane",
-        "name": "Самолёт"
+        "name": "Реактивный самолёт"
     },
     "rct2tt.scenery_large.jetplan3": {
         "reference-name": "Jet Aeroplane",
-        "name": "Самолёт"
+        "name": "Реактивный самолёт"
     },
     "rct2tt.scenery_large.majoroak": {
         "reference-name": "Large Oak",
-        "name": "Дуб"
+        "name": "Большой дуб"
     },
     "rct2tt.scenery_large.mcastl01": {
         "reference-name": "Castle Inverted Corner",
-        "name": "Деталь замка"
+        "name": "Перевёрнутый угол замка"
     },
     "rct2tt.scenery_large.mcastl11": {
         "reference-name": "Castle Portcullis",
@@ -6499,107 +6499,107 @@
     },
     "rct2tt.scenery_large.mcastl13": {
         "reference-name": "Castle Tower Corner Piece",
-        "name": "Деталь башни замка"
+        "name": "Угол башни замка"
     },
     "rct2tt.scenery_large.mcastl14": {
         "reference-name": "Castle Tower Corner Piece",
-        "name": "Деталь башни замка"
+        "name": "Угол башни замка"
     },
     "rct2tt.scenery_large.mcastl15": {
         "reference-name": "Castle Tower Cross Piece",
-        "name": "Деталь башни замка"
+        "name": "Угол башни замка"
     },
     "rct2tt.scenery_large.mcastl16": {
         "reference-name": "Castle Tower Straight Piece",
-        "name": "Прямая деталь башни замка"
+        "name": "Прямая часть башни замка"
     },
     "rct2tt.scenery_large.mcastl17": {
         "reference-name": "Castle Tower T Piece",
-        "name": "Деталь башни замка"
+        "name": "Т-перекрёсток башни замка"
     },
     "rct2tt.scenery_large.mcastl18": {
         "reference-name": "Castle Tower T Piece",
-        "name": "Деталь башни замка"
+        "name": "Т-перекрёсток башни замка"
     },
     "rct2tt.scenery_large.melmtree": {
         "reference-name": "Large Elm Tree",
-        "name": "Большой Вяз"
+        "name": "Большой вяз"
     },
     "rct2tt.scenery_large.metoan01": {
         "reference-name": "Meteor Crater Corner",
-        "name": "Деталь кратера"
+        "name": "Угол метеоритного кратера"
     },
     "rct2tt.scenery_large.metoan02": {
         "reference-name": "Meteor Crater Inverted Corner",
-        "name": "Деталь кратера"
+        "name": "Перевёрнутый угол метеоритного кратера"
     },
     "rct2tt.scenery_large.oldnyk20": {
         "reference-name": "New York Roof Piece",
-        "name": "Крыша Нью-Йорка"
+        "name": "Крыша в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk21": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk22": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk23": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk24": {
         "reference-name": "New York Inverted Corner Roof",
-        "name": "Угол крыши Нью-Йорка"
+        "name": "Перевёрнутый угол крыши Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk25": {
         "reference-name": "New York Roof Piece",
-        "name": "Крыша Нью-Йорка"
+        "name": "Крыша в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk26": {
         "reference-name": "New York Entrance",
-        "name": "Вход Нью-Йорка"
+        "name": "Вход в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk27": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk28": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk29": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk30": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.oldnyk32": {
         "reference-name": "New York Roof Piece",
-        "name": "Крыша Нью-Йорка"
+        "name": "Крыша в стиле Нью-Йорка"
     },
     "rct2tt.scenery_large.peasthut": {
         "reference-name": "Peasant Hut",
-        "name": "Хижина"
+        "name": "Фермерская изба"
     },
     "rct2tt.scenery_large.peramob1": {
         "reference-name": "Period Automobile",
-        "name": "Автомобиль"
+        "name": "Старый автомобиль"
     },
     "rct2tt.scenery_large.peramob2": {
         "reference-name": "Period Automobile",
-        "name": "Автомобиль"
+        "name": "Старый автомобиль"
     },
     "rct2tt.scenery_large.perdtk01": {
         "reference-name": "Period Truck",
-        "name": "Грузовик"
+        "name": "Старый грузовик"
     },
     "rct2tt.scenery_large.perdtk02": {
         "reference-name": "Period Truck",
-        "name": "Грузовик"
+        "name": "Старый грузовик"
     },
     "rct2tt.scenery_large.ploughxx": {
         "reference-name": "Plough",
@@ -6607,79 +6607,79 @@
     },
     "rct2tt.scenery_large.prdyacht": {
         "reference-name": "Period Sailing Yacht",
-        "name": "Яхта"
+        "name": "Старая яхта"
     },
     "rct2tt.scenery_large.psntwl26": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Средневековая деталь крыши"
+        "name": "Часть средневеково-деревенской крыши"
     },
     "rct2tt.scenery_large.psntwl27": {
         "reference-name": "Dark Age Village Corner Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Угол средневеково-деревенской крыши"
     },
     "rct2tt.scenery_large.psntwl28": {
         "reference-name": "Dark Age Village Inverted Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Перевернутый угол средневеково-деревенской крыши"
     },
     "rct2tt.scenery_large.rdmet2x2": {
         "reference-name": "Small Red Meteor Crater",
-        "name": "Маленький кратер"
+        "name": "Маленький красный метеоритный кратер"
     },
     "rct2tt.scenery_large.rdmet4x4": {
         "reference-name": "Large Red Meteor Crater",
-        "name": "Большой кратер"
+        "name": "Большой красный метеоритный кратер"
     },
     "rct2tt.scenery_large.rdmeto01": {
         "reference-name": "Red Meteor Crater Corner",
-        "name": "Часть кратера"
+        "name": "Угол красного метеоритного кратера"
     },
     "rct2tt.scenery_large.rdmeto02": {
         "reference-name": "Red Meteor Crater Corner",
-        "name": "Часть кратера"
+        "name": "Угол красного метеоритного кратера"
     },
     "rct2tt.scenery_large.robncamp": {
         "reference-name": "Robin Hood’s Camp",
-        "name": "Лагерь Робина"
+        "name": "Лагерь Робин-Гуда"
     },
     "rct2tt.scenery_large.romnc2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Деталь дворца"
+        "name": "Угол римского дворца"
     },
     "rct2tt.scenery_large.romne2x1": {
         "reference-name": "Roman Palace End Piece",
-        "name": "Деталь дворца"
+        "name": "Конец римского дворца"
     },
     "rct2tt.scenery_large.romnm2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Деталь дворца"
+        "name": "Перекрёсток римского дворца"
     },
     "rct2tt.scenery_large.romns2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Деталь дворца"
+        "name": "Прямая часть римского дворца"
     },
     "rct2tt.scenery_large.romvc2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Деталь дворца"
+        "name": "Угол римского дворца"
     },
     "rct2tt.scenery_large.romve2x1": {
         "reference-name": "Roman Palace End Piece",
-        "name": "Деталь дворца"
+        "name": "Конец римского дворца"
     },
     "rct2tt.scenery_large.romvm2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Деталь дворца"
+        "name": "Перекрёсток римского дворца"
     },
     "rct2tt.scenery_large.romvs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Деталь дворца"
+        "name": "Прямая часть римского дворца"
     },
     "rct2tt.scenery_large.schnpit2": {
         "reference-name": "Seaplane Pits",
-        "name": "Ангар"
+        "name": "Ямы для гидросамолётов"
     },
     "rct2tt.scenery_large.schnpits": {
         "reference-name": "Seaplane Pits",
-        "name": "Ангар"
+        "name": "Ямы для гидросамолётов"
     },
     "rct2tt.scenery_large.schntent": {
         "reference-name": "Marquee",
@@ -6699,91 +6699,91 @@
     },
     "rct2tt.scenery_large.strgs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Деталь дворца"
+        "name": "Прямая часть римского дворца"
     },
     "rct2tt.scenery_large.strvs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Деталь дворца"
+        "name": "Прямая часть римского дворца"
     },
     "rct2tt.scenery_large.tavernxx": {
         "reference-name": "Dark Ages Tavern",
-        "name": "Таверна"
+        "name": "Средневековая таверна"
     },
     "rct2tt.scenery_large.travlr01": {
         "reference-name": "Traveller Van",
-        "name": "Фургон"
+        "name": "Фургон путешественника"
     },
     "rct2tt.scenery_large.travlr02": {
         "reference-name": "Microbus",
-        "name": "Микробус"
+        "name": "Микро-автобус"
     },
     "rct2tt.scenery_small.1920slmp": {
         "reference-name": "Period Street Lamps",
-        "name": "Уличные фонари"
+        "name": "Старые фонари"
     },
     "rct2tt.scenery_small.alenplt1": {
         "reference-name": "Alien Plant",
-        "name": "Растение"
+        "name": "Пришельское растение"
     },
     "rct2tt.scenery_small.alenplt2": {
         "reference-name": "Alien Plant",
-        "name": "Растение"
+        "name": "Пришельское растение"
     },
     "rct2tt.scenery_small.alentre1": {
         "reference-name": "Alien Tree",
-        "name": "Дерево"
+        "name": "Пришельское дерево"
     },
     "rct2tt.scenery_small.alentre2": {
         "reference-name": "Alien Tree",
-        "name": "Дерево"
+        "name": "Пришельское дерево"
     },
     "rct2tt.scenery_small.allseeye": {
         "reference-name": "Animatronic All Seeing Eye",
-        "name": "Всевидящее Око"
+        "name": "Движущееся всевидящее око"
     },
     "rct2tt.scenery_small.alnstr01": {
         "reference-name": "Alien Structure Small",
-        "name": "Космическая структура"
+        "name": "Маленькая пришельская структура"
     },
     "rct2tt.scenery_small.alnstr02": {
         "reference-name": "Alien Structure Small",
-        "name": "Космическая структура"
+        "name": "Маленькая пришельская структура"
     },
     "rct2tt.scenery_small.alnstr03": {
         "reference-name": "Alien Structure Small",
-        "name": "Космическая структура"
+        "name": "Маленькая пришельская структура"
     },
     "rct2tt.scenery_small.alnstr04": {
         "reference-name": "Alien Skylight Small",
-        "name": "Инопланетная крыша"
+        "name": "Маленький пришельский проектор"
     },
     "rct2tt.scenery_small.alnstr05": {
         "reference-name": "Alien Tower Bottom",
-        "name": "Основание башни"
+        "name": "Основание пришельской башни"
     },
     "rct2tt.scenery_small.alnstr06": {
         "reference-name": "Alien Tower Middle",
-        "name": "Середина башни"
+        "name": "Середина пришельской башни"
     },
     "rct2tt.scenery_small.alnstr07": {
         "reference-name": "Alien Tower Top",
-        "name": "Верх башни"
+        "name": "Верх пришельской башни"
     },
     "rct2tt.scenery_small.argonau1": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Аргонавт"
+        "name": "Движущийся аргонавт"
     },
     "rct2tt.scenery_small.argonau2": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Аргонавт"
+        "name": "Движущийся аргонавт"
     },
     "rct2tt.scenery_small.argonau3": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Аргонавт"
+        "name": "Движущийся аргонавт"
     },
     "rct2tt.scenery_small.armrbody": {
         "reference-name": "Magical Armour",
-        "name": "Волшебные латы"
+        "name": "Волшебная броня"
     },
     "rct2tt.scenery_small.armrhelm": {
         "reference-name": "Magical Helmet",
@@ -6799,139 +6799,139 @@
     },
     "rct2tt.scenery_small.artdec01": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec02": {
         "reference-name": "Art Deco Inverted Corner Section",
-        "name": "Угловая секция Арт-Деко"
+        "name": "Перевёрнутый угол арт-деко"
     },
     "rct2tt.scenery_small.artdec03": {
         "reference-name": "Art Deco Wall with Door",
-        "name": "Стена Арт-Деко с дверью"
+        "name": "Стена арт-деко с дверью"
     },
     "rct2tt.scenery_small.artdec04": {
         "reference-name": "Art Deco Wall with Windows",
-        "name": "Стена Арт-Деко с окнами"
+        "name": "Стена арт-деко с окнами"
     },
     "rct2tt.scenery_small.artdec05": {
         "reference-name": "Art Deco Wall with Windows",
-        "name": "Стена Арт-Деко с окнами"
+        "name": "Стена арт-деко с окнами"
     },
     "rct2tt.scenery_small.artdec06": {
         "reference-name": "Art Deco Top Section",
-        "name": "Секция Арт-Деко"
+        "name": "Верхняя секция арт-деко"
     },
     "rct2tt.scenery_small.artdec07": {
         "reference-name": "Art Deco Corner Section",
-        "name": "Угловая секция Арт-Деко"
+        "name": "Угол арт-деко"
     },
     "rct2tt.scenery_small.artdec08": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Верхний угол Арт-Деко"
+        "name": "Верхний угол арт-деко"
     },
     "rct2tt.scenery_small.artdec09": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec10": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec11": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Угол Арт-Деко с окнами"
+        "name": "Угол арт-деко с окнами"
     },
     "rct2tt.scenery_small.artdec12": {
         "reference-name": "Art Deco Corner with Railings",
-        "name": "Угол Арт-Деко с оградой"
+        "name": "Угол арт-деко с оградой"
     },
     "rct2tt.scenery_small.artdec13": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Верхний угол Арт-Деко"
+        "name": "Верхний угол арт-деко"
     },
     "rct2tt.scenery_small.artdec14": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Угол Арт-Деко с окнами"
+        "name": "Угол арт-деко с окнами"
     },
     "rct2tt.scenery_small.artdec15": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec16": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec17": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec18": {
         "reference-name": "Art Deco Top Section",
-        "name": "Секция Арт-Деко"
+        "name": "Верхняя секция арт-деко"
     },
     "rct2tt.scenery_small.artdec19": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec20": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Стена Арт-Деко"
+        "name": "Стена арт-деко"
     },
     "rct2tt.scenery_small.artdec21": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Стена Арт-Деко с оградой"
+        "name": "Стена арт-деко с оградой"
     },
     "rct2tt.scenery_small.artdec22": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Стена Арт-Деко с оградой"
+        "name": "Стена арт-деко с оградой"
     },
     "rct2tt.scenery_small.artdec23": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Стена Арт-Деко с оградой"
+        "name": "Стена арт-деко с оградой"
     },
     "rct2tt.scenery_small.artdec24": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Стена Арт-Деко с оградой"
+        "name": "Стена арт-деко с оградой"
     },
     "rct2tt.scenery_small.artdec28": {
         "reference-name": "Art Deco Roof Section",
-        "name": "Крыша Арт-Деко"
+        "name": "Крыша арт-деко"
     },
     "rct2tt.scenery_small.artdec29": {
         "reference-name": "Art Deco Inverted Corner Section",
-        "name": "Угловая секция Арт-Деко"
+        "name": "Перевёрнутый угол арт-деко"
     },
     "rct2tt.scenery_small.astrongt": {
         "reference-name": "Animatronic Astronaut",
-        "name": "Астронавт"
+        "name": "Движущийся астронавт"
     },
     "rct2tt.scenery_small.bigbassx": {
         "reference-name": "Giant Bass Guitar",
-        "name": "Бас-гитара"
+        "name": "Огромная бас-гитара"
     },
     "rct2tt.scenery_small.biggutar": {
         "reference-name": "Giant Guitar",
-        "name": "Гитара"
+        "name": "Огромная гитара"
     },
     "rct2tt.scenery_small.bkrgang1": {
         "reference-name": "Biker",
-        "name": "Мачо"
+        "name": "Байкер"
     },
     "rct2tt.scenery_small.bolpot01": {
         "reference-name": "Boiling Pot",
-        "name": "Котёл"
+        "name": "Кипящий котёл"
     },
     "rct2tt.scenery_small.cagdstat": {
         "reference-name": "Animatronic Eagle on Cage",
-        "name": "Орёл на клетке"
+        "name": "Движущийся орёл на клетке"
     },
     "rct2tt.scenery_small.cavemenx": {
         "reference-name": "Animatronic Caveman lighting Fire",
-        "name": "Человек, зажигающий огонь"
+        "name": "Движущийся пещерный человек, зажигающий огонь"
     },
     "rct2tt.scenery_small.chanmaid": {
         "reference-name": "Animatronic Chained Maiden",
-        "name": "Девушка"
+        "name": "Движущаяся оцеплённая дева"
     },
     "rct2tt.scenery_small.chprbke1": {
         "reference-name": "Motorcycle",
@@ -6943,95 +6943,95 @@
     },
     "rct2tt.scenery_small.clnsmen1": {
         "reference-name": "Animatronic Clansman",
-        "name": "Человек"
+        "name": "Движущийся человек из древнего клана"
     },
     "rct2tt.scenery_small.compeyex": {
         "reference-name": "Super Computer Monitor",
-        "name": "Монитор компьютера"
+        "name": "Монитор суперкомпьютера"
     },
     "rct2tt.scenery_small.cookspit": {
         "reference-name": "Animal cooking on Spit",
-        "name": "Вертел"
+        "name": "Мясо на вертеле"
     },
     "rct2tt.scenery_small.dinsign1": {
         "reference-name": "Neon Diner Sign",
-        "name": "Вывеска"
+        "name": "Неоновая вывеска для кафе"
     },
     "rct2tt.scenery_small.dinsign2": {
         "reference-name": "Neon Diner Sign",
-        "name": "Вывеска"
+        "name": "Неоновая вывеска для кафе"
     },
     "rct2tt.scenery_small.dinsign3": {
         "reference-name": "Neon Diner Sign",
-        "name": "Вывеска"
+        "name": "Неоновая вывеска для кафе"
     },
     "rct2tt.scenery_small.dinsign4": {
         "reference-name": "Neon Diner Sign",
-        "name": "Вывеска"
+        "name": "Неоновая вывеска для кафе"
     },
     "rct2tt.scenery_small.dkfight1": {
         "reference-name": "Animatronic Knight",
-        "name": "Рыцарь"
+        "name": "Движущийся рыцарь"
     },
     "rct2tt.scenery_small.dkfight2": {
         "reference-name": "Animatronic Knight",
-        "name": "Рыцарь"
+        "name": "Движущийся рыцарь"
     },
     "rct2tt.scenery_small.drgnattk": {
         "reference-name": "Dragon Attacking",
-        "name": "Дракон"
+        "name": "Нападающий дракон"
     },
     "rct2tt.scenery_small.elecfen1": {
         "reference-name": "Electric Fence Corner Piece",
-        "name": "Деталь ограды"
+        "name": "Угол электрозабора"
     },
     "rct2tt.scenery_small.elecfen2": {
         "reference-name": "Electric Fence",
-        "name": "Ограда"
+        "name": "Электрозабор"
     },
     "rct2tt.scenery_small.elecfen3": {
         "reference-name": "Electric Fence with Light",
-        "name": "Деталь ограды"
+        "name": "Электрозабор с лампой"
     },
     "rct2tt.scenery_small.elecfen4": {
         "reference-name": "Electric Fence Broken",
-        "name": "Сломанный забор"
+        "name": "Сломанный электрозабор"
     },
     "rct2tt.scenery_small.elecfen5": {
         "reference-name": "Electric Fence Inverted Corner Piece",
-        "name": "Деталь ограды"
+        "name": "Перевёрнутый угол электрозабора"
     },
     "rct2tt.scenery_small.evalien1": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся злой пришелец"
     },
     "rct2tt.scenery_small.evalien2": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся злой пришелец"
     },
     "rct2tt.scenery_small.evalien3": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся злой пришелец"
     },
     "rct2tt.scenery_small.fircanon": {
         "reference-name": "Animatronic Firing Cannon",
-        "name": "Пушка"
+        "name": "Двигающаяся пушка"
     },
     "rct2tt.scenery_small.firemanx": {
         "reference-name": "Animatronic Fireman",
-        "name": "Пожарный"
+        "name": "Движущийся пожарный"
     },
     "rct2tt.scenery_small.fltsign1": {
         "reference-name": "Anti-Gravity LCD Billboard",
-        "name": "LCD-табло"
+        "name": "Антигравитационное LCD-табло"
     },
     "rct2tt.scenery_small.fltsign2": {
         "reference-name": "Anti-Gravity LCD Billboard",
-        "name": "LCD-табло"
+        "name": "Антигравитационное LCD-табло"
     },
     "rct2tt.scenery_small.frbeacon": {
         "reference-name": "Fiery Beacon",
-        "name": "Маяк"
+        "name": "Огненный маяк"
     },
     "rct2tt.scenery_small.furobot1": {
         "reference-name": "Robot",
@@ -7043,179 +7043,179 @@
     },
     "rct2tt.scenery_small.futsky01": {
         "reference-name": "Sandstone Skyscraper Walkway",
-        "name": "Деталь небоскрёба"
+        "name": "Тропа для небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky02": {
         "reference-name": "Sandstone Skyscraper Filler",
-        "name": "Деталь небоскрёба"
+        "name": "Наполнитель для небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky03": {
         "reference-name": "Sandstone Skyscraper Bottom Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky04": {
         "reference-name": "Sandstone Skyscraper Curved Slope Top",
-        "name": "Деталь небоскрёба"
+        "name": "Наклонная крыша небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky05": {
         "reference-name": "Sandstone Skyscraper Corner Top",
-        "name": "Деталь небоскрёба"
+        "name": "Верхний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky06": {
         "reference-name": "Sandstone Skyscraper Mid Curved Slope",
-        "name": "Деталь небоскрёба"
+        "name": "Средний наклон небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky07": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Деталь небоскрёба"
+        "name": "Средняя стена небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky08": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Деталь небоскрёба"
+        "name": "Средняя стена небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky09": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Деталь небоскрёба"
+        "name": "Средняя стена небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky10": {
         "reference-name": "Sandstone Skyscraper Bottom Slope Base",
-        "name": "Деталь небоскрёба"
+        "name": "Наклонное основание небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky11": {
         "reference-name": "Sandstone Skyscraper Mid Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Средний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky12": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Деталь небоскрёба"
+        "name": "Средняя стена небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky13": {
         "reference-name": "Sandstone Skyscraper Roof Spire",
-        "name": "Деталь небоскрёба"
+        "name": "Шпиль небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky14": {
         "reference-name": "Sandstone Skyscraper Roof Spire",
-        "name": "Деталь небоскрёба"
+        "name": "Шпиль небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky15": {
         "reference-name": "Sandstone Skyscraper Docking Bay",
-        "name": "Деталь небоскрёба"
+        "name": "Док небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky16": {
         "reference-name": "Sandstone Skyscraper Mid Slope Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Наклонный средний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky17": {
         "reference-name": "Sandstone Skyscraper Filler",
-        "name": "Деталь небоскрёба"
+        "name": "Наполнитель небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky18": {
         "reference-name": "Sandstone Skyscraper Doorway",
-        "name": "Деталь небоскрёба"
+        "name": "Дверь в небоскрёб из песчаника"
     },
     "rct2tt.scenery_small.futsky19": {
         "reference-name": "Sandstone Skyscraper Bottom Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky21": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Деталь небоскрёба"
+        "name": "Средняя стена небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky23": {
         "reference-name": "Sandstone Skyscraper Inverted Corner Top",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый верхний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky29": {
         "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
-        "name": "Деталь небоскрёба"
+        "name": "Нижний наклон небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky33": {
         "reference-name": "Sandstone Skyscraper Walkway",
-        "name": "Деталь небоскрёба"
+        "name": "Тропа небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky34": {
         "reference-name": "Sandstone Skyscraper Roof",
-        "name": "Крыша небоскрёба"
+        "name": "Крыша небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky35": {
         "reference-name": "Sandstone Skyscraper Mid Curved Slope",
-        "name": "Деталь небоскрёба"
+        "name": "Средний наклон небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky36": {
         "reference-name": "Obsidian Skyscraper Door Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Дверь небоскрёба из обсидиана"
     },
     "rct2tt.scenery_small.futsky37": {
         "reference-name": "Obsidian Skyscraper Shallow Slope Corner",
-        "name": "Угол небоскрёба"
+        "name": "Узкий наклонный угол небоскрёба из обсидиана"
     },
     "rct2tt.scenery_small.futsky38": {
         "reference-name": "Obsidian Skyscraper Shallow Sloped Wall",
-        "name": "Деталь стены небоскрёба"
+        "name": "Узкая наклонная стена небоскрёба из обсидиана"
     },
     "rct2tt.scenery_small.futsky39": {
         "reference-name": "Obsidian Skyscraper Shallow Slope Corner",
-        "name": "Угол небоскрёба"
+        "name": "Узкий наклонный угол небоскрёба из обсидиана"
     },
     "rct2tt.scenery_small.futsky40": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Деталь стены небоскрёба"
+        "name": "Стена небоскрёба из обсидиана с крутым наклоном"
     },
     "rct2tt.scenery_small.futsky41": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Деталь стены небоскрёба"
+        "name": "Стена небоскрёба из обсидиана с крутым наклоном"
     },
     "rct2tt.scenery_small.futsky42": {
         "reference-name": "Sandstone Skyscraper Curved Slope Top",
-        "name": "Деталь крыши небоскрёба"
+        "name": "Верхний наклон небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky44": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Деталь стены небоскрёба"
+        "name": "Стена небоскрёба из обсидиана с крутым наклоном"
     },
     "rct2tt.scenery_small.futsky46": {
         "reference-name": "Obsidian Skyscraper Steep Slope Corner",
-        "name": "Угол небоскрёба"
+        "name": "Угол небоскрёба из обсидиана с крутым наклоном"
     },
     "rct2tt.scenery_small.futsky47": {
         "reference-name": "Obsidian Skyscraper Wall",
-        "name": "Стена небоскрёба"
+        "name": "Стена небоскрёба из обсидиана"
     },
     "rct2tt.scenery_small.futsky48": {
         "reference-name": "Obsidian Skyscraper Wall with Window",
-        "name": "Стена небоскрёба с окном"
+        "name": "Стена небоскрёба из обсидиана с окном"
     },
     "rct2tt.scenery_small.futsky52": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Деталь небоскрёба"
+        "name": "Перевёрнутый нижний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky53": {
         "reference-name": "Sandstone Skyscraper Mid Corner",
-        "name": "Угол небоскрёба"
+        "name": "Средний угол небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.futsky54": {
         "reference-name": "Obsidian Skyscraper Roof Piece",
-        "name": "Деталь крыши небоскрёба"
+        "name": "Крыша небоскрёба из песчаника"
     },
     "rct2tt.scenery_small.fwrprdc1": {
         "reference-name": "Groovy Dancer",
-        "name": "Танцор"
+        "name": "Стильный танцор"
     },
     "rct2tt.scenery_small.gangster": {
         "reference-name": "Animatronic Gangster",
-        "name": "Гангстер"
+        "name": "Движущийся бандит"
     },
     "rct2tt.scenery_small.gdalien1": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся добрый пришелец"
     },
     "rct2tt.scenery_small.gdalien2": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся добрый пришелец"
     },
     "rct2tt.scenery_small.gdalien3": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Инопланетянин"
+        "name": "Движущийся добрый пришелец"
     },
     "rct2tt.scenery_small.geyserxx": {
         "reference-name": "Geysers",
@@ -7223,11 +7223,11 @@
     },
     "rct2tt.scenery_small.ggntocto": {
         "reference-name": "B-Movie Giant Octopus",
-        "name": "Осьминог"
+        "name": "Огромный осьминог из плохого фильма"
     },
     "rct2tt.scenery_small.ggntspid": {
         "reference-name": "B-Movie Giant Spider",
-        "name": "Паук"
+        "name": "Огромный паук из плохого фильма"
     },
     "rct2tt.scenery_small.gldchest": {
         "reference-name": "Treasure Chest",
@@ -7239,11 +7239,11 @@
     },
     "rct2tt.scenery_small.gscorpo2": {
         "reference-name": "Animatronic attacking Scorpion",
-        "name": "Скорпион"
+        "name": "Движущийся нападающий скорпион"
     },
     "rct2tt.scenery_small.gscorpon": {
         "reference-name": "Animatronic attacking Scorpion",
-        "name": "Скорпион"
+        "name": "Движущийся нападающий скорпион"
     },
     "rct2tt.scenery_small.guyqwifx": {
         "reference-name": "Singer with Quiff",
@@ -7251,135 +7251,135 @@
     },
     "rct2tt.scenery_small.haybails": {
         "reference-name": "Hay Bale",
-        "name": "Тюк"
+        "name": "Стог сена"
     },
     "rct2tt.scenery_small.hevbth01": {
         "reference-name": "Heavenly Bath Pool",
-        "name": "Деталь бассейна"
+        "name": "Бассейн \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth02": {
         "reference-name": "Heavenly Bath Pool Corner",
-        "name": "Деталь бассейна"
+        "name": "Угол бассейна \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth03": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Фонтан"
+        "name": "Фонтан \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth04": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Деталь бассейна"
+        "name": "Фонтан \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth05": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Арка"
+        "name": "Арка \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth06": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Арка"
+        "name": "Арка \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth07": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Деталь бассейна"
+        "name": "\"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth08": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Деталь бассейна"
+        "name": "Лестница \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth09": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Деталь бассейна"
+        "name": "Лестница \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth10": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Деталь бассейна"
+        "name": "Архитектура \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth11": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Деталь бассейна"
+        "name": "Архитектура \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth12": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Деталь бассейна"
+        "name": "Архитектура \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth13": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Деталь бассейна"
+        "name": "Архитектура \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth14": {
         "reference-name": "Heavenly Bath Window",
-        "name": "Деталь бассейна"
+        "name": "Окно \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth15": {
         "reference-name": "Heavenly Bath Floor",
-        "name": "Деталь бассейна"
+        "name": "Пол \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth16": {
         "reference-name": "Heavenly Bath Pool Steps",
-        "name": "Лестница"
+        "name": "Лестница в бассейн \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevbth17": {
         "reference-name": "Heavenly Bath Pool Edge",
-        "name": "Деталь бассейна"
+        "name": "Край бассейна \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevrof01": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Деталь бассейна"
+        "name": "Крыша \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevrof02": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Деталь крыши"
+        "name": "Крыша \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevrof03": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Деталь крыши"
+        "name": "Крыша \"Райская ванна\""
     },
     "rct2tt.scenery_small.hevrof04": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Деталь крыши"
+        "name": "Крыша \"Райская ванна\""
     },
     "rct2tt.scenery_small.horsecrt": {
         "reference-name": "Horse",
-        "name": "Конь"
+        "name": "Лошадь"
     },
     "rct2tt.scenery_small.hovrcar1": {
         "reference-name": "Hovercar on Stand",
-        "name": "Ховеркар"
+        "name": "Ховеркар на стенде"
     },
     "rct2tt.scenery_small.hovrcar2": {
         "reference-name": "Hovercar on Stand",
-        "name": "Ховеркар"
+        "name": "Ховеркар на стенде"
     },
     "rct2tt.scenery_small.hovrcar3": {
         "reference-name": "Hovercar Flying",
-        "name": "Ховеркар"
+        "name": "Летающий ховеркар"
     },
     "rct2tt.scenery_small.hovrcar4": {
         "reference-name": "Hovercar Flying",
-        "name": "Ховеркар"
+        "name": "Летающий ховеркар"
     },
     "rct2tt.scenery_small.hrbwal01": {
         "reference-name": "Harbour Wall",
-        "name": "Деталь"
+        "name": "Стена гавани"
     },
     "rct2tt.scenery_small.hrbwal02": {
         "reference-name": "Harbour Wall with Fishing Gear",
-        "name": "Деталь гавани"
+        "name": "Стена гавани со снастями для рыбалки"
     },
     "rct2tt.scenery_small.hrbwal03": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Деталь гавани"
+        "name": "Стена гавани с причалом"
     },
     "rct2tt.scenery_small.hrbwal04": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Деталь гавани"
+        "name": "Стена гавани с причалом"
     },
     "rct2tt.scenery_small.hrbwal05": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Деталь гавани"
+        "name": "Стена гавани с причалом"
     },
     "rct2tt.scenery_small.hrbwal06": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Деталь гавани"
+        "name": "Стена гавани с причалом"
     },
     "rct2tt.scenery_small.hurcluls": {
         "reference-name": "Hercules",
@@ -7387,35 +7387,35 @@
     },
     "rct2tt.scenery_small.hvrbike1": {
         "reference-name": "Hoverbike on Stand",
-        "name": "Ховербайк"
+        "name": "Ховербайк на стенде"
     },
     "rct2tt.scenery_small.hvrbike2": {
         "reference-name": "Hoverbike on Stand",
-        "name": "Ховербайк"
+        "name": "Ховербайк на стенде"
     },
     "rct2tt.scenery_small.hvrbike3": {
         "reference-name": "Hoverbike Flying",
-        "name": "Ховербайк"
+        "name": "Летающий ховербайк"
     },
     "rct2tt.scenery_small.hvrbike4": {
         "reference-name": "Hoverbike Flying",
-        "name": "Ховербайк"
+        "name": "Летающий ховербайк"
     },
     "rct2tt.scenery_small.indwal01": {
         "reference-name": "Industrial Wall Set",
-        "name": "Стена"
+        "name": "Индустриальный набор стен"
     },
     "rct2tt.scenery_small.indwal02": {
         "reference-name": "Industrial Wall Set",
-        "name": "Стена"
+        "name": "Индустриальный набор стен"
     },
     "rct2tt.scenery_small.indwal03": {
         "reference-name": "Industrial Wall Set",
-        "name": "Стена"
+        "name": "Индустриальный набор стен"
     },
     "rct2tt.scenery_small.indwal04": {
         "reference-name": "Industrial Wall Set",
-        "name": "Стена"
+        "name": "Индустриальный набор стен"
     },
     "rct2tt.scenery_small.indwal05": {
         "reference-name": "Industrial Roof Corner Piece",
@@ -7427,55 +7427,55 @@
     },
     "rct2tt.scenery_small.indwal07": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal08": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal09": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal10": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal11": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal12": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal13": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Стена с дверью"
+        "name": "Индустриальная стена с дверью"
     },
     "rct2tt.scenery_small.indwal14": {
         "reference-name": "Industrial Wall Corner Piece",
-        "name": "Угловая стена"
+        "name": "Угол индустриальной стены"
     },
     "rct2tt.scenery_small.indwal15": {
         "reference-name": "Industrial Wall Corner Piece",
-        "name": "Угловая стена"
+        "name": "Угол индустриальной стены"
     },
     "rct2tt.scenery_small.indwal16": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal17": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal18": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal19": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal20": {
         "reference-name": "Industrial Roof Piece",
@@ -7519,15 +7519,15 @@
     },
     "rct2tt.scenery_small.indwal30": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal31": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.indwal32": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Стена с окном"
+        "name": "Индустриальная стена с окном"
     },
     "rct2tt.scenery_small.jailxx01": {
         "reference-name": "Prison Wall Piece",
@@ -7555,51 +7555,51 @@
     },
     "rct2tt.scenery_small.jailxx07": {
         "reference-name": "Prison Wall Roof",
-        "name": "Тюремная крыша"
+        "name": "Крыша тюремной стены"
     },
     "rct2tt.scenery_small.jailxx08": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx09": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx10": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx11": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx12": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx13": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Деталь тюрьмы"
+        "name": "Перевёрнутая деталь тюрьмы"
     },
     "rct2tt.scenery_small.jailxx14": {
         "reference-name": "Prison Watch Tower Stairs",
-        "name": "Ступени башни"
+        "name": "Лестница на башню охраны тюрьмы"
     },
     "rct2tt.scenery_small.jailxx15": {
         "reference-name": "Prison Watch Tower Stairs",
-        "name": "Ступени башни"
+        "name": "Лестница на башню охраны тюрьмы"
     },
     "rct2tt.scenery_small.jailxx16": {
         "reference-name": "Prison Watch Tower",
-        "name": "Смотровая башня"
+        "name": "Башня охраны тюрьмы"
     },
     "rct2tt.scenery_small.jailxx20": {
         "reference-name": "Prison Wall Corner",
-        "name": "Деталь стены"
+        "name": "Угол тюремной стены"
     },
     "rct2tt.scenery_small.jailxx21": {
         "reference-name": "Prison Wall Corner",
-        "name": "Угловая стена"
+        "name": "Угол тюремной стены"
     },
     "rct2tt.scenery_small.jazzmbr1": {
         "reference-name": "Jazz Band Member",
@@ -7619,51 +7619,51 @@
     },
     "rct2tt.scenery_small.killrvin": {
         "reference-name": "Climbing Vine Tree",
-        "name": "Хищное дерево"
+        "name": "Лозовое дерево"
     },
     "rct2tt.scenery_small.knfight1": {
         "reference-name": "Animatronic Dark Knight",
-        "name": "Рыцарь"
+        "name": "Движущийся тёмный рыцарь"
     },
     "rct2tt.scenery_small.knfight2": {
         "reference-name": "Animatronic Dark Knight",
-        "name": "Рыцарь"
+        "name": "Движущийся тёмный рыцарь"
     },
     "rct2tt.scenery_small.largecpu": {
         "reference-name": "Super Computer Large CPU",
-        "name": "ЦПУ Компьютера"
+        "name": "Большой процессор суперкомпьютера"
     },
     "rct2tt.scenery_small.laserx01": {
         "reference-name": "Laser Fence",
-        "name": "Ограда"
+        "name": "Лазерный забор"
     },
     "rct2tt.scenery_small.laserx02": {
         "reference-name": "Laser Fence Corner",
-        "name": "Лазерный забор"
+        "name": "Угол лазерного забора"
     },
     "rct2tt.scenery_small.mamthw01": {
         "reference-name": "Large Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой мамонтовый забор"
     },
     "rct2tt.scenery_small.mamthw02": {
         "reference-name": "Large Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой мамонтовый забор"
     },
     "rct2tt.scenery_small.mamthw03": {
         "reference-name": "Large Angled Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой угловой мамонтовый забор"
     },
     "rct2tt.scenery_small.mamthw04": {
         "reference-name": "Large Angled Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой угловой мамонтовый забор"
     },
     "rct2tt.scenery_small.mamthw05": {
         "reference-name": "Small Angled Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой угловой мамонтовый забор"
     },
     "rct2tt.scenery_small.mamthw06": {
         "reference-name": "Small Angled Mammoth Fence",
-        "name": "Ограда"
+        "name": "Большой угловой мамонтовый забор"
     },
     "rct2tt.scenery_small.mcastl02": {
         "reference-name": "Castle Wall",
@@ -7691,11 +7691,11 @@
     },
     "rct2tt.scenery_small.mcastl08": {
         "reference-name": "Castle Ramparts Inverted Corner",
-        "name": "Угол бастиона замка"
+        "name": "Перевернутый угол бастиона замка"
     },
     "rct2tt.scenery_small.mcastl09": {
         "reference-name": "Castle Corner Piece",
-        "name": "Деталь замка"
+        "name": "Угол замка"
     },
     "rct2tt.scenery_small.mcastl10": {
         "reference-name": "Castle Ramparts Corner",
@@ -7703,23 +7703,23 @@
     },
     "rct2tt.scenery_small.mcastl19": {
         "reference-name": "Castle Corner Piece",
-        "name": "Деталь замка"
+        "name": "Угол замка"
     },
     "rct2tt.scenery_small.mdbucket": {
         "reference-name": "Bucket",
-        "name": "Сосуд"
+        "name": "Ведро"
     },
     "rct2tt.scenery_small.mdusasta": {
         "reference-name": "Animatronic Medusa",
-        "name": "Медуза"
+        "name": "Движущаяся медуза"
     },
     "rct2tt.scenery_small.medstool": {
         "reference-name": "Stool",
-        "name": "Лавка"
+        "name": "Табурет"
     },
     "rct2tt.scenery_small.medtools": {
         "reference-name": "Farm Tools",
-        "name": "Орудия"
+        "name": "Фермерские инструменты"
     },
     "rct2tt.scenery_small.medtrget": {
         "reference-name": "Archery Target",
@@ -7727,523 +7727,523 @@
     },
     "rct2tt.scenery_small.meteorcr": {
         "reference-name": "Meteor Crater Corner",
-        "name": "Деталь кратера"
+        "name": "Угол кратера от метеорита"
     },
     "rct2tt.scenery_small.meteorst": {
         "reference-name": "Meteor Crater Wall",
-        "name": "Деталь кратера"
+        "name": "Стена кратера от метеорита"
     },
     "rct2tt.scenery_small.metrcrs1": {
         "reference-name": "Meteor Crater Wall with Crystals",
-        "name": "Кратер с Кристаллами"
+        "name": "Стена кратера от метеорита с кристаллами"
     },
     "rct2tt.scenery_small.metrcrs2": {
         "reference-name": "Meteor Crater Wall with Crystals",
-        "name": "Кратер с Кристаллами"
+        "name": "Стена кратера от метеорита с кристаллами"
     },
     "rct2tt.scenery_small.minotaur": {
         "reference-name": "Minotaur Statue",
-        "name": "Минотавр"
+        "name": "Статуя минотавра"
     },
     "rct2tt.scenery_small.oldnyk01": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk02": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk03": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk04": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk05": {
         "reference-name": "New York Roof Piece",
-        "name": "Крыша Нью-Йорка"
+        "name": "Крыша в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk06": {
         "reference-name": "New York Corner Filler",
-        "name": "Деталь Нью-Йорка"
+        "name": "Наполнитель угла в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk07": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Угловая деталь Нью-Йорка"
+        "name": "Перевёрнутый угол в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk08": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Угловая деталь Нью-Йорка"
+        "name": "Перевёрнутый угол в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk09": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Угловая деталь Нью-Йорка"
+        "name": "Перевёрнутый угол в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk10": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Угловая деталь Нью-Йорка"
+        "name": "Перевёрнутый угол в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk11": {
         "reference-name": "New York Wall with Line",
-        "name": "Стена"
+        "name": "Стена с линией в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk12": {
         "reference-name": "New York Washing Line",
-        "name": "Деталь Нью-Йорка"
+        "name": "Вешалка в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk13": {
         "reference-name": "New York Wall with Line",
-        "name": "Стена"
+        "name": "Стена с линией в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk14": {
         "reference-name": "New York Washing Line",
-        "name": "Деталь Нью-Йорка"
+        "name": "Вешалка в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk15": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk16": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk17": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk18": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk19": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk31": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk33": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk34": {
         "reference-name": "New York Wall Piece",
-        "name": "Стена"
+        "name": "Стена в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.oldnyk35": {
         "reference-name": "New York Roof Piece",
-        "name": "Крыша Нью-Йорка"
+        "name": "Крыша в стиле Нью-Йорка"
     },
     "rct2tt.scenery_small.pdflag02": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag03": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag04": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag05": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag06": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag08": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag13": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag14": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag15": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.pdflag16": {
         "reference-name": "Period Flag",
-        "name": "Флаг"
+        "name": "Старый флаг"
     },
     "rct2tt.scenery_small.polwtbtn": {
         "reference-name": "Animatronic Police Officer",
-        "name": "Полицейский"
+        "name": "Движущийся полицейский"
     },
     "rct2tt.scenery_small.primhead": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primhear": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primroor": {
         "reference-name": "Wood Fence with Climbing Vines",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primroot": {
         "reference-name": "Wood Fence with Climbing Vines",
-        "name": "Деревянная ограда"
+        "name": "Деревянная забор с лозой"
     },
     "rct2tt.scenery_small.primscrn": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primst01": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primst02": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primst03": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primtall": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с растением-людоедом"
     },
     "rct2tt.scenery_small.primwal1": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с мёртвой лозой"
     },
     "rct2tt.scenery_small.primwal2": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с мёртвой лозой"
     },
     "rct2tt.scenery_small.primwal3": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Деревянная ограда"
+        "name": "Деревянный забор с мёртвой лозой"
     },
     "rct2tt.scenery_small.psntwl01": {
         "reference-name": "Dark Age Village Roof with Chimney",
-        "name": "Средневековая крыша с трубой"
+        "name": "Крыша средневековой деревни с трубой"
     },
     "rct2tt.scenery_small.psntwl02": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl03": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl04": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl05": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl06": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl07": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Деталь нижней стены"
+        "name": "Нижняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl08": {
         "reference-name": "Dark Age Village Lower Corner Piece",
-        "name": "Деталь стены"
+        "name": "Нижний угол средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl09": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Деталь верхней стены"
+        "name": "Верхняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl10": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Деталь верхней стены"
+        "name": "Верхняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl11": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Деталь верхней стены"
+        "name": "Верхняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl12": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Деталь верхней стены"
+        "name": "Верхняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl13": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Верхняя стена средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl14": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl15": {
         "reference-name": "Dark Age Village Inverted Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Перевёрнутая крыша средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl16": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl17": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl20": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Средневековая крыша с окном"
+        "name": "Крыша средневековой деревни с окном"
     },
     "rct2tt.scenery_small.psntwl21": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Средневековая крыша с окном"
+        "name": "Крыша средневековой деревни с окном"
     },
     "rct2tt.scenery_small.psntwl23": {
         "reference-name": "Dark Age Village Upper Corner Piece",
-        "name": "Угловая секция"
+        "name": "Верхний угол средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl24": {
         "reference-name": "Dark Age Village Window Box",
-        "name": "Средневековое окно"
+        "name": "Окно средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl25": {
         "reference-name": "Dark Age Village Window Box",
-        "name": "Средневековое окно"
+        "name": "Окно средневековой деревни"
     },
     "rct2tt.scenery_small.psntwl29": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Средневековая крыша с окном"
+        "name": "Крыша средневековой деревни с окном"
     },
     "rct2tt.scenery_small.psntwl30": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Средневековая крыша с окном"
+        "name": "Крыша средневековой деревни с окном"
     },
     "rct2tt.scenery_small.psntwl31": {
         "reference-name": "Dark Age Village Corner Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Угловая крыша средневековой деревни"
     },
     "rct2tt.scenery_small.rcknrolr": {
         "reference-name": "Cool Dude",
-        "name": "Пижон"
+        "name": "Крутой Чувак"
     },
     "rct2tt.scenery_small.rdmeto03": {
         "reference-name": "Red Meteor Crater Wall",
-        "name": "Часть кратера"
+        "name": "Стена красного кратера от метеорита"
     },
     "rct2tt.scenery_small.rdmeto04": {
         "reference-name": "Red Meteor Crater Inverted Corner",
-        "name": "Деталь метеорита"
+        "name": "Перевёрнутый угол кратера от метеорита"
     },
     "rct2tt.scenery_small.robnhood": {
         "reference-name": "Animatronic Robin Hood",
-        "name": "Робин Гуд"
+        "name": "Движущийся Робин Гуд"
     },
     "rct2tt.scenery_small.rswatres": {
         "reference-name": "Rollerskating Waitress",
-        "name": "Официантка"
+        "name": "Официантка на коньках"
     },
     "rct2tt.scenery_small.runway01": {
         "reference-name": "Runway Piece",
-        "name": "Деталь"
+        "name": "Часть шоссе"
     },
     "rct2tt.scenery_small.runway02": {
         "reference-name": "Runway Piece",
-        "name": "Деталь"
+        "name": "Часть шоссе"
     },
     "rct2tt.scenery_small.runway03": {
         "reference-name": "Runway Corner Piece",
-        "name": "Деталь"
+        "name": "Угол шоссе"
     },
     "rct2tt.scenery_small.runway04": {
         "reference-name": "Runway Edge Piece",
-        "name": "Деталь"
+        "name": "Край шоссе"
     },
     "rct2tt.scenery_small.runway05": {
         "reference-name": "Runway Piece",
-        "name": "Деталь"
+        "name": "Часть шоссе"
     },
     "rct2tt.scenery_small.runway06": {
         "reference-name": "Runway Inverted Corner Piece",
-        "name": "Деталь"
+        "name": "Перевернутый угол шоссе"
     },
     "rct2tt.scenery_small.schnbost": {
         "reference-name": "Buoy",
-        "name": "Буй"
+        "name": "Буёк"
     },
     "rct2tt.scenery_small.schnbouy": {
         "reference-name": "Buoy",
-        "name": "Буй"
+        "name": "Буёк"
     },
     "rct2tt.scenery_small.schncrsh": {
         "reference-name": "Wrecked Seaplane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт, попавший в аварию"
     },
     "rct2tt.scenery_small.schndrum": {
         "reference-name": "Oil Barrel",
-        "name": "Бочка"
+        "name": "Нефтяная бочка"
     },
     "rct2tt.scenery_small.schnpl01": {
         "reference-name": "Sea Plane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schnpl02": {
         "reference-name": "Sea Plane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schnpl03": {
         "reference-name": "Sea Plane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schnpl04": {
         "reference-name": "Sea Plane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schnpl05": {
         "reference-name": "Sea Plane",
-        "name": "Акваплан"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schnpl06": {
         "reference-name": "Sea Plane",
-        "name": "Самолёт"
+        "name": "Гидросамолёт"
     },
     "rct2tt.scenery_small.schntnny": {
         "reference-name": "Racing Tannoy",
-        "name": "Репродуктор"
+        "name": "Гоночная машина"
     },
     "rct2tt.scenery_small.sdragfly": {
         "reference-name": "Animatronic Dragonflies",
-        "name": "Стрекоза"
+        "name": "Двигающиеся стрекозы"
     },
     "rct2tt.scenery_small.shwdfrst": {
         "reference-name": "Forest Trees",
-        "name": "Деревья"
+        "name": "Лесные деревья"
     },
     "rct2tt.scenery_small.skeleto1": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Скелет"
+        "name": "Движущийся скелет"
     },
     "rct2tt.scenery_small.skeleto2": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Скелет"
+        "name": "Движущийся скелет"
     },
     "rct2tt.scenery_small.skeleto3": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Скелет"
+        "name": "Движущийся скелет"
     },
     "rct2tt.scenery_small.smallcpu": {
         "reference-name": "Super Computer Small CPU",
-        "name": "ЦПУ Компьютера"
+        "name": "Маленький процессор суперкомпьютера"
     },
     "rct2tt.scenery_small.smoksk01": {
         "reference-name": "Large Smoking Chimney",
-        "name": "Дымящая труба"
+        "name": "Большая дымящая труба"
     },
     "rct2tt.scenery_small.smoksk02": {
         "reference-name": "Smoke Stack Mid",
-        "name": "Деталь"
+        "name": "Средний дым"
     },
     "rct2tt.scenery_small.smoksk03": {
         "reference-name": "Smoke Stack Base",
-        "name": "Деталь"
+        "name": "Основание дыма"
     },
     "rct2tt.scenery_small.soupcrn2": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.soupcrnr": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.souped01": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.souped02": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.souptl01": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.souptl02": {
         "reference-name": "Primordial Soup",
-        "name": "Субстанция"
+        "name": "Первичный бульон"
     },
     "rct2tt.scenery_small.spacrang": {
         "reference-name": "Animatronic Space Ranger",
-        "name": "Космический рейнджер"
+        "name": "Движущийся космический рейнджер"
     },
     "rct2tt.scenery_small.spcshp01": {
         "reference-name": "Space Ship Cargo Section",
-        "name": "Секция корабля"
+        "name": "Карго-секция космического корабля"
     },
     "rct2tt.scenery_small.spcshp02": {
         "reference-name": "Space Ship Comms Section",
-        "name": "Секция корабля"
+        "name": "Центр коммуникаций космического корабля"
     },
     "rct2tt.scenery_small.spcshp03": {
         "reference-name": "Space Ship Solar Section",
-        "name": "Секция корабля"
+        "name": "Секция солнечных панелей космического корабля"
     },
     "rct2tt.scenery_small.spcshp04": {
         "reference-name": "Space Ship Solar Panels",
-        "name": "Секция корабля"
+        "name": "Солнечные панели космического корабля"
     },
     "rct2tt.scenery_small.spcshp05": {
         "reference-name": "Space Ship Gravity Section",
-        "name": "Секция корабля"
+        "name": "Гравитационная секция космического корабля"
     },
     "rct2tt.scenery_small.spcshp06": {
         "reference-name": "Space Ship Cross Section",
-        "name": "Секция корабля"
+        "name": "Перекрёсток космического корабля"
     },
     "rct2tt.scenery_small.spcshp07": {
         "reference-name": "Space Ship Control Deck",
-        "name": "Секция корабля"
+        "name": "Мост космического корабля"
     },
     "rct2tt.scenery_small.spcshp08": {
         "reference-name": "Space Ship Fuel Section",
-        "name": "Секция корабля"
+        "name": "Топливная секция космического корабля"
     },
     "rct2tt.scenery_small.spcshp09": {
         "reference-name": "Space Ship Docking Section",
-        "name": "Секция корабля"
+        "name": "Док космического корабля"
     },
     "rct2tt.scenery_small.spcshp10": {
         "reference-name": "Space Ship Engine Section",
-        "name": "Секция корабля"
+        "name": "Двигательная секция космического корабля"
     },
     "rct2tt.scenery_small.spcshp11": {
         "reference-name": "Space Ship Living Section",
-        "name": "Секция корабля"
+        "name": "Жилая секция космического корабля"
     },
     "rct2tt.scenery_small.spcshp12": {
         "reference-name": "Space Ship Science Section",
-        "name": "Секция корабля"
+        "name": "Научная секция космического корабля"
     },
     "rct2tt.scenery_small.speakr01": {
         "reference-name": "Small Speaker",
-        "name": "Динамик"
+        "name": "Маленький динамик"
     },
     "rct2tt.scenery_small.speakr02": {
         "reference-name": "Large Speaker",
-        "name": "Динамик"
+        "name": "Большой динамик"
     },
     "rct2tt.scenery_small.spiktail": {
         "reference-name": "Animatronic Stegosaurus",
-        "name": "Стегозавр"
+        "name": "Движущийся стегозавр"
     },
     "rct2tt.scenery_small.spterdac": {
         "reference-name": "Animatronic flapping Pterodactyl",
-        "name": "Птеродактиль"
+        "name": "Движущийся птеродактиль с крыльями"
     },
     "rct2tt.scenery_small.stgband1": {
         "reference-name": "Band Member",
@@ -8263,67 +8263,67 @@
     },
     "rct2tt.scenery_small.stmdran1": {
         "reference-name": "Steaming Drains",
-        "name": "Фонтанчик"
+        "name": "Канализационный пар"
     },
     "rct2tt.scenery_small.stnesta1": {
         "reference-name": "Men Turned to Stone",
-        "name": "Каменный человек"
+        "name": "Окаменевшие люди"
     },
     "rct2tt.scenery_small.stnesta2": {
         "reference-name": "Men Turned to Stone",
-        "name": "Каменный человек"
+        "name": "Окаменевшие люди"
     },
     "rct2tt.scenery_small.stnesta3": {
         "reference-name": "Men Turned to Stone",
-        "name": "Каменный человек"
+        "name": "Окаменевшие люди"
     },
     "rct2tt.scenery_small.stnesta4": {
         "reference-name": "Men Turned to Stone",
-        "name": "Каменный человек"
+        "name": "Окаменевшие люди"
     },
     "rct2tt.scenery_small.stoolset": {
         "reference-name": "Stools",
-        "name": "Скамья"
+        "name": "Табуретки"
     },
     "rct2tt.scenery_small.strictop": {
         "reference-name": "Animatronic Triceratops",
-        "name": "Трицераптор"
+        "name": "Движущийся трицератопс"
     },
     "rct2tt.scenery_small.swamplt1": {
         "reference-name": "Swamp Plant",
-        "name": "Растение"
+        "name": "Болотное растение"
     },
     "rct2tt.scenery_small.swamplt2": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swamplt3": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swamplt4": {
         "reference-name": "Swamp Plant",
-        "name": "Растение"
+        "name": "Болотное растение"
     },
     "rct2tt.scenery_small.swamplt5": {
         "reference-name": "Swamp Plant",
-        "name": "Растение"
+        "name": "Болотное растение"
     },
     "rct2tt.scenery_small.swamplt6": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swamplt7": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swamplt8": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swamplt9": {
         "reference-name": "Swamp Fern",
-        "name": "Папоротник"
+        "name": "Болотный папоротник"
     },
     "rct2tt.scenery_small.swrdstne": {
         "reference-name": "Sword in the Stone",
@@ -8331,67 +8331,67 @@
     },
     "rct2tt.scenery_small.tarpit01": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit02": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit03": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit04": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit05": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit06": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit07": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit08": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit09": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit10": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit11": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit12": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit13": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.tarpit14": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Ловушка"
+        "name": "Яма с кипящей смолой"
     },
     "rct2tt.scenery_small.titansta": {
         "reference-name": "Atlas Statue",
-        "name": "Глобус"
+        "name": "Статуя Атласа"
     },
     "rct2tt.scenery_small.tyranrex": {
         "reference-name": "Animatronic T-Rex",
-        "name": "Т-Рекс"
+        "name": "Движущийся ти-рекс"
     },
     "rct2tt.scenery_small.valkri01": {
         "reference-name": "Valkyrie",
@@ -8403,19 +8403,19 @@
     },
     "rct2tt.scenery_small.volcvent": {
         "reference-name": "Active Volcanic Vent",
-        "name": "Вулкан"
+        "name": "Жерло активного вулкана"
     },
     "rct2tt.scenery_small.waveking": {
         "reference-name": "Animatronic Waving King",
-        "name": "Король"
+        "name": "Движущийся король, машущий рукой"
     },
     "rct2tt.scenery_small.wdncart2": {
         "reference-name": "Wooden Cart",
-        "name": "Тележка"
+        "name": "Деревянная тележка"
     },
     "rct2tt.scenery_small.wepnrack": {
         "reference-name": "Weapon Set",
-        "name": "Оружие"
+        "name": "Набор оружий"
     },
     "rct2tt.scenery_small.whccolds": {
         "reference-name": "Witches around Cauldron",
@@ -8427,7 +8427,7 @@
     },
     "rct2tt.scenery_small.wiskybl2": {
         "reference-name": "Whisky Barrels",
-        "name": "Бочки с виски"
+        "name": "Бочки виски"
     },
     "rct2tt.scenery_small.yewtreex": {
         "reference-name": "Yew Tree",
@@ -8435,35 +8435,35 @@
     },
     "rct2tt.scenery_small.zeusstat": {
         "reference-name": "Zeus Statue",
-        "name": "Зевс"
+        "name": "Статуя Зевса"
     },
     "rct2tt.scenery_wall.jailxx19": {
         "reference-name": "Prison Fence",
-        "name": "Забор"
+        "name": "Тюремный забор"
     },
     "rct2tt.scenery_wall.mspkwa01": {
         "reference-name": "Spiked Fence",
-        "name": "Забор"
+        "name": "Забор с шипами"
     },
     "rct2ww.park_entrance.africent": {
         "reference-name": "Africa Park Entrance",
-        "name": "Африканский вход"
+        "name": "Африканский вход в парк"
     },
     "rct2ww.park_entrance.euroent": {
         "reference-name": "European Park Entrance",
-        "name": "Европейский вход"
+        "name": "Европейский вход в парк"
     },
     "rct2ww.park_entrance.iceent": {
         "reference-name": "Ice Park Entrance",
-        "name": "Ледяной вход"
+        "name": "Ледяной вход в парк"
     },
     "rct2ww.park_entrance.japent": {
         "reference-name": "Japanese Park Entrance",
-        "name": "Восточный вход в парк"
+        "name": "Японский вход в парк"
     },
     "rct2ww.park_entrance.naent": {
         "reference-name": "North America Park Entrance",
-        "name": "Североамериканский вход"
+        "name": "Североамериканский вход в парк"
     },
     "rct2ww.park_entrance.ozentran": {
         "reference-name": "Australasian Park Entrance",
@@ -8475,679 +8475,679 @@
     },
     "rct2ww.ride.anaconda": {
         "reference-name": "Anaconda Trains",
-        "name": "Анаконда",
+        "name": "Поезда \"Анаконда\"",
         "reference-description": "Spacious trains with simple lap restraints",
-        "description": "Анаконда",
+        "description": "Просторные поезда с простой безопасностью на ноги",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 пассажиров"
     },
     "rct2ww.ride.blackcab": {
         "reference-name": "Black Cabs",
-        "name": "Лондонское такси",
+        "name": "Чёрное такси",
         "reference-description": "Powered vehicles in the shape of London Taxis",
-        "description": "Лондонское такси",
+        "description": "Электромобили в форме лондонских такси",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.bomerang": {
         "reference-name": "Boomerang Trains",
-        "name": "Бумеранг",
+        "name": "Поезда \"Бумеранг\"",
         "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
-        "description": "Поезд едет вертикально до вершины и затем вниз на станцию",
+        "description": "Поезда для аттракционов в форме бумеранга, запускаемые воздухом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.bullet": {
         "reference-name": "Bullet Trains",
-        "name": "Пулевые горки",
+        "name": "Синкансэн",
         "reference-description": "Japanese Bullet Train themed roller coaster cars",
-        "description": "Горки в виде восточного поезда.",
+        "description": "Поезда для аттракционов в стиле японской пули-поезда",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.caddilac": {
         "reference-name": "Limousine Trains",
-        "name": "Лимузинные горки",
+        "name": "Лимузинные поезда",
         "reference-description": "Limousine-themed roller coaster cars",
         "description": "Горки с вагончиками в виде лимузинов.",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.coffeecu": {
         "reference-name": "Coffee Cup Ride",
-        "name": "Чашечка кофе",
+        "name": "Чашка кофе",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
-        "description": "Людей катают попарно с вращением",
+        "description": "Парные сиденья, вращающиеся вокруг большой движущейся кофемолки",
         "reference-capacity": "18 passengers",
-        "capacity": "18 passengers"
+        "capacity": "18 пассажиров"
     },
     "rct2ww.ride.condorrd": {
         "reference-name": "Condor Trains",
-        "name": "Кондор",
+        "name": "Поезда \"Кондор\"",
         "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
-        "description": "Люди едут лицом вперед лежа, в вагончиках в форме кондора",
+        "description": "Спецальные запряжки в форме кондоров, подвешивающие пассажиров на трек сверху, что позволяет им испытать чувство полета",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.congaeel": {
         "reference-name": "Conger Eel Trains",
-        "name": "Угрь-Конга",
+        "name": "Морской угорь",
         "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
-        "description": "Компактные горки с вагончиками в виде рыбы",
+        "description": "Поезда с безопасностью для плечей в форме морских угрей",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.crnvbfly": {
         "reference-name": "Carnival Butterfly Cars",
-        "name": "Карнавал - Бабочки",
+        "name": "Карнавальные машины-бабочки",
         "reference-description": "Cars in the shape of butterfly carnival floats",
-        "description": "Вагончики в виде бабочек",
+        "description": "Машины в виде карнавальной платформы с бабочками",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.crnvfrog": {
         "reference-name": "Carnival Frog Cars",
-        "name": "Карнавал - Лягушки",
+        "name": "Карнавальные машины-лягушки",
         "reference-description": "Cars in the shape of frog carnival floats",
-        "description": "Вагончики в форме лягушек",
+        "description": "Машины в виде карнавальной платформы с лягушками",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.crnvlzrd": {
         "reference-name": "Carnival Lizard Cars",
-        "name": "Карнавал - Вараны",
+        "name": "Карнавальные машины-ящеры",
         "reference-description": "Cars in the shape of lizard carnival floats",
-        "description": "Вагончики в форме варана",
+        "description": "Машины в виде карнавальной платформы с ящерицами",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.crocflum": {
         "reference-name": "Crocodile Boats",
-        "name": "Крокодил",
+        "name": "Лодки-крокодилы",
         "reference-description": "Crocodile-shaped boats built for running in water channels",
-        "description": "Лодки в форме крокодилов плывут по каналу.",
+        "description": "Лодки в форме крокодилов для водных каналов",
         "reference-capacity": "4 passengers per boat",
-        "capacity": "4 человека в лодке"
+        "capacity": "4 человека на лодку"
     },
     "rct2ww.ride.dhowwatr": {
         "reference-name": "Dhow Boats",
-        "name": "Кораблик",
+        "name": "Лодки для рыбалки",
         "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
-        "description": "Рыбацкий кораблик, пассажиры гребут сами",
+        "description": "Декоративные рыбацкие лодки, на которых пассажиры гребут сами",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 человека в лодке"
+        "capacity": "2 человека на лодку"
     },
     "rct2ww.ride.diamondr": {
         "reference-name": "Diamond Ride",
         "name": "Алмаз",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
-        "description": "Люди сидят попарно и катаются в свободно раскачивающихся вагончиках",
+        "description": "Парные сиденья, вращающиеся вокруг большого алмаза",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
     "rct2ww.ride.dolphinr": {
         "reference-name": "Dolphin Boats",
-        "name": "Дельфин",
+        "name": "Лодки-дельфины",
         "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
-        "description": "Одиночные машинки в форме дельфина",
+        "description": "Одиночные машины в форме дельфина, которыми управляют пассажиры",
         "reference-capacity": "1 rider per vehicle",
-        "capacity": "1 человек в машинке"
+        "capacity": "1 человек на машину"
     },
     "rct2ww.ride.dragdodg": {
         "reference-name": "Chinese Dragonhead Dodgems",
-        "name": "Китайский дракон",
+        "name": "Машины для автодрома в форме китайских драконов",
         "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
-        "description": "Самодвижущиеся машинки",
+        "description": "Машины для автодрома в форме китайских драконов, сражающихся друг с другом",
         "reference-capacity": "1 person per car",
-        "capacity": "1 чел в машинке"
+        "capacity": "1 человек на машину"
     },
     "rct2ww.ride.dragon": {
         "reference-name": "Dragon Trains",
-        "name": "Дракон-Коастер",
+        "name": "Поезда-драконы",
         "reference-description": "Dragon-themed roller coaster cars",
-        "description": "Горки с вагончиками-драконами",
+        "description": "Машины для аттракционов в форме драконов",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 чел. в вагончике"
+        "capacity": "4 человека на машину"
     },
     "rct2ww.ride.faberge": {
         "reference-name": "Fabergé Egg Ride",
-        "name": "Фаберже",
+        "name": "Яйцо Фаберже",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
-        "description": "Людей катают попарно с вращением",
+        "description": "Парные сиденья, вращающиеся вокруг большой реплики яйца Фаберже",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
     "rct2ww.ride.fightkit": {
         "reference-name": "Fighting Kite Ride",
-        "name": "Боевой змей",
+        "name": "Боевые летающие змеи",
         "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-        "description": "Гости катаются парами с вращением.",
+        "description": "Парные сиденья, вращающиеся на трёх длинных рычагах",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
     "rct2ww.ride.firecrak": {
         "reference-name": "Fire Cracker Ride",
-        "name": "Огненные гонки",
+        "name": "Фейрверк",
         "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
-        "description": "Вращ. колесо с подвешенными платформами",
+        "description": "Вращающееся колесо с подвешенными капсулами для пассажиров, поддерживаемое рычагом",
         "reference-capacity": "16 passengers",
         "capacity": "16 пассажиров"
     },
     "rct2ww.ride.football": {
         "reference-name": "Football Trains",
-        "name": "Футбол",
+        "name": "Футбольные поезда",
         "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
-        "description": "Подвешенные горки на футбольную тему",
+        "description": "Подвесные поезда в стиле футбольного мяча, свободно раскачивающиеся при резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 человека на вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.gorilla": {
         "reference-name": "Gorilla Trains",
-        "name": "Горилла",
+        "name": "Поезда-гориллы",
         "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
-        "description": "Подвешенные вагончики в форме горилл, свободно качает в поворотах",
+        "description": "Подвесные поезда в стиле гориллы, свободно раскачивающиеся при резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 человека в вагоне"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.gratwhte": {
         "reference-name": "Great White Shark Trains",
-        "name": "Белая акула",
+        "name": "Поезда-акулы",
         "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
-        "description": "Просторные поезда с ремнем безопасности",
+        "description": "Поезда с безопасностью на плечи в форме большой белой акулы",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 человек на вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.hipporid": {
         "reference-name": "Hippo Submarines",
-        "name": "Гиппопотам",
+        "name": "Подлодки-гиппопотамиы",
         "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
-        "description": "Путешествие на субмарине по подводной трассе.",
+        "description": "Подлодка для подводных трасс в форме гиппопотама",
         "reference-capacity": "5 passengers per submarine",
-        "capacity": "5 человек в вагоне"
+        "capacity": "5 пассажиров на подлодку"
     },
     "rct2ww.ride.huskie": {
         "reference-name": "Huskie Car",
-        "name": "Хаски",
+        "name": "Машины-хаски",
         "reference-description": "Powered vehicles in the shape of Huskie sleds",
-        "description": "Машинки в форме эскимосских санок едут по рельсам.",
+        "description": "Электромобили в форме собачьих санок",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 человека в машинке"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.italypor": {
         "reference-name": "Italian Police Ride",
-        "name": "Полицейский",
+        "name": "Итальянская полиция",
         "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
-        "description": "Итальянский полицейский",
+        "description": "Реплики машин, используемых полицией Италии, вращающиеся по кругу",
         "reference-capacity": "18 passengers",
         "capacity": "18 пассажиров"
     },
     "rct2ww.ride.jaguarrd": {
         "reference-name": "Jaguar Cars",
-        "name": "Пантера",
+        "name": "Машины-ягуары",
         "reference-description": "Roller coaster cars themed to look like jaguars",
-        "description": "Компактные горки с отдельными вагончиками",
+        "description": "Машины для аттракционов в стиле ягуаров",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.junkswng": {
         "reference-name": "Chinese Junk Swing Ride",
-        "name": "Китайская джонка",
+        "name": "Китайский аттракцион",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
-        "description": "Кораблик прикреплён к маятнику и вращается на 360 градусов.",
+        "description": "Корабль, прикрепленный рычагом к противовесу на другом конце, вращающийся на 360 градусов",
         "reference-capacity": "12 passengers",
         "capacity": "12 пассажиров"
     },
     "rct2ww.ride.killwhal": {
         "reference-name": "Killer Whale Submarines",
-        "name": "Кит-Убийца",
+        "name": "Подлодки-киты",
         "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
-        "description": "Люди плывут в субмарине по подводной трассе",
+        "description": "Подлодка для подводных трасс в форме китов-убийц",
         "reference-capacity": "5 passengers per submarine",
-        "capacity": "5 пассажиров"
+        "capacity": "5 пассажиров на подлодку"
     },
     "rct2ww.ride.kolaride": {
         "reference-name": "Koala Car",
-        "name": "Коала Райд",
+        "name": "Машины-коалы",
         "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
-        "description": "Крупные машины реверсивного паден.",
+        "description": "Большая машина в форме коалы для реверсивных аттракционов",
         "reference-capacity": "8 passengers per car",
-        "capacity": "8 пассажиров"
+        "capacity": "8 пассажиров на машину"
     },
     "rct2ww.ride.lionride": {
         "reference-name": "Lion Cars",
-        "name": "Лев",
+        "name": "Машины-львы",
         "reference-description": "Roller coaster cars themed to look like lions",
-        "description": "Компактные горки с отдельными вагончиками и легкими перепадами.",
+        "description": "Машины для аттракционов в виде львов",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.londonbs": {
         "reference-name": "Routemaster Buses",
-        "name": "Автобус",
+        "name": "Автобусы \"Routemaster\"",
         "reference-description": "Replicas of the famous London Routemaster bus",
-        "description": "Автобус",
+        "description": "Реплики знаменитых лондонских автобусов \"Routemaster\"",
         "reference-capacity": "10 passengers per car",
-        "capacity": "10 пассажиров в вагон"
+        "capacity": "10 пассажиров на машину"
     },
     "rct2ww.ride.mandarin": {
         "reference-name": "Mandarin Duck Boats",
-        "name": "Мандариновая утка",
+        "name": "Лодки-мандаринки",
         "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
-        "description": "Лодки в виде уток с педалями.",
+        "description": "Лодки в фирме уток, с педалями на переднем ряду",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 пассажира в лодке"
+        "capacity": "2 пассажира на лодку"
     },
     "rct2ww.ride.mantaray": {
         "reference-name": "Manta Ray Boats",
-        "name": "Манта Рей",
+        "name": "Лодки-скаты",
         "reference-description": "Coaster boats in the shape of a manta ray",
-        "description": "Путешествие на лодке по широкому каналу на транспортере",
+        "description": "Лодки в форме рыбы скат",
         "reference-capacity": "6 passengers per boat",
-        "capacity": "6 пассажиров в лодке"
+        "capacity": "6 пассажиров на лодку"
     },
     "rct2ww.ride.minecart": {
         "reference-name": "Mine Cart Trains",
-        "name": "Вагонетки",
+        "name": "Шахтёрские поезда",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Деревянные горки со скамейками.",
+        "description": "Деревянные поезда с набитыми сиденьями и безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира в вагоне"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.minelift": {
         "reference-name": "Mine Lift Cabin",
-        "name": "Шахта",
+        "name": "Шахтёрский лифт",
         "reference-description": "A steel lift cabin commonly used in mines",
-        "description": "Люди едут на лифте вверх и вниз по вертикальной шахте",
+        "description": "Стальная кабина для лифта, часто используемая в шахтах",
         "reference-capacity": "16 passengers",
         "capacity": "16 пассажиров"
     },
     "rct2ww.ride.ostrich": {
         "reference-name": "Ostrich Trains",
-        "name": "Австрийцы",
+        "name": "Поезда-страусы",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
-        "description": "Круговые горки, люди катаются стоя.",
+        "description": "Поезда для езды стоя, стилизированные под страусов",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.outriggr": {
         "reference-name": "Outrigger Canoes",
-        "name": "Каноэ",
+        "name": "Каноэ с балансиром",
         "reference-description": "Long canoes which the passengers paddle themselves",
-        "description": "Длинные каноэ, люди гребут сами.",
+        "description": "Длинные каноэ, где пассажиры гребут сами",
         "reference-capacity": "2 passengers per canoe",
-        "capacity": "2 пассажира в каноэ"
+        "capacity": "2 пассажира на каноэ"
     },
     "rct2ww.ride.penguinb": {
         "reference-name": "Penguin Trains",
-        "name": "Пингвин-Бобслей",
+        "name": "Поезда-пингвины",
         "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
-        "description": "Люди едут вниз по треку в бобах в виде пингвинов.",
+        "description": "Поезда в виде пингвинов, с двухвестными машинами, где пассажиры сидят друг за другом",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.polarber": {
         "reference-name": "Polar Bear Trains",
-        "name": "Белый медведь",
+        "name": "Поезда-медведи",
         "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
-        "description": "Люди сидят парами и вращаются вперед-назад",
+        "description": "Подвесные поезда в стиле белых медведей, с креслами, расположенными друг напротив друга",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.rhinorid": {
         "reference-name": "Rhino Trains",
-        "name": "Носорог",
+        "name": "Поезда-носороги",
         "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
-        "description": "Компактные горки со спиральным лифтом",
+        "description": "Компактные поезда с сиденьями, идущими в ряд, оформленными под носорогов",
         "reference-capacity": "6 passengers per car",
-        "capacity": "6 пассажиров"
+        "capacity": "6 пассажиров на машину"
     },
     "rct2ww.ride.rocket": {
         "reference-name": "1950s Rockets",
-        "name": "Ракета 1950",
+        "name": "Ракеты 1950х",
         "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-        "description": "Обратные горки поднимают вертикально вверх и бросают вниз на станцию.",
+        "description": "Подвесные поезда в стиле ракет, свободно раскачивающиеся при резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира в вагон"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.rssncrrd": {
         "reference-name": "Trabant Cars",
-        "name": "Трабант",
+        "name": "Машины \"Trabant\"",
         "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
-        "description": "Горки в форме автомобилей",
+        "description": "Машины для аттракционов в форме автомобилей от Trabant",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира в машине"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.sanftram": {
         "reference-name": "San Francisco Trams",
-        "name": "Трамвай Сан-Франц.",
+        "name": "Трамваи Сан-Франциско",
         "reference-description": "Replicas of the San Francisco Trams",
-        "description": "Трамвайчики",
+        "description": "Реплика трамваев из Сан-Франциско",
         "reference-capacity": "10 passengers per car",
-        "capacity": "10 пассажиров"
+        "capacity": "10 пассажиров на машину"
     },
     "rct2ww.ride.seals": {
         "reference-name": "Seal Trains",
-        "name": "Тюлени",
+        "name": "Поезда-тюлени",
         "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
-        "description": "Компактные горки с виражами и петлями.",
+        "description": "Поезда с безопасностью для плечей в форме тюленей",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.skidoo": {
         "reference-name": "Skidoo Dodgems",
-        "name": "Скидо-машинки",
+        "name": "Машины для автодрома \"Skidoo\"",
         "reference-description": "Guests slide around in skidoo-shaped vehicles that they freely control",
-        "description": "Электрические машинки",
+        "description": "Скользящие реплики машин Skidoo, свободно управляемые пассажирами",
         "reference-capacity": "1 person per car",
-        "capacity": "1 человек"
+        "capacity": "1 человек на машину"
     },
     "rct2ww.ride.sloth": {
         "reference-name": "Sloth Trains",
-        "name": "Ленивец",
+        "name": "Поезда-ленивцы",
         "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
-        "description": "Подвесные горки с вагончиками, свободно качаются на виражах.",
+        "description": "Подвесные поезда в стиле животных-ленивцев, свободно раскачивающиеся при резких поворотах",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.sputnikr": {
         "reference-name": "Sputnik Cars",
-        "name": "Спутник",
+        "name": "Машины \"Спутник\"",
         "reference-description": "Russian satellite-shaped cars which swing from the rail above",
-        "description": "Пассажиры едут, лёжа лицом вниз, по треку, свободно кач. по сторонам",
+        "description": "Подвесные машины в форме русского искуственного спутника",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.steamtrn": {
         "reference-name": "Maharaja Steam Trains",
-        "name": "Паровоз Магараджей",
+        "name": "Паровоз \"Махараджа\"",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
-        "description": "Миниатюрный паровозик тянет деревянные вагончики.",
+        "description": "Миниатюрные паравозы с локомотивом-репликой и нежными деревянными вагончиками, накрытыми тканевой крышей",
         "reference-capacity": "6 passengers per carriage",
-        "capacity": "6 пассажиров в вагоне"
+        "capacity": "6 пассажиров на вагон"
     },
     "rct2ww.ride.stgccstr": {
         "reference-name": "Stage Coaches",
         "name": "Дилижанс",
         "reference-description": "Single roller coaster cars in the shape of a stage coach, with padded seats and lap bar restraints",
-        "description": "Деревянные горки со скамейками",
+        "description": "Машины для аттракционов в форме дилижансов, с набитыми сиденьями и безопасностью для ног",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.surfbrdc": {
         "reference-name": "Surfing Trains",
-        "name": "Серфинг Коастер",
+        "name": "Поезда для сёрфинга",
         "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
-        "description": "Пассажир стоит в широком вагончике со спец системой безопасности.",
+        "description": "Широкие поезда с подставкой для пассажиров в виде сёрф-доски с особой системой безопасности",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.taxicstr": {
         "reference-name": "Yellow Taxi Trains",
-        "name": "Yellow Taxi Trains",
+        "name": "Жёлтое такси",
         "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
-        "description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
+        "description": "Поезда для Гига-аттракционов, стилизованные под жёлтое такси",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.tgvtrain": {
         "reference-name": "TGV Trains",
-        "name": "Поезд TGV",
+        "name": "Поезда TGV",
         "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
-        "description": "Поезд с линейным индукционным мотором с крутыми виражами",
+        "description": "Поезда для аттракционов с линейными индукционными моторами, стилизованные под французские высокоскоростные поезда TGV",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.tigrtwst": {
         "reference-name": "Bengal Tiger Cars",
-        "name": "Бенгальский тигр",
+        "name": "Поезда-тигры",
         "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
-        "description": "Горки с вращением",
+        "description": "Машины, способные совершать перевороты Heartline, стилизованные под бенганлских тигров",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 пассажира"
+        "capacity": "4 пассажира на машину"
     },
     "rct2ww.ride.tutlboat": {
         "reference-name": "Turtle Boats",
-        "name": "Черепаха",
+        "name": "Лодки-черепахи",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
-        "description": "Маленькие круглые шлюпки с моторчиком",
+        "description": "Маленькие круглые шлюпки с мотором в центре, которыми управляют сами пассажиры",
         "reference-capacity": "2 passengers per boat",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.ride.whicgrub": {
         "reference-name": "Witchetty Grub Trains",
-        "name": "Колдовство",
+        "name": "Поезда-личинки",
         "reference-description": "Roller coaster trains with small grub-shaped cars",
-        "description": "Горки с маленькими вагончиками.",
+        "description": "Поезда с маленькими машинами в форме личинок",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 пассажира"
+        "capacity": "2 пассажира на машину"
     },
     "rct2ww.scenario_text.ayers_adventure": {
         "reference-name": "Ayers Adventure",
-        "name": "Приключение Айа",
+        "name": "Ayers Adventure",
         "reference-park_name": "Ayers Adventure",
-        "park_name": "Приключение Айа",
+        "park_name": "Ayers Adventure",
         "reference-details": "You are helping Aboriginal people to build a park as part of a cultural awareness program. You need to get a large number of guests to educate them in the unique heritage of the Aboriginal people.",
         "details": "Вы помогаете аборигенам построить парк, как часть культурной программы. Вам нужно привлечь большое число гостей и передать им уникальное наследие местной культуры."
     },
     "rct2ww.scenario_text.beach_barbecue_blast": {
         "reference-name": "Beach Barbecue Blast",
-        "name": "Барбекю на Берегу",
+        "name": "Beach Barbecue Blast",
         "reference-park_name": "Beach Barbecue Blast",
-        "park_name": "Барбекю на Берегу",
+        "park_name": "Beach Barbecue Blast",
         "reference-details": "A local entrepreneur’s sealife park has gone bust. You already operate a small park and buy the other park from the construction company. Develop a big combined park.",
-        "details": "Местный морской парк потерпел банкротство. У вас уже есть небольшой парк и вы можете купить еще один у строительной компании. Создайте один общий парк."
+        "details": "Морской парк местного предпринимателя закрылся. У вас уже есть небольшой парк, и вы прикупаете себе и обанкроченный. Создайте большой общий парк."
     },
     "rct2ww.scenario_text.canyon_calamities": {
         "reference-name": "Canyon Calamities",
-        "name": "Гранд Каньон",
+        "name": "Canyon Calamities",
         "reference-park_name": "Canyon Calamities",
-        "park_name": "Гранд Каньон",
+        "park_name": "Canyon Calamities",
         "reference-details": "You have to build a park on limited land either side of this natural treasure - you do have the opportunity to buy neighbouring land from the Native American Indians. You need to complete the objective to sustain the local town’s population.",
-        "details": "Вы должны построить парк на небольшом участке земли - у вас есть возможность покупать близлежащие территории у местных индейцев. Необходимо поддерживать население местного городка."
+        "details": "Вы должны построить парк на двух участках земли, лежащих по обе стороны природного сокровища. У вас будет возможность купить близлежащую землю у коренного населения. Достигните своей цели, чтобы поддержать жизнь в местном городе."
     },
     "rct2ww.scenario_text.european_extravaganza": {
         "reference-name": "European Extravaganza",
-        "name": "Европейский Фестиваль",
+        "name": "European Extravaganza",
         "reference-park_name": "European Extravaganza",
-        "park_name": "Европейский Фестиваль",
+        "park_name": "European Extravaganza",
         "reference-details": "You have been brought in to take over a European Cultural Visitor Attraction and must increase the number of guests in order to pay back the EU subsidy by the end of the current European parliament term.",
-        "details": "Вам передали в управление Европейский Культурный Центр. Вы должны увеличить число гостей и вернуть субсидию Евросоюза до начала парламентских выборов."
+        "details": "Вам передали в управление европейский культурный объект. Вы должны увеличить число гостей и вернуть субсидию Евросоюза до начала парламентских выборов."
     },
     "rct2ww.scenario_text.from_the_ashes": {
         "reference-name": "From The Ashes",
-        "name": "Возрождение",
+        "name": "From The Ashes",
         "reference-park_name": "From The Ashes",
-        "park_name": "Возрождение",
+        "park_name": "From The Ashes",
         "reference-details": "An old park has fallen into disrepair. You gain a European Union grant to return this deprived area to its former glory! You need to renovate the park and repay the grant.",
-        "details": "Старый парк пришел в запустение. Вы получили грант Евросоюза и должны вернуть эту землю к былой славе! Необходимо обновить парк и выплатить грант."
+        "details": "Старый парк начал разваливаться. Вы получили грант Евросоюза и должны вернуть эту землю к былой славе! Необходимо обновить парк и выплатить грант."
     },
     "rct2ww.scenario_text.great_wall_of_china": {
         "reference-name": "Great Wall of China",
-        "name": "Великая стена",
+        "name": "Great Wall of China",
         "reference-park_name": "Great Wall of China",
-        "park_name": "Великая стена",
+        "park_name": "Great Wall of China",
         "reference-details": "The authorities have decided to enhance tourism around the Great Wall by building a theme park on the adjacent land. Money is no object!",
-        "details": "Власти решили развивать туризм вокруг ВКС, построив тематический парк. Деньги - не проблема!"
+        "details": "Власти решили развивать туризм вокруг Китайской Стены, построив рядом парк. Деньги для вас не проблема!"
     },
     "rct2ww.scenario_text.icy_adventures": {
         "reference-name": "Icy Adventures",
-        "name": "Ледовый Мир",
+        "name": "Icy Adventures",
         "reference-park_name": "Icy Adventures",
-        "park_name": "Ледовый Мир",
+        "park_name": "Icy Adventures",
         "reference-details": "The environment agency has turned to you to transform an old oil refinery ecological eyesore into a top tourist attraction. Land is cheap but loan interest is high. You can sell the old buildings for salvage.",
-        "details": "Агентство по охране природы обратилось к вам, чтобы попросить помощи в строительстве парка развлечений. Земля недорога, но процент по кредитам высок. Можете продавать старые постройки."
+        "details": "Агентство по охране природы обратилось к вам, чтобы превратить мозолящую глаза нефтяную вышку в туристическое назначение. Земля недорога, но процент по кредитам высок. У вас есть возможность продать старые здания, чтобы подзаработать."
     },
     "rct2ww.scenario_text.lost_city_founder": {
         "reference-name": "Lost City Founder",
-        "name": "Город Инков",
+        "name": "Lost City Founder",
         "reference-park_name": "Lost City Founder",
-        "park_name": "Город Инков",
+        "park_name": "Lost City Founder",
         "reference-details": "To further boost local tourism you must construct a park that is in tune with its surroundings.",
-        "details": "Чтобы развивать местный туризм, вы должны создать парк в духе местных достопримечательностей."
+        "details": "Чтобы развивать местный туризм, вы должны создать парк не нарушая природный покой."
     },
     "rct2ww.scenario_text.mines_of_africa": {
         "reference-name": "Mines of Africa",
-        "name": "Шахты Африки",
+        "name": "Mines of Africa",
         "reference-park_name": "Mines of Africa",
-        "park_name": "Шахты Африки",
+        "park_name": "Mines of Africa",
         "reference-details": "You inherited a disused diamond mine, and find a valuable diamond.  You decide to invest that money to build a world-famous theme park.",
-        "details": "Вы унаследовали алмазную шахту и нашли дорогой алмаз. Затем вы решили инвестировать деньги в тематический парк."
+        "details": "Вы унаследовали алмазную шахту и нашли дорогой алмаз. Вы решили инвестировать эти деньги, чтобы построить парк развлечений, известный на весь мир."
     },
     "rct2ww.scenario_text.mirage_madness": {
         "reference-name": "Mirage Madness",
-        "name": "Мираж",
+        "name": "Mirage Madness",
         "reference-park_name": "Mirage Madness",
-        "park_name": "Мираж",
+        "park_name": "Mirage Madness",
         "reference-details": "A desert Oasis has been discovered and would provide a beautiful location for a park. Transport to the oasis has been provided.",
-        "details": "Был открыт пустынный оазис, который может стать прекрасным местом для парка. Транспорт в оазис уже обеспечен."
+        "details": "В пустыне был обнаружен оазис, который был бы замечательным положением для парка. К тому же, к нему уже проложена транспортировка."
     },
     "rct2ww.scenario_text.okinawa_coast": {
         "reference-name": "Okinawa Coast",
-        "name": "Окинава",
+        "name": "Okinawa Coast",
         "reference-park_name": "Okinawa Coast",
-        "park_name": "Окинава",
+        "park_name": "Okinawa Coast",
         "reference-details": "An existing park has run out of space. Your only option is to build out into the sea, and so you have taken out a loan. Height restrictions on your building are enforced due to foundations and earthquake risk.",
-        "details": "Парку не хватает земли. Единственный шанс - строить в море, и вы берете заем. Высоту сооружений ограничивает фундамент и риск землетрясений."
+        "details": "Уже существующему парку не хватает места для расширения. Единственный вариант - строить на морских платформах, которые вы купили в кредит. Однако, на высоту ваших построек наложено ограничение из-за нестабильного фундамента и риска землетрясений."
     },
     "rct2ww.scenario_text.over_the_edge": {
         "reference-name": "Over The Edge",
-        "name": "Водопад",
+        "name": "Over The Edge",
         "reference-park_name": "Over The Edge",
-        "park_name": "Водопад",
+        "park_name": "Over The Edge",
         "reference-details": "A dam has been built offering abundant, cheap hydroelectric power with which to run a park. You need to reach a high park value to help repay the loan for the dam.",
-        "details": "Была построена плотина, котор. дала дешёвую электроэнергию. Вам надо увеличить доходы парка, чтобы помочь выплатить заем за плотину."
+        "details": "Была построена дамба, обеспечивающая ваш парк дешёвой электроэнергией. Вам нужно достичь высокой стоимости парка, чтобы расплатиться по кредиту за дамбу."
     },
     "rct2ww.scenario_text.park_maharaja": {
         "reference-name": "Park Maharaja",
-        "name": "Парк Магарадж",
+        "name": "Park Maharaja",
         "reference-park_name": "Park Maharaja",
-        "park_name": "Парк Магарадж",
+        "park_name": "Park Maharaja",
         "reference-details": "You have been commissioned by the Maharaja to bring entertainment to the large local population. Build a park inspired by the Maharaja’s palace.",
-        "details": "Вас выбрали развлекать людей вокруг Магараджи. Постройте парк в духе дворца Магараджей."
+        "details": "Махараджа платит вам, чтобы развлекать местное население. Постройте парк, вдохновлённый его дворцом."
     },
     "rct2ww.scenario_text.rainforest_romp": {
         "reference-name": "Rainforest Romp",
-        "name": "Тропический Лес",
+        "name": "Rainforest Romp",
         "reference-park_name": "Rainforest Romp",
-        "park_name": "Тропический Лес",
+        "park_name": "Rainforest Romp",
         "reference-details": "Space is limited in the precious rainforest - you must cram as much as possible into the existing clearing, in order to provide a viable alternative to the local timber industry.",
-        "details": "Место ограничено ценнейшими тропическими лесами - вы должны строить на существующей территории, чтобы не дать вырубать леса."
+        "details": "В этом драгоценном лесу место очень ограничено - впихните всё что можете в существующее пространство, чтобы отговорить местные власти от лесорубства."
     },
     "rct2ww.scenario_text.rollercoaster_heaven": {
         "reference-name": "Rollercoaster Heaven",
-        "name": "Горки в Небесах",
+        "name": "Rollercoaster Heaven",
         "reference-park_name": "Rollercoaster Heaven",
-        "park_name": "Горки в Небесах",
+        "park_name": "Rollercoaster Heaven",
         "reference-details": "You are a successful business tycoon on long sabbatical who desires to use this time transforming the city park into Rollercoaster Heaven. Money is no object!",
-        "details": "Вы - успешный предприниматель и желаете сделать из городского парка Горки на Небесах. Деньги для вас - не проблема!"
+        "details": "Вы уже являятесь успешным предпринимателем. Во время длинного отпуска вам пришла в голову идея: превратить горотской парк аттракционов в настоящий рай. Деньги - не проблема!"
     },
     "rct2ww.scenario_text.sugarloaf_shores": {
         "reference-name": "Sugarloaf Shores",
-        "name": "Сахарный Берег",
+        "name": "Sugarloaf Shores",
         "reference-park_name": "Sugarloaf Shores",
-        "park_name": "Сахарный Берег",
+        "park_name": "Sugarloaf Shores",
         "reference-details": "You run a small park near Rio but the bank has called in your loan. You need to quickly increase your earning capacity to repay this unexpected debt.",
-        "details": "У вас небольшой парк близ Рио, но банк требует вернуть кредит. Вам срочно нужно увеличить прибыли, чтобы вернуть долг."
+        "details": "Вы владеете маленьким парком рядом с Рио, и банк требует от вас вернуть кредит. Увеличьте свою прибыльность как можно быстрее, и расплатитесь со своими долгами."
     },
     "rct2ww.scenario_text.wacky_waikiki": {
         "reference-name": "Wacky Waikiki",
-        "name": "Ваки Ваикики",
+        "name": "Wacky Waikiki",
         "reference-park_name": "Wacky Waikiki",
-        "park_name": "Ваки Ваикики",
+        "park_name": "Wacky Waikiki",
         "reference-details": "The people of Hawaii are bored of surfing and are looking for something more intense. You need to build a park with this in mind to keep the area’s tourist attraction rating high.",
-        "details": "Населению Гаваев надоело заниматься сёрфингом и они желают что-нибудь более экстремальное. Вам надо построить парк, чтобы жители островов снова почувствовали вкус жизни!"
+        "details": "Населению Гаваев надоело заниматься сёрфингом и они ищут что-нибудь более интенсивное. Постройте парк, учитывающий это желание, и поддержите местный туризм."
     },
     "rct2ww.scenery_group.scgafric": {
         "reference-name": "Africa Theming",
-        "name": "Тема Африки"
+        "name": "Африканская тема"
     },
     "rct2ww.scenery_group.scgartic": {
         "reference-name": "Antarctic Theming",
-        "name": "Тема Антарктики"
+        "name": "Антарктическая тема"
     },
     "rct2ww.scenery_group.scgasia": {
         "reference-name": "Asia Theming",
-        "name": "Тема Азии"
+        "name": "Азиатская тема"
     },
     "rct2ww.scenery_group.scgaustr": {
         "reference-name": "Australasian Theming",
-        "name": "Тема Австралазии"
+        "name": "Австралазийская тема"
     },
     "rct2ww.scenery_group.scgeurop": {
         "reference-name": "Europe Theming",
-        "name": "Тема Европы"
+        "name": "Европейская тема"
     },
     "rct2ww.scenery_group.scgnamrc": {
         "reference-name": "North America Theming",
-        "name": "Тема Северной Америки"
+        "name": "Североамериканская тема"
     },
     "rct2ww.scenery_group.scgsamer": {
         "reference-name": "South America Theming",
-        "name": "Тема Северной Америки"
+        "name": "Южноамериканская тема"
     },
     "rct2ww.scenery_large.1x2abr01": {
         "reference-name": "Aboriginal Plain Tile",
-        "name": "Деталь аборигенов"
+        "name": "Аборигенская плитка"
     },
     "rct2ww.scenery_large.1x2abr02": {
         "reference-name": "Aboriginal Snake Artwork",
-        "name": "Змей аборигенов"
+        "name": "Аборигенский рисунок \"Змея\""
     },
     "rct2ww.scenery_large.1x2abr03": {
         "reference-name": "Aboriginal Spirit Artwork",
-        "name": "Сувенир от аборигенов"
+        "name": "Аборигенский рисунок \"Дух\""
     },
     "rct2ww.scenery_large.1x2azt01": {
         "reference-name": "Temple Wall Piece with Head",
-        "name": "Кусок стены с головой"
+        "name": "Часть стены храма с головой"
     },
     "rct2ww.scenery_large.1x2azt02": {
         "reference-name": "Temple Broken Wall Piece with Head",
-        "name": "Кусок стены с головой"
+        "name": "Сломанная часть стены храма с головой"
     },
     "rct2ww.scenery_large.1x2glama": {
         "reference-name": "Gold Llama",
-        "name": "Лама"
+        "name": "Золотая лама"
     },
     "rct2ww.scenery_large.1x2lgchm": {
         "reference-name": "Log Cabin Side Chimney",
-        "name": "Труба от хижины"
+        "name": "Сторонняя труба деревянной кабины"
     },
     "rct2ww.scenery_large.1x4brg01": {
         "reference-name": "Suspension Bridge Start side 1",
-        "name": "Подвесной мост"
+        "name": "Начало подвесного моста, сторона 1"
     },
     "rct2ww.scenery_large.1x4brg02": {
         "reference-name": "Suspension Bridge Start side 2",
-        "name": "Подвесной мост"
+        "name": "Начало подвесного моста, сторона 2"
     },
     "rct2ww.scenery_large.1x4brg03": {
         "reference-name": "Suspension Bridge Tower side 1",
-        "name": "Подвесной мост"
+        "name": "Башня подвесного моста, сторона 1"
     },
     "rct2ww.scenery_large.1x4brg04": {
         "reference-name": "Suspension Bridge Tower side 2",
-        "name": "Подвесной мост"
+        "name": "Башня подвесного моста, сторона 2"
     },
     "rct2ww.scenery_large.1x4brg05": {
         "reference-name": "Suspension Bridge Cable Section",
-        "name": "Подвесной мост"
+        "name": "Кабельная секция подвесного моста"
     },
     "rct2ww.scenery_large.3x3altre": {
         "reference-name": "Jungle Tree with Leopards",
-        "name": "Дерево с леопардами"
+        "name": "Дерево из джунглей с леопардами"
     },
     "rct2ww.scenery_large.3x3atre1": {
         "reference-name": "Jungle Tree 2",
-        "name": "Дерево"
+        "name": "Дерево из джунглей 2"
     },
     "rct2ww.scenery_large.3x3atre2": {
         "reference-name": "Jungle Tree 1",
-        "name": "Дерево"
+        "name": "Дерево из джунглей 1"
     },
     "rct2ww.scenery_large.3x3atre3": {
         "reference-name": "Jungle Tree with Vines",
-        "name": "Дерево"
+        "name": "Дерево из джунглей с лозами"
     },
     "rct2ww.scenery_large.3x3eucal": {
         "reference-name": "Eucalyptus Tree",
@@ -9155,19 +9155,19 @@
     },
     "rct2ww.scenery_large.3x3hmsen": {
         "reference-name": "HMS Endeavour",
-        "name": "Эндевор"
+        "name": "Корабль \"HMS Endeavour\""
     },
     "rct2ww.scenery_large.3x3mantr": {
         "reference-name": "Mangrove Tree",
-        "name": "Дерево манго"
+        "name": "Мангровое дерево"
     },
     "rct2ww.scenery_large.50rocket": {
         "reference-name": "1950s Rocket",
-        "name": "1950 Ракета"
+        "name": "Ракета 1950х"
     },
     "rct2ww.scenery_large.adultele": {
         "reference-name": "Adult Indian Elephant",
-        "name": "Индийский слон"
+        "name": "Взрослый индийский слон"
     },
     "rct2ww.scenery_large.afrclion": {
         "reference-name": "Lion",
@@ -9175,7 +9175,7 @@
     },
     "rct2ww.scenery_large.afrrhino": {
         "reference-name": "Rhino",
-        "name": "Рино"
+        "name": "Носорог"
     },
     "rct2ww.scenery_large.afrzebra": {
         "reference-name": "Zebra",
@@ -9191,15 +9191,15 @@
     },
     "rct2ww.scenery_large.bamborf1": {
         "reference-name": "Bamboo Roof Corner",
-        "name": "Крыша"
+        "name": "Угол бамбуковой крыши"
     },
     "rct2ww.scenery_large.bamborf2": {
         "reference-name": "Bamboo Roof",
-        "name": "Крыша"
+        "name": "Бамбуковая крыша"
     },
     "rct2ww.scenery_large.bamborf3": {
         "reference-name": "Bamboo Roof Inverted Corner",
-        "name": "Крыша"
+        "name": "Перевёрнутый угол бамбуковой крыши"
     },
     "rct2ww.scenery_large.bigben": {
         "reference-name": "Big Ben and the Houses of Parliament",
@@ -9207,15 +9207,15 @@
     },
     "rct2ww.scenery_large.bigdish": {
         "reference-name": "Satellite Dish",
-        "name": "Тарелка"
+        "name": "Спутниковая тарелка"
     },
     "rct2ww.scenery_large.biggeosp": {
         "reference-name": "Big Geosphere",
-        "name": "Геосфера"
+        "name": "Большая геосфера"
     },
     "rct2ww.scenery_large.cdragon": {
         "reference-name": "Chinese Dragon",
-        "name": "Дракон"
+        "name": "Китайский дракон"
     },
     "rct2ww.scenery_large.circus": {
         "reference-name": "Circus",
@@ -9231,19 +9231,19 @@
     },
     "rct2ww.scenery_large.damtower": {
         "reference-name": "Dam Tower",
-        "name": "Плотина"
+        "name": "Башня дамбы"
     },
     "rct2ww.scenery_large.damtower_fix": {
         "reference-name": "Dam Tower",
-        "name": "Плотина"
+        "name": "Башня дамбы"
     },
     "rct2ww.scenery_large.easerlnd": {
         "reference-name": "Easter Island Statue",
-        "name": "Статуя о. Пасхи"
+        "name": "Статуя Пасхального Острова"
     },
     "rct2ww.scenery_large.eiffel": {
         "reference-name": "Eiffel Tower",
-        "name": "Башня"
+        "name": "Эйфельская башня"
     },
     "rct2ww.scenery_large.evilsam": {
         "reference-name": "Evil Samurai",
@@ -9251,15 +9251,15 @@
     },
     "rct2ww.scenery_large.fatbudda": {
         "reference-name": "Fat Buddha",
-        "name": "Будда"
+        "name": "Толстый будда"
     },
     "rct2ww.scenery_large.gdstaue1": {
         "reference-name": "Gold Statue 1",
-        "name": "Статуэтка 1"
+        "name": "Золотая статуя 1"
     },
     "rct2ww.scenery_large.gdstaue2": {
         "reference-name": "Gold Statue 2",
-        "name": "Статуэтка 2"
+        "name": "Золотая статуя 2"
     },
     "rct2ww.scenery_large.geisha": {
         "reference-name": "Geisha",
@@ -9279,43 +9279,43 @@
     },
     "rct2ww.scenery_large.goodsam": {
         "reference-name": "Good Samurai",
-        "name": "Самурай"
+        "name": "Добрый самурай"
     },
     "rct2ww.scenery_large.gwoctur1": {
         "reference-name": "Great Wall Of China Turret Straight",
-        "name": "Фрагмент Великой Стены"
+        "name": "Прямая секция великой Китайской Стены"
     },
     "rct2ww.scenery_large.gwoctur2": {
         "reference-name": "Great Wall Of China Turret Corner",
-        "name": "Фрагмент Великой Стены"
+        "name": "Угол великой Китайской стены"
     },
     "rct2ww.scenery_large.helipad": {
         "reference-name": "Helipad",
-        "name": "Площадь"
+        "name": "Вертолётная площадка"
     },
     "rct2ww.scenery_large.hippo01": {
         "reference-name": "Hippo 1",
-        "name": "Бегемот"
+        "name": "Бегемот 1"
     },
     "rct2ww.scenery_large.hippo02": {
         "reference-name": "Hippo 2",
-        "name": "Бегемот"
+        "name": "Бегемот 2"
     },
     "rct2ww.scenery_large.icefor01": {
         "reference-name": "Ice Formation",
-        "name": "Конструкция"
+        "name": "Лёдообразование"
     },
     "rct2ww.scenery_large.icefor02": {
         "reference-name": "Ice Formation",
-        "name": "Конструкция"
+        "name": "Лёдообразование"
     },
     "rct2ww.scenery_large.indianst": {
         "reference-name": "Native American",
-        "name": "Индеец"
+        "name": "Коренной американец"
     },
     "rct2ww.scenery_large.largeju1": {
         "reference-name": "Large Rainforest Tree",
-        "name": "Большое дерево"
+        "name": "Большое дождевое дерево"
     },
     "rct2ww.scenery_large.lincolns": {
         "reference-name": "Washington Statue",
@@ -9327,11 +9327,11 @@
     },
     "rct2ww.scenery_large.mbskyr02": {
         "reference-name": "Skyscraper Tip",
-        "name": "Верхушка"
+        "name": "Верхушка небоскрёба"
     },
     "rct2ww.scenery_large.ovrgrwnt": {
         "reference-name": "Old Overgrown Tree",
-        "name": "Старое дерево"
+        "name": "Старое заросшее дерево"
     },
     "rct2ww.scenery_large.pagodam": {
         "reference-name": "Pagoda",
@@ -9343,7 +9343,7 @@
     },
     "rct2ww.scenery_large.pagodatw": {
         "reference-name": "Pagoda Tower",
-        "name": "Пагода"
+        "name": "Башня пагоды"
     },
     "rct2ww.scenery_large.pogodal": {
         "reference-name": "Pagoda",
@@ -9351,23 +9351,23 @@
     },
     "rct2ww.scenery_large.radar": {
         "reference-name": "Radar Dish",
-        "name": "Радар"
+        "name": "Тарелка радара"
     },
     "rct2ww.scenery_large.rdrab01": {
         "reference-name": "Drab Large Tower Mid-Section",
-        "name": "Деталь башни"
+        "name": "Средняя секция старой большой башни"
     },
     "rct2ww.scenery_large.rdrab02": {
         "reference-name": "Drab Large Tower Base",
-        "name": "Деталь башни"
+        "name": "Основание старой большой башни"
     },
     "rct2ww.scenery_large.rdrab03": {
         "reference-name": "Drab Large Tower Top",
-        "name": "Деталь башни"
+        "name": "Верх старой большой башни"
     },
     "rct2ww.scenery_large.rdrab04": {
         "reference-name": "Drab Large Tower Broken Base",
-        "name": "Деталь башни"
+        "name": "Сломанное основание старой большой башни"
     },
     "rct2ww.scenery_large.redwood": {
         "reference-name": "Redwood Tree",
@@ -9375,23 +9375,23 @@
     },
     "rct2ww.scenery_large.rkreml08": {
         "reference-name": "Kremlin Large Tower Base",
-        "name": "Кремль"
+        "name": "Основание большой Кремльской башни"
     },
     "rct2ww.scenery_large.rkreml09": {
         "reference-name": "Kremlin Large Tower Top",
-        "name": "Кремль"
+        "name": "Верх большой Кремльской башни"
     },
     "rct2ww.scenery_large.rkreml10": {
         "reference-name": "Kremlin Large Tower Mid-Section",
-        "name": "Кремль"
+        "name": "Средняя секция болшой Кремльской башни"
     },
     "rct2ww.scenery_large.rtudor05": {
         "reference-name": "Tudor Roof Piece 3",
-        "name": "Деталь крыши"
+        "name": "Крыша Тюдора 3"
     },
     "rct2ww.scenery_large.rtudor06": {
         "reference-name": "Tudor Roof Piece 4",
-        "name": "Деталь крыши"
+        "name": "Крыша Тюдора 4"
     },
     "rct2ww.scenery_large.shiva": {
         "reference-name": "Shiva",
@@ -9399,11 +9399,11 @@
     },
     "rct2ww.scenery_large.soflibrt": {
         "reference-name": "Statue of Liberty",
-        "name": "Статуя Свободы"
+        "name": "Статуя свободы"
     },
     "rct2ww.scenery_large.spaceorb": {
         "reference-name": "Space Orbs",
-        "name": "Телескоп"
+        "name": "Космические сферы"
     },
     "rct2ww.scenery_large.sputnik": {
         "reference-name": "Sputnik",
@@ -9411,23 +9411,23 @@
     },
     "rct2ww.scenery_large.sunken": {
         "reference-name": "Sunken Ship",
-        "name": "Корабль"
+        "name": "Утонувший корабль"
     },
     "rct2ww.scenery_large.tajmcbse": {
         "reference-name": "Maharaja Palace Tower Base",
-        "name": "Деталь башни дворца"
+        "name": "Основание башни дворца Махараджа"
     },
     "rct2ww.scenery_large.tajmcolm": {
         "reference-name": "Maharaja Palace Tower Column",
-        "name": "Колонна дворца"
+        "name": "Колонна башни дворца Махараджа"
     },
     "rct2ww.scenery_large.tajmctop": {
         "reference-name": "Maharaja Palace Tower Top",
-        "name": "Крыша дворца"
+        "name": "Крыша дворца Махараджа"
     },
     "rct2ww.scenery_large.tajmdome": {
         "reference-name": "Maharaja Palace Dome",
-        "name": "Купол дворца"
+        "name": "Купол дворца Махараджа"
     },
     "rct2ww.scenery_large.windmill": {
         "reference-name": "Windmill",
@@ -9435,11 +9435,11 @@
     },
     "rct2ww.scenery_small.1x1atre2": {
         "reference-name": "Vine Tree",
-        "name": "Дерево"
+        "name": "Лозовое дерево"
     },
     "rct2ww.scenery_small.1x1atree": {
         "reference-name": "Low Bush",
-        "name": "Куст"
+        "name": "Низкий куст"
     },
     "rct2ww.scenery_small.1x1brang": {
         "reference-name": "Boomerang",
@@ -9447,7 +9447,7 @@
     },
     "rct2ww.scenery_small.1x1didge": {
         "reference-name": "Digeridoo",
-        "name": "Дигериду"
+        "name": "Диджериду"
     },
     "rct2ww.scenery_small.1x1emuxx": {
         "reference-name": "Emu",
@@ -9455,11 +9455,11 @@
     },
     "rct2ww.scenery_small.1x1jugt2": {
         "reference-name": "Small Rainforest Tree 1",
-        "name": "Маленькое дерево"
+        "name": "Маленькое дождевое дерево 1"
     },
     "rct2ww.scenery_small.1x1jugt3": {
         "reference-name": "Small Rainforest Tree 2",
-        "name": "Маленькое дерево"
+        "name": "Маленькое дождевое дерево 2"
     },
     "rct2ww.scenery_small.1x1kanga": {
         "reference-name": "Kangaroo",
@@ -9471,15 +9471,15 @@
     },
     "rct2ww.scenery_small.adpanda": {
         "reference-name": "Adult Panda",
-        "name": "Панда"
+        "name": "Взрослая панда"
     },
     "rct2ww.scenery_small.antilopf": {
         "reference-name": "Antelope Female",
-        "name": "Антилопа"
+        "name": "Антилопа (самка)"
     },
     "rct2ww.scenery_small.antilopm": {
         "reference-name": "Antelope Male",
-        "name": "Антилопа"
+        "name": "Антилопа (самец)"
     },
     "rct2ww.scenery_small.antilopp": {
         "reference-name": "Antelope Pair",
@@ -9487,123 +9487,123 @@
     },
     "rct2ww.scenery_small.babpanda": {
         "reference-name": "Baby Panda",
-        "name": "Панда"
+        "name": "Ребёнок панды"
     },
     "rct2ww.scenery_small.babyele": {
         "reference-name": "Baby Indian Elephant",
-        "name": "Индийский слонёнок"
+        "name": "Ребёнок индийского слона"
     },
     "rct2ww.scenery_small.balllan2": {
         "reference-name": "Ball Lantern",
-        "name": "Лампа"
+        "name": "Шарообразная лампа"
     },
     "rct2ww.scenery_small.balllant": {
         "reference-name": "Ball Lantern",
-        "name": "Лампа"
+        "name": "Шарообразная лампа"
     },
     "rct2ww.scenery_small.bamboobs": {
         "reference-name": "Bamboo Bush",
-        "name": "Бамбук"
+        "name": "Бамбуковый куст"
     },
     "rct2ww.scenery_small.bamboopl": {
         "reference-name": "Bamboo Plinth",
-        "name": "Цоколь"
+        "name": "Бамбуковый плинтус"
     },
     "rct2ww.scenery_small.bstatue1": {
         "reference-name": "Broken Statue",
-        "name": "Статуэтка"
+        "name": "Сломанная статуя"
     },
     "rct2ww.scenery_small.campfani": {
         "reference-name": "Animated Camp Fire",
-        "name": "Костёр"
+        "name": "Движущийся костёр"
     },
     "rct2ww.scenery_small.conveyr1": {
         "reference-name": "Conveyer Belt Corner",
-        "name": "Транспортёр"
+        "name": "Угол конвеера"
     },
     "rct2ww.scenery_small.conveyr2": {
         "reference-name": "Conveyer Belt Rise",
-        "name": "Транспортёр"
+        "name": "Подъем конвеера"
     },
     "rct2ww.scenery_small.conveyr3": {
         "reference-name": "Conveyer Belt End",
-        "name": "Транспортёр"
+        "name": "Конец конвеера"
     },
     "rct2ww.scenery_small.conveyr4": {
         "reference-name": "Conveyer Belt Straight",
-        "name": "Транспортёр"
+        "name": "Прямая секция конвеера"
     },
     "rct2ww.scenery_small.conveyr5": {
         "reference-name": "Conveyer Belt Corner Reverse",
-        "name": "Транспортёр"
+        "name": "Перевёрнутый угол конвеера"
     },
     "rct2ww.scenery_small.fishhole": {
         "reference-name": "Fish Hole",
-        "name": "Рыбалка"
+        "name": "Рыбный пруд"
     },
     "rct2ww.scenery_small.flamngo1": {
         "reference-name": "Flamingo Feeding",
-        "name": "Фламинго"
+        "name": "Фламинго (питающийся)"
     },
     "rct2ww.scenery_small.flamngo2": {
         "reference-name": "Flamingo Looking",
-        "name": "Фламинго"
+        "name": "Фламинго (оглядывающийся)"
     },
     "rct2ww.scenery_small.flamngo3": {
         "reference-name": "Flamingo Preening",
-        "name": "Фламинго"
+        "name": "Фламинго (чистящий перья)"
     },
     "rct2ww.scenery_small.fountarc": {
         "reference-name": "Australian Fountain Set 2",
-        "name": "Австралийский фонтан"
+        "name": "Набор австралийских фонтанов 2"
     },
     "rct2ww.scenery_small.fountrow": {
         "reference-name": "Australian Fountain Set 2",
-        "name": "Австралийский фонтан"
+        "name": "Набор австралийских фонтанов 2"
     },
     "rct2ww.scenery_small.fstatue1": {
         "reference-name": "Fixed Statue",
-        "name": "Статуэтка"
+        "name": "Отремонтированная статуя"
     },
     "rct2ww.scenery_small.g1dancer": {
         "reference-name": "Mardi Gras Dancer",
-        "name": "Танцор Марди Грас"
+        "name": "Танцор Марди Гра"
     },
     "rct2ww.scenery_small.g2dancer": {
         "reference-name": "Mardi Gras Dancer",
-        "name": "Танцор Марди Грас"
+        "name": "Танцор Марди Гра"
     },
     "rct2ww.scenery_small.icebarl1": {
         "reference-name": "Iced Barrels",
-        "name": "Бочки"
+        "name": "Бочки со льдом"
     },
     "rct2ww.scenery_small.icebarl2": {
         "reference-name": "Iced Barrels",
-        "name": "Бочки"
+        "name": "Бочки со льдом"
     },
     "rct2ww.scenery_small.icebarl3": {
         "reference-name": "Iced Barrels",
-        "name": "Бочки"
+        "name": "Бочки со льдом"
     },
     "rct2ww.scenery_small.inflag01": {
         "reference-name": "Indian Silk Flag",
-        "name": "Индийский флаг"
+        "name": "Шёлоквый индийский флаг"
     },
     "rct2ww.scenery_small.inflag02": {
         "reference-name": "Indian Silk Flag",
-        "name": "Индийский флаг"
+        "name": "Шёлоквый индийский флаг"
     },
     "rct2ww.scenery_small.inflag03": {
         "reference-name": "Indian Silk Flag",
-        "name": "Индийский флаг"
+        "name": "Шёлоквый индийский флаг"
     },
     "rct2ww.scenery_small.inflag04": {
         "reference-name": "Indian Silk Flag",
-        "name": "Индийский флаг"
+        "name": "Шёлоквый индийский флаг"
     },
     "rct2ww.scenery_small.inflag05": {
         "reference-name": "Indian Silk Flag",
-        "name": "Индийский флаг"
+        "name": "Шёлоквый индийский флаг"
     },
     "rct2ww.scenery_small.inuit": {
         "reference-name": "Inuit",
@@ -9615,51 +9615,51 @@
     },
     "rct2ww.scenery_small.jachtree": {
         "reference-name": "Japanese Cherry Tree",
-        "name": "Сакура"
+        "name": "Японское вишнёвое дерево"
     },
     "rct2ww.scenery_small.japchblo": {
         "reference-name": "Japanese Cherry Blossom Tree",
-        "name": "Сакура в цвету"
+        "name": "Сакура"
     },
     "rct2ww.scenery_small.jappintr": {
         "reference-name": "Japanese Pine Tree",
-        "name": "Сосна"
+        "name": "Японская сосна"
     },
     "rct2ww.scenery_small.japsnotr": {
         "reference-name": "Japanese Snowball Tree",
-        "name": "Снежное дерево"
+        "name": "Заснеженное японское дерево"
     },
     "rct2ww.scenery_small.jpflag01": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.jpflag02": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.jpflag03": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.jpflag04": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.jpflag05": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.jpflag06": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Шёлковый флаг"
+        "name": "Шёлковый японский флаг"
     },
     "rct2ww.scenery_small.oilpump": {
         "reference-name": "Oil Pump",
-        "name": "Насос"
+        "name": "Нефтяной насос"
     },
     "rct2ww.scenery_small.oriegong": {
         "reference-name": "Asian Gong",
-        "name": "Гонг"
+        "name": "Азиатский гонг"
     },
     "rct2ww.scenery_small.pcg": {
         "reference-name": "Pipe",
@@ -9671,15 +9671,15 @@
     },
     "rct2ww.scenery_small.pipebase": {
         "reference-name": "Ice Pipe Base",
-        "name": "Труба"
+        "name": "Основа ледяной трубы"
     },
     "rct2ww.scenery_small.pipevent": {
         "reference-name": "Ice Pipe Vent",
-        "name": "Труба"
+        "name": "Вентиляционное отверстие ледяной трубы"
     },
     "rct2ww.scenery_small.postbox": {
         "reference-name": "British Post Box",
-        "name": "Почтовый ящик"
+        "name": "Британскйи почтовый ящик"
     },
     "rct2ww.scenery_small.pst": {
         "reference-name": "Pipe",
@@ -9699,267 +9699,267 @@
     },
     "rct2ww.scenery_small.rbrick01": {
         "reference-name": "Red Brick Inverted Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Перевёрнутая крыша из красного кирпича"
     },
     "rct2ww.scenery_small.rbrick02": {
         "reference-name": "Red Brick Corner Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Угол крыши из красного кирпича"
     },
     "rct2ww.scenery_small.rbrick03": {
         "reference-name": "Red Brick Flat Roof Edge Piece",
-        "name": "Деталь крыши"
+        "name": "Плоский край крыши из красного кирпича"
     },
     "rct2ww.scenery_small.rbrick04": {
         "reference-name": "Red Brick Flat Roof Corner",
-        "name": "Деталь крыши"
+        "name": "Плоский угол крыши из красного кирпича"
     },
     "rct2ww.scenery_small.rbrick05": {
         "reference-name": "Red Brick Roof Piece 2",
-        "name": "Деталь крыши"
+        "name": "Часть красной кирпичной крыши 2"
     },
     "rct2ww.scenery_small.rbrick07": {
         "reference-name": "Red Brick Roof Piece 3",
-        "name": "Деталь крыши"
+        "name": "Часть красной кирпичной крыши 3"
     },
     "rct2ww.scenery_small.rbrick08": {
         "reference-name": "Red Brick Roof Piece 1",
-        "name": "Деталь крыши"
+        "name": "Часть красной кирпичной крыши 1"
     },
     "rct2ww.scenery_small.rcorr01": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr02": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr03": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr04": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr05": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr07": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr08": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr09": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr10": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rcorr11": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Рифлёная крыша"
     },
     "rct2ww.scenery_small.rdrab05": {
         "reference-name": "Drab Small Tower Minaret Base",
-        "name": "Деталь башни"
+        "name": "Основание старого минарета"
     },
     "rct2ww.scenery_small.rdrab06": {
         "reference-name": "Drab Small Tower Top or Mid-Section",
-        "name": "Деталь башни"
+        "name": "Верх или середина старой башни"
     },
     "rct2ww.scenery_small.rdrab07": {
         "reference-name": "Drab Small Tower Base",
-        "name": "Деталь башни"
+        "name": "Основание старой башни"
     },
     "rct2ww.scenery_small.rdrab08": {
         "reference-name": "Drab Minaret Piece 1",
-        "name": "Деталь Минарета"
+        "name": "Старый минарет 1"
     },
     "rct2ww.scenery_small.rdrab09": {
         "reference-name": "Drab Minaret Piece 2",
-        "name": "Деталь Минарета"
+        "name": "Старый минарет 2"
     },
     "rct2ww.scenery_small.rdrab10": {
         "reference-name": "Drab Minaret Piece 3",
-        "name": "Деталь Минарета"
+        "name": "Старый минарет 3"
     },
     "rct2ww.scenery_small.rdrab11": {
         "reference-name": "Drab Roof Piece 1",
-        "name": "Деталь крыши"
+        "name": "Старая крыша 1"
     },
     "rct2ww.scenery_small.rdrab12": {
         "reference-name": "Drab Roof Piece 2",
-        "name": "Деталь крыши"
+        "name": "Старая крыша 2"
     },
     "rct2ww.scenery_small.rdrab13": {
         "reference-name": "Drab Roof Piece 3",
-        "name": "Деталь крыши"
+        "name": "Старая крыша 3"
     },
     "rct2ww.scenery_small.rdrab14": {
         "reference-name": "Drab Roof Piece 4",
-        "name": "Деталь крыши"
+        "name": "Старая крыша 4"
     },
     "rct2ww.scenery_small.rgeorg01": {
         "reference-name": "Georgian Roof End Piece 1",
-        "name": "Деталь крыши"
+        "name": "Конец грузинской крыши 1"
     },
     "rct2ww.scenery_small.rgeorg02": {
         "reference-name": "Georgian Roof End Piece 2",
-        "name": "Деталь крыши"
+        "name": "Конец грузинской крыши 2"
     },
     "rct2ww.scenery_small.rgeorg03": {
         "reference-name": "Georgian Roof Piece 1",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 1"
     },
     "rct2ww.scenery_small.rgeorg04": {
         "reference-name": "Georgian Roof Piece 2",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 2"
     },
     "rct2ww.scenery_small.rgeorg05": {
         "reference-name": "Georgian Roof Piece 3",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 3"
     },
     "rct2ww.scenery_small.rgeorg06": {
         "reference-name": "Georgian Roof Piece 4",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 4"
     },
     "rct2ww.scenery_small.rgeorg07": {
         "reference-name": "Georgian Roof Piece 5",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 5"
     },
     "rct2ww.scenery_small.rgeorg08": {
         "reference-name": "Georgian Ground Floor Wall Piece 7",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 7"
     },
     "rct2ww.scenery_small.rgeorg09": {
         "reference-name": "Georgian Flat Roof Edge 1",
-        "name": "Georgian Flat Roof Edge 1"
+        "name": "Плоский край грузинской крыши 1"
     },
     "rct2ww.scenery_small.rgeorg10": {
         "reference-name": "Georgian Flat Roof Edge 2",
-        "name": "Деталь крыши"
+        "name": "Плоский край грузинской крыши 2"
     },
     "rct2ww.scenery_small.rgeorg11": {
         "reference-name": "Georgian Flat Roof Corner",
-        "name": "Деталь крыши"
+        "name": "Плоский угол грузинской крыши"
     },
     "rct2ww.scenery_small.rgeorg12": {
         "reference-name": "Georgian Roof Piece 7",
-        "name": "Деталь крыши"
+        "name": "Грузинская крыша 7"
     },
     "rct2ww.scenery_small.rkreml01": {
         "reference-name": "Kremlin Minaret Piece 1",
-        "name": "Кремль"
+        "name": "Кремлёвский минарет 1"
     },
     "rct2ww.scenery_small.rkreml02": {
         "reference-name": "Kremlin Minaret Piece 2",
-        "name": "Кремль"
+        "name": "Кремлёвский минарет 2"
     },
     "rct2ww.scenery_small.rkreml03": {
         "reference-name": "Kremlin Minaret Piece 3",
-        "name": "Кремль"
+        "name": "Кремлёвский минарет 3"
     },
     "rct2ww.scenery_small.rkreml04": {
         "reference-name": "Kremlin Roof Piece 1",
-        "name": "Кремль"
+        "name": "Кремлёвская крыша 1"
     },
     "rct2ww.scenery_small.rkreml05": {
         "reference-name": "Kremlin Roof Piece 2",
-        "name": "Кремль"
+        "name": "Кремлёвская крыша 2"
     },
     "rct2ww.scenery_small.rkreml06": {
         "reference-name": "Kremlin Small Tower Mid-Section",
-        "name": "Кремль"
+        "name": "Середина маленькой кремлёвская башни"
     },
     "rct2ww.scenery_small.rkreml07": {
         "reference-name": "Kremlin Small Tower Base",
-        "name": "Кремль"
+        "name": "Основание маленькой кремлёвской башни"
     },
     "rct2ww.scenery_small.rkreml11": {
         "reference-name": "Kremlin Small Tower Minaret Base",
-        "name": "Кремль"
+        "name": "Основание маленького кремлёвского минарета"
     },
     "rct2ww.scenery_small.rlog01": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша деревянной кабины"
     },
     "rct2ww.scenery_small.rlog02": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша деревянной кабины"
     },
     "rct2ww.scenery_small.rlog03": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь крыши"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_small.rlog04": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь крыши"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_small.rlog05": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша деревянной кабины"
     },
     "rct2ww.scenery_small.rmarble1": {
         "reference-name": "Marble Roof",
-        "name": "Крыша"
+        "name": "Мраморная крыша"
     },
     "rct2ww.scenery_small.rmarble2": {
         "reference-name": "Marble Roof",
-        "name": "Крыша"
+        "name": "Мраморная крыша"
     },
     "rct2ww.scenery_small.rmarble3": {
         "reference-name": "Marble Roof",
-        "name": "Крыша"
+        "name": "Мраморная крыша"
     },
     "rct2ww.scenery_small.rmarble4": {
         "reference-name": "Marble Roof",
-        "name": "Крыша"
+        "name": "Мраморная крыша"
     },
     "rct2ww.scenery_small.rmud01": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Наклонная стена из грязи"
     },
     "rct2ww.scenery_small.rmud02": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Наклонная стена из грязи"
     },
     "rct2ww.scenery_small.rmud03": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Наклонная стена из грязи"
     },
     "rct2ww.scenery_small.rmud05": {
         "reference-name": "Wattle & Daub Roof",
-        "name": "Крыша"
+        "name": "Крыша Wattle & Daub"
     },
     "rct2ww.scenery_small.roofice1": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofice2": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofice3": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofice4": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofice5": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofice6": {
         "reference-name": "Ice Roof",
-        "name": "Крыша"
+        "name": "Ледяная крыша"
     },
     "rct2ww.scenery_small.roofig01": {
         "reference-name": "Igloo Wall",
@@ -9983,63 +9983,63 @@
     },
     "rct2ww.scenery_small.rshogi1": {
         "reference-name": "Japanese Roof",
-        "name": "Крыша"
+        "name": "Японская крыша"
     },
     "rct2ww.scenery_small.rshogi2": {
         "reference-name": "Japanese Roof",
-        "name": "Крыша"
+        "name": "Японская крыша"
     },
     "rct2ww.scenery_small.rshogi3": {
         "reference-name": "Japanese Roof",
-        "name": "Крыша"
+        "name": "Японская крыша"
     },
     "rct2ww.scenery_small.rtudor01": {
         "reference-name": "Tudor Roof Piece 1",
-        "name": "Деталь крыши"
+        "name": "Крыша Тюдора 1"
     },
     "rct2ww.scenery_small.rtudor02": {
         "reference-name": "Tudor Roof Piece 1 Extender Piece",
-        "name": "Деталь крыши"
+        "name": "Удлинитель крыши Тюдора 1"
     },
     "rct2ww.scenery_small.rtudor03": {
         "reference-name": "Tudor Roof Piece 2",
-        "name": "Деталь крыши"
+        "name": "Крыша Тюдора 2"
     },
     "rct2ww.scenery_small.rwdaub01": {
         "reference-name": "Wattle & Daub Roof",
-        "name": "Крыша"
+        "name": "Крыша Wattle & Daub"
     },
     "rct2ww.scenery_small.rwdaub02": {
         "reference-name": "Wattle & Daub Roof",
-        "name": "Крыша"
+        "name": "Крыша Wattle & Daub"
     },
     "rct2ww.scenery_small.rwdaub03": {
         "reference-name": "Wattle & Daub Roof",
-        "name": "Крыша"
+        "name": "Крыша Wattle & Daub"
     },
     "rct2ww.scenery_small.sb1hspb1": {
         "reference-name": "Suspension Bridge Base Piece",
-        "name": "Подвесной Мостик"
+        "name": "Основание подвесного моста"
     },
     "rct2ww.scenery_small.sb1hspb2": {
         "reference-name": "Suspension Bridge Base Spacer Piece",
-        "name": "Подвесной Мостик"
+        "name": "Широкое основание подвесного моста"
     },
     "rct2ww.scenery_small.sb1hspb3": {
         "reference-name": "Suspension Bridge Mid Section Piece",
-        "name": "Подвесной Мостик"
+        "name": "Средняя секция подвесного моста"
     },
     "rct2ww.scenery_small.sb2palm1": {
         "reference-name": "Cabana Porch",
-        "name": "Крыльцо"
+        "name": "Крыльцо кабаны"
     },
     "rct2ww.scenery_small.sb2sky01": {
         "reference-name": "Stone Skyscraper Stairway Base",
-        "name": "Деталь небоскрёба"
+        "name": "Основание лестницы каменного небоскрёба"
     },
     "rct2ww.scenery_small.sballoon": {
         "reference-name": "Animated Balloons",
-        "name": "Шарики"
+        "name": "Движущиеся шарики"
     },
     "rct2ww.scenery_small.sbh1tepe": {
         "reference-name": "Tee Pee",
@@ -10047,7 +10047,7 @@
     },
     "rct2ww.scenery_small.sbh1wgwh": {
         "reference-name": "Wagon Wheel",
-        "name": "Колесо"
+        "name": "Колесо вагонетки"
     },
     "rct2ww.scenery_small.sbh2shlt": {
         "reference-name": "Search Light",
@@ -10067,11 +10067,11 @@
     },
     "rct2ww.scenery_small.sbh3cskl": {
         "reference-name": "Cattle Skull",
-        "name": "Череп"
+        "name": "Череп животного"
     },
     "rct2ww.scenery_small.sbh3oscr": {
         "reference-name": "Rollercoaster Award Statue",
-        "name": "Статуэтка Роллеркоастер"
+        "name": "Статуя награды парка"
     },
     "rct2ww.scenery_small.sbh3plm1": {
         "reference-name": "Palm Tree",
@@ -10087,19 +10087,19 @@
     },
     "rct2ww.scenery_small.sbh3rt66": {
         "reference-name": "Route 66 Sign",
-        "name": "‘Трасса 66’"
+        "name": "Знак \"Route 66\""
     },
     "rct2ww.scenery_small.sbh4totm": {
         "reference-name": "Large Totem Pole",
-        "name": "Большой Тотем"
+        "name": "Большой тотем"
     },
     "rct2ww.scenery_small.sbskys01": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена небоскрёба из камня"
     },
     "rct2ww.scenery_small.sbskys02": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Деталь небесной стены"
+        "name": "Стена небоскрёба из камня"
     },
     "rct2ww.scenery_small.sbskys03": {
         "reference-name": "Skyscraper Lift Piece",
@@ -10111,135 +10111,135 @@
     },
     "rct2ww.scenery_small.sbskys05": {
         "reference-name": "Skyscraper Metal Set 1 Convex Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Выгнутая металлическая деталь небоскрёба 1"
     },
     "rct2ww.scenery_small.sbskys06": {
         "reference-name": "Skyscraper Metal Set 1 Concave Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Вогнутая металлическая деталь небоскрёба 1"
     },
     "rct2ww.scenery_small.sbskys07": {
         "reference-name": "Skyscraper Metal Set 2 Convex Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Выгнутая металлическая деталь небоскрёба 2"
     },
     "rct2ww.scenery_small.sbskys08": {
         "reference-name": "Skyscraper Metal Set 2 Concave Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Вогнутая металлическая деталь небоскрёба 1"
     },
     "rct2ww.scenery_small.sbskys09": {
         "reference-name": "Skyscraper Metal Set 2 Concave Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Вогнутая металлическая деталь небоскрёба 1"
     },
     "rct2ww.scenery_small.sbskys10": {
         "reference-name": "Skyscraper Concave Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Вогнутая деталь небоскрёба"
     },
     "rct2ww.scenery_small.sbskys11": {
         "reference-name": "Skyscraper Concave Roof",
-        "name": "Деталь крыши небоскрёба"
+        "name": "Вогнутая крыша небосркёба"
     },
     "rct2ww.scenery_small.sbskys12": {
         "reference-name": "Skyscraper Convex Piece",
-        "name": "Деталь небоскрёба"
+        "name": "Выгнутая деталь небоскрёба"
     },
     "rct2ww.scenery_small.sbskys13": {
         "reference-name": "Skyscraper Convex Roof",
-        "name": "Деталь крыши"
+        "name": "Выгнутая крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbskys14": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbskys15": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbskys16": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbskys17": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbskys18": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша небоскрёба"
     },
     "rct2ww.scenery_small.sbwind01": {
         "reference-name": "Wind Sculpted Concave Wall Corner",
-        "name": "Деталь стены"
+        "name": "Вогнутый угол ветренной стены"
     },
     "rct2ww.scenery_small.sbwind02": {
         "reference-name": "Wind Sculpted Concave Roof Corner",
-        "name": "Деталь крыши"
+        "name": "Вогнутый угол ветренной крыши"
     },
     "rct2ww.scenery_small.sbwind03": {
         "reference-name": "Wind Sculpted Concave Wall Corner",
-        "name": "Деталь стены"
+        "name": "Вогнутый угол ветренной стены"
     },
     "rct2ww.scenery_small.sbwind04": {
         "reference-name": "Wind Sculpted Convex Wall Corner",
-        "name": "Деталь стены"
+        "name": "Выгнутый угол ветренной стены"
     },
     "rct2ww.scenery_small.sbwind05": {
         "reference-name": "Wind Sculpted Convex Roof Corner",
-        "name": "Деталь крыши"
+        "name": "Выгнутый угол ветренной крыши"
     },
     "rct2ww.scenery_small.sbwind06": {
         "reference-name": "Wind Sculpted Convex Wall Corner",
-        "name": "Деталь стены"
+        "name": "Выгнутый угол ветренной стены"
     },
     "rct2ww.scenery_small.sbwind07": {
         "reference-name": "Wind Sculpted Rock Formation Base",
-        "name": "Деталь"
+        "name": "Оснвание ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind08": {
         "reference-name": "Wind Sculpted Rock Formation Base",
-        "name": "Деталь"
+        "name": "Оснвание ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind09": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Деталь"
+        "name": "Средняя секция ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind10": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Деталь"
+        "name": "Средняя секция ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind11": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Деталь"
+        "name": "Средняя секция ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind12": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Деталь"
+        "name": "Средняя секция ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind13": {
         "reference-name": "Wind Sculpted Rock Formation Top",
-        "name": "Деталь"
+        "name": "Верх ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind14": {
         "reference-name": "Wind Sculpted Rock Formation Top",
-        "name": "Деталь"
+        "name": "Верх ветренной каменной формации"
     },
     "rct2ww.scenery_small.sbwind15": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская ветренная крыша"
     },
     "rct2ww.scenery_small.sbwind16": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская ветренная крыша"
     },
     "rct2ww.scenery_small.sbwind17": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская ветренная крыша"
     },
     "rct2ww.scenery_small.sbwind18": {
         "reference-name": "Wind Sculpted Floor Piece",
-        "name": "Деталь Пола"
+        "name": "Ветренный пол"
     },
     "rct2ww.scenery_small.sbwind19": {
         "reference-name": "Wind Sculpted Floor Piece",
-        "name": "Деталь Пола"
+        "name": "Ветренный пол"
     },
     "rct2ww.scenery_small.sbwind20": {
         "reference-name": "Wind Sculpted Wall Base",
@@ -10247,991 +10247,991 @@
     },
     "rct2ww.scenery_small.sbwind21": {
         "reference-name": "Wind Sculpted Wall Base",
-        "name": "Деталь стены"
+        "name": "Основание ветренной стены"
     },
     "rct2ww.scenery_small.sbwplm01": {
         "reference-name": "Cabana Top",
-        "name": "Верх"
+        "name": "Верх кабаны"
     },
     "rct2ww.scenery_small.sbwplm02": {
         "reference-name": "Cabana Porch",
-        "name": "Крыльцо"
+        "name": "Крыльцо кабаны"
     },
     "rct2ww.scenery_small.sbwplm03": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша кабаны"
     },
     "rct2ww.scenery_small.sbwplm04": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша кабаны"
     },
     "rct2ww.scenery_small.sbwplm05": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша кабаны"
     },
     "rct2ww.scenery_small.sbwplm06": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_small.sbwplm07": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_small.sbwplm08": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_small.smallgeo": {
         "reference-name": "Small Geosphere",
-        "name": "Геосфера"
+        "name": "Маленькая геосфера"
     },
     "rct2ww.scenery_small.talllan1": {
         "reference-name": "Tall Lantern",
-        "name": "Лампа"
+        "name": "Высокая лампа"
     },
     "rct2ww.scenery_small.talllan2": {
         "reference-name": "Tall Lantern",
-        "name": "Лампа"
+        "name": "Высокая лампа"
     },
     "rct2ww.scenery_small.terrarmy": {
         "reference-name": "Terracotta Army",
-        "name": "Солдаты"
+        "name": "Армия из терракоты"
     },
     "rct2ww.scenery_small.tjblock1": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Деталь дворца"
+        "name": "Дворец Махараджа"
     },
     "rct2ww.scenery_small.tjblock2": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Деталь дворца"
+        "name": "Дворец Махараджа"
     },
     "rct2ww.scenery_small.tjblock3": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Деталь дворца"
+        "name": "Дворец Махараджа"
     },
     "rct2ww.scenery_small.tnt1": {
         "reference-name": "TNT Stack",
-        "name": "Куча ТНТ"
+        "name": "Стек TNT"
     },
     "rct2ww.scenery_small.tnt2": {
         "reference-name": "TNT Barrels",
-        "name": "Бочки ТНТ"
+        "name": "Бочки с TNT"
     },
     "rct2ww.scenery_small.tnt3": {
         "reference-name": "TNT Detonator",
-        "name": "Детонатор ТНТ"
+        "name": "Детонатор TNT"
     },
     "rct2ww.scenery_small.tnt4": {
         "reference-name": "TNT Crates",
-        "name": "ТНТ"
+        "name": "Ящики TNT"
     },
     "rct2ww.scenery_small.trckprt1": {
         "reference-name": "Diamond Cart",
-        "name": "Вагонетка"
+        "name": "Вагонетка с алмазами"
     },
     "rct2ww.scenery_small.trckprt2": {
         "reference-name": "Empty Cart",
-        "name": "Вагонетка"
+        "name": "Пустая вагонетка"
     },
     "rct2ww.scenery_small.trckprt3": {
         "reference-name": "Diamond Shaft",
-        "name": "Ствол"
+        "name": "Алмазный вал"
     },
     "rct2ww.scenery_small.trckprt4": {
         "reference-name": "Cart Shaft",
-        "name": "Карт"
+        "name": "Вал тележки"
     },
     "rct2ww.scenery_small.trckprt5": {
         "reference-name": "Track Bend",
-        "name": "Трек"
+        "name": "Изгиб трека"
     },
     "rct2ww.scenery_small.trckprt6": {
         "reference-name": "Track Broke",
-        "name": "Трек"
+        "name": "Сломанный трек"
     },
     "rct2ww.scenery_small.trckprt7": {
         "reference-name": "Track End",
-        "name": "Трек"
+        "name": "Конец трека"
     },
     "rct2ww.scenery_small.trckprt8": {
         "reference-name": "Track Split",
-        "name": "Трек"
+        "name": "Разветвление трека"
     },
     "rct2ww.scenery_small.trckprt9": {
         "reference-name": "Track Straight",
-        "name": "Трек"
+        "name": "Прямой участок трека"
     },
     "rct2ww.scenery_small.ukphone": {
         "reference-name": "British Telephone Box",
-        "name": "Телефонная будка"
+        "name": "Британская телефонная будка"
     },
     "rct2ww.scenery_small.vertpipe": {
         "reference-name": "Ice Pipe Section",
-        "name": "Труба"
+        "name": "Секция ледяной трубы"
     },
     "rct2ww.scenery_small.waborg01": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg02": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg03": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg04": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg05": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg06": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg07": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waborg08": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Местный сувенир"
+        "name": "Аборигенская выставка"
     },
     "rct2ww.scenery_small.waztec01": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec02": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec03": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec04": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec05": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec06": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec07": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec08": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec09": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec10": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec11": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены храма"
     },
     "rct2ww.scenery_small.waztec12": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены храма"
     },
     "rct2ww.scenery_small.waztec13": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь крыши"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec14": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь крыши"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec15": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec16": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec17": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec18": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec19": {
         "reference-name": "Temple Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Крыша храма"
     },
     "rct2ww.scenery_small.waztec20": {
         "reference-name": "Temple Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени храма"
     },
     "rct2ww.scenery_small.waztec21": {
         "reference-name": "Temple Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени храма"
     },
     "rct2ww.scenery_small.waztec22": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec23": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec24": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec25": {
         "reference-name": "Temple Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена храма"
     },
     "rct2ww.scenery_small.waztec26": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Деталь стены храма"
+        "name": "Угол стены храма"
     },
     "rct2ww.scenery_small.waztec27": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Деталь стены храма"
+        "name": "Угол стены храма"
     },
     "rct2ww.scenery_small.wcuzco01": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco02": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco03": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco04": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco05": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco06": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco07": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco08": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco09": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco10": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco11": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco12": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco13": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco14": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco15": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco16": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco17": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco18": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzco19": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени памятника"
     },
     "rct2ww.scenery_small.wcuzco20": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени памятника"
     },
     "rct2ww.scenery_small.wcuzco21": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены памятника"
     },
     "rct2ww.scenery_small.wcuzco22": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены памятника"
     },
     "rct2ww.scenery_small.wcuzco23": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены памятника"
     },
     "rct2ww.scenery_small.wcuzco24": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены памятника"
     },
     "rct2ww.scenery_small.wcuzco25": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени памятника"
     },
     "rct2ww.scenery_small.wcuzco26": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени памятника"
     },
     "rct2ww.scenery_small.wcuzco27": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена памятника"
     },
     "rct2ww.scenery_small.wcuzco28": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Деталь стены"
+        "name": "Сломанная стена памятника"
     },
     "rct2ww.scenery_small.wcuzfoun": {
         "reference-name": "Monumental Fountain",
-        "name": "Фонтан"
+        "name": "Памятный фонтан"
     },
     "rct2ww.scenery_small.wdrab09": {
         "reference-name": "Drab Step-up Piece 1",
-        "name": "Деталь"
+        "name": "Старая ступень 1"
     },
     "rct2ww.scenery_small.wdrab10": {
         "reference-name": "Drab Wall Piece 9",
-        "name": "Деталь стены"
+        "name": "Старая стена 9"
     },
     "rct2ww.scenery_small.wdrab11": {
         "reference-name": "Drab Wall Piece 10",
-        "name": "Деталь стены"
+        "name": "Старая стена 10"
     },
     "rct2ww.scenery_small.wdrab12": {
         "reference-name": "Drab Wall Piece 11",
-        "name": "Деталь стены"
+        "name": "Старая стена 11"
     },
     "rct2ww.scenery_small.wdrab13": {
         "reference-name": "Drab Step-up Piece 2",
-        "name": "Деталь"
+        "name": "Старая ступень 2"
     },
     "rct2ww.scenery_small.wgeorg07": {
         "reference-name": "Georgian Ground Floor Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 4"
     },
     "rct2ww.scenery_small.wgeorg08": {
         "reference-name": "Georgian Ground Floor Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 5"
     },
     "rct2ww.scenery_small.wgeorg09": {
         "reference-name": "Georgian Ground Floor Wall Piece 6",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 6"
     },
     "rct2ww.scenery_small.wgeorg10": {
         "reference-name": "Georgian Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 4"
     },
     "rct2ww.scenery_small.wgeorg11": {
         "reference-name": "Georgian Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 5"
     },
     "rct2ww.scenery_small.wgeorg12": {
         "reference-name": "Georgian Wall Piece 6",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 6"
     },
     "rct2ww.scenery_small.wkreml01": {
         "reference-name": "Kremlin Step-up Wall Piece 1",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская ступень 1"
     },
     "rct2ww.scenery_small.wkreml02": {
         "reference-name": "Kremlin Step-up Wall Piece 2",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская ступень 2"
     },
     "rct2ww.scenery_small.wkreml03": {
         "reference-name": "Kremlin Wall Piece 1",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 1"
     },
     "rct2ww.scenery_small.wkreml04": {
         "reference-name": "Kremlin Wall Piece 2",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 2"
     },
     "rct2ww.scenery_small.wkreml05": {
         "reference-name": "Kremlin Wall Piece 3",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 3"
     },
     "rct2ww.scenery_small.wkreml06": {
         "reference-name": "Kremlin Wall Piece 4",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 4"
     },
     "rct2ww.scenery_small.wmayan01": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan02": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская крыша потерянного города"
     },
     "rct2ww.scenery_small.wmayan03": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan04": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan05": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan06": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan07": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan08": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan09": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan10": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь Ступеней"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan11": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь Ступеней"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan12": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени потерянного города"
     },
     "rct2ww.scenery_small.wmayan13": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени потерянного города"
     },
     "rct2ww.scenery_small.wmayan14": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени потерянного города"
     },
     "rct2ww.scenery_small.wmayan15": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени потерянного города"
     },
     "rct2ww.scenery_small.wmayan16": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Деталь Ступеней"
+        "name": "Ступени потерянного города"
     },
     "rct2ww.scenery_small.wmayan17": {
         "reference-name": "Lost City Column Piece",
-        "name": "Деталь Колонны"
+        "name": "Колонна потерянного города"
     },
     "rct2ww.scenery_small.wmayan18": {
         "reference-name": "Lost City Column Piece",
-        "name": "Деталь колонны"
+        "name": "Колонна потерянного города"
     },
     "rct2ww.scenery_small.wmayan20": {
         "reference-name": "Lost City Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена потерянного города"
     },
     "rct2ww.scenery_small.wmayan21": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская крыша потерянного города"
     },
     "rct2ww.scenery_small.wmayan22": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Плоская крыша потерянного города"
     },
     "rct2ww.scenery_small.wmayan23": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены потерянного города"
     },
     "rct2ww.scenery_small.wmayan24": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены потерянного города"
     },
     "rct2ww.scenery_small.wmayan25": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены потерянного города"
     },
     "rct2ww.scenery_small.wmayan26": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Деталь стены"
+        "name": "Угол стены потерянного города"
     },
     "rct2ww.scenery_small.wnauti01": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Морская крыша"
     },
     "rct2ww.scenery_small.wnauti02": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Морская крыша"
     },
     "rct2ww.scenery_small.wnauti03": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Морская крыша"
     },
     "rct2ww.scenery_small.wnauti04": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Морская крыша"
     },
     "rct2ww.scenery_small.wnauti05": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Деталь крыши"
+        "name": "Морская крыша"
     },
     "rct2ww.scenery_small.wropecor": {
         "reference-name": "Nautical Corner Roof Railing",
-        "name": "Перила крыши"
+        "name": "Перила угла морской крыши"
     },
     "rct2ww.scenery_small.wropeswa": {
         "reference-name": "Nautical Roof Railing",
-        "name": "Перила крыши"
+        "name": "Перила морской крыши"
     },
     "rct2ww.scenery_small.wtudor12": {
         "reference-name": "Tudor Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Стена Тюдора 4"
     },
     "rct2ww.scenery_small.wtudor13": {
         "reference-name": "Tudor Ground Bay Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена причала Тюдора"
     },
     "rct2ww.scenery_small.wtudor14": {
         "reference-name": "Tudor Ground Floor Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 1"
     },
     "rct2ww.scenery_small.wtudor15": {
         "reference-name": "Tudor Ground Floor Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 2"
     },
     "rct2ww.scenery_small.wtudor16": {
         "reference-name": "Tudor Ground Floor Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 3"
     },
     "rct2ww.scenery_small.wtudor17": {
         "reference-name": "Tudor Ground Floor Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 4"
     },
     "rct2ww.scenery_small.wtudor18": {
         "reference-name": "Tudor Ground Floor Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 5"
     },
     "rct2ww.scenery_wall.tmarch1": {
         "reference-name": "Maharaja Palace Arch 1",
-        "name": "Арка дворца магараджей"
+        "name": "Арка дворца Махараджа 1"
     },
     "rct2ww.scenery_wall.tmarch2": {
         "reference-name": "Maharaja Palace Arch 2",
-        "name": "Арка дворца магараджей"
+        "name": "Арка дворца Махараджа 2"
     },
     "rct2ww.scenery_wall.w2corr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w2corr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.w3corr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wallic10": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice1": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice2": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice3": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice4": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice5": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice6": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice7": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice8": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallice9": {
         "reference-name": "Ice Wall",
-        "name": "Стена"
+        "name": "Ледяная стена"
     },
     "rct2ww.scenery_wall.wallna01": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna02": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna03": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna04": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna05": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna06": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna07": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna08": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna09": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna10": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name":"Морская стена"
     },
     "rct2ww.scenery_wall.wallna11": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna12": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna13": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wallna14": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Деталь стены"
+        "name": "Морская стена"
     },
     "rct2ww.scenery_wall.wbambo01": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo02": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo03": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo04": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo05": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo11": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo12": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo13": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo14": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo15": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambo21": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbambopc": {
         "reference-name": "Bamboo Wall",
-        "name": "Стена"
+        "name": "Бамбуковая стена"
     },
     "rct2ww.scenery_wall.wbrick01": {
         "reference-name": "Red Brick Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 1"
     },
     "rct2ww.scenery_wall.wbrick02": {
         "reference-name": "Red Brick Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 2"
     },
     "rct2ww.scenery_wall.wbrick03": {
         "reference-name": "Red Brick Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 3"
     },
     "rct2ww.scenery_wall.wbrick04": {
         "reference-name": "Red Brick Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 4"
     },
     "rct2ww.scenery_wall.wbrick05": {
         "reference-name": "Red Brick Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 5"
     },
     "rct2ww.scenery_wall.wbrick08": {
         "reference-name": "Red Brick Wall Piece 8",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 8"
     },
     "rct2ww.scenery_wall.wbrick11": {
         "reference-name": "Red Brick Wall Piece 11",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 11"
     },
     "rct2ww.scenery_wall.wbrick12": {
         "reference-name": "Red Brick Wall Piece 12",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 12"
     },
     "rct2ww.scenery_wall.wbrick13": {
         "reference-name": "Red Brick Wall Piece 13",
-        "name": "Деталь стены"
+        "name": "Кирпичная стена 13"
     },
     "rct2ww.scenery_wall.wcorr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr09": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr10": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr11": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr12": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr13": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr14": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr15": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wcorr16": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Деталь стены"
+        "name": "Рифлёная стена"
     },
     "rct2ww.scenery_wall.wdrab01": {
         "reference-name": "Drab Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Старая стена 1"
     },
     "rct2ww.scenery_wall.wdrab02": {
         "reference-name": "Drab Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Старая стена 2"
     },
     "rct2ww.scenery_wall.wdrab03": {
         "reference-name": "Drab Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Старая стена 3"
     },
     "rct2ww.scenery_wall.wdrab04": {
         "reference-name": "Drab Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Старая стена 4"
     },
     "rct2ww.scenery_wall.wdrab05": {
         "reference-name": "Drab Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Старая стена 5"
     },
     "rct2ww.scenery_wall.wdrab06": {
         "reference-name": "Drab Wall Piece 6",
-        "name": "Деталь стены"
+        "name": "Старая стена 6"
     },
     "rct2ww.scenery_wall.wdrab07": {
         "reference-name": "Drab Wall Piece 7",
-        "name": "Деталь стены"
+        "name": "Старая стена 7"
     },
     "rct2ww.scenery_wall.wdrab08": {
         "reference-name": "Drab Wall Piece 8",
-        "name": "Деталь стены"
+        "name": "Старая стена 8"
     },
     "rct2ww.scenery_wall.wgeorg01": {
         "reference-name": "Georgian Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 1"
     },
     "rct2ww.scenery_wall.wgeorg02": {
         "reference-name": "Georgian Ground Floor Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 1"
     },
     "rct2ww.scenery_wall.wgeorg03": {
         "reference-name": "Georgian Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 2"
     },
     "rct2ww.scenery_wall.wgeorg04": {
         "reference-name": "Georgian Ground Floor Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 2"
     },
     "rct2ww.scenery_wall.wgeorg05": {
         "reference-name": "Georgian Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Грузинская стена 3"
     },
     "rct2ww.scenery_wall.wgeorg06": {
         "reference-name": "Georgian Ground Floor Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Грузинская стена первого этажа 4"
     },
     "rct2ww.scenery_wall.wgwoc1": {
         "reference-name": "Great Wall Of China Front Wall Section",
-        "name": "Деталь китайской стены"
+        "name": "Передняя секция великой Китайской Стены"
     },
     "rct2ww.scenery_wall.wgwoc2": {
         "reference-name": "Great Wall Of China Rear Wall Section",
-        "name": "Деталь китайской стены"
+        "name": "Задняя секция великой Китайской Стены"
     },
     "rct2ww.scenery_wall.wgwoc3": {
         "reference-name": "Great Wall Of China Step up Wall Section",
-        "name": "Деталь китайской стены"
+        "name": "Ступень великой Китайской Стены"
     },
     "rct2ww.scenery_wall.wigloo1": {
         "reference-name": "Igloo Wall",
@@ -11243,67 +11243,67 @@
     },
     "rct2ww.scenery_wall.wkreml07": {
         "reference-name": "Kremlin Wall Piece 5",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 5"
     },
     "rct2ww.scenery_wall.wkreml08": {
         "reference-name": "Kremlin Wall Piece 6",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 6"
     },
     "rct2ww.scenery_wall.wkreml09": {
         "reference-name": "Kremlin Wall Piece 7",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 7"
     },
     "rct2ww.scenery_wall.wkreml10": {
         "reference-name": "Kremlin Wall Piece 8",
-        "name": "Стена Кремля"
+        "name": "Кремлёвская стена 8"
     },
     "rct2ww.scenery_wall.wlog01": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wlog02": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wlog03": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wlog04": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wlog05": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wlog06": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена деревянной кабины"
     },
     "rct2ww.scenery_wall.wmarble1": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarble2": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarble3": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarble4": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarble5": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarble6": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Мраморная стена"
+        "name": "Орнаментная мраморная стена"
     },
     "rct2ww.scenery_wall.wmarbpl1": {
         "reference-name": "Plain Marble Wall",
@@ -11335,347 +11335,347 @@
     },
     "rct2ww.scenery_wall.wmud01": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud02": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud03": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud04": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud05": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud06": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud07": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wmud08": {
         "reference-name": "Mud Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена из грязи"
     },
     "rct2ww.scenery_wall.wpalm01": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_wall.wpalm02": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_wall.wpalm03": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_wall.wpalm04": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_wall.wpalm05": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена кабаны"
     },
     "rct2ww.scenery_wall.wshogi01": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi02": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi03": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi04": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi05": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi06": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi07": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi08": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi09": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi10": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi11": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi12": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi13": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi14": {
         "reference-name": "Shōji Wall",
-        "name": "Стена"
+        "name": "Стена сёдзи"
     },
     "rct2ww.scenery_wall.wshogi15": {
         "reference-name": "Japanese Fence",
-        "name": "Стена"
+        "name": "Японский забор"
     },
     "rct2ww.scenery_wall.wshogi16": {
         "reference-name": "Japanese Fence",
-        "name": "Стена"
+        "name": "Японский забор"
     },
     "rct2ww.scenery_wall.wshogi17": {
         "reference-name": "Japanese Fence",
-        "name": "Стена"
+        "name": "Японский забор"
     },
     "rct2ww.scenery_wall.wskysc01": {
         "reference-name": "Skyscraper Metal Set 2 Wall Piece",
-        "name": "Деталь стены"
+        "name": "Металлическая стена небоскрёба 2"
     },
     "rct2ww.scenery_wall.wskysc02": {
         "reference-name": "Skyscraper Metal Set 2 Wall Piece",
-        "name": "Деталь стены"
+        "name": "Металлическая стена небоскрёба 2"
     },
     "rct2ww.scenery_wall.wskysc03": {
         "reference-name": "Skyscraper Metal Set 1 Wall Piece",
-        "name": "Деталь стены"
+        "name": "Металлическая стена небоскрёба 1"
     },
     "rct2ww.scenery_wall.wskysc04": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Деталь секции лифта"
+        "name": "Секция лифта небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc05": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Деталь секции лифта"
+        "name": "Секция лифта небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc06": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc07": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Деталь секции лифта"
+        "name": "Секция лифта небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc08": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc09": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc10": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена каменного небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc11": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена каменного небоскрёба"
     },
     "rct2ww.scenery_wall.wskysc12": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Деталь стены"
+        "name": "Стена каменного небоскрёба"
     },
     "rct2ww.scenery_wall.wtudor01": {
         "reference-name": "Tudor Ground Floor Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 1"
     },
     "rct2ww.scenery_wall.wtudor02": {
         "reference-name": "Tudor Ground Floor Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 2"
     },
     "rct2ww.scenery_wall.wtudor03": {
         "reference-name": "Tudor Ground Floor Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 3"
     },
     "rct2ww.scenery_wall.wtudor04": {
         "reference-name": "Tudor Ground Floor Wall Piece 4",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 4"
     },
     "rct2ww.scenery_wall.wtudor05": {
         "reference-name": "Tudor Ground Floor Wall Piece 5",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 5"
     },
     "rct2ww.scenery_wall.wtudor06": {
         "reference-name": "Tudor Ground Floor Wall Piece 6",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 6"
     },
     "rct2ww.scenery_wall.wtudor07": {
         "reference-name": "Tudor Ground Floor Wall Piece 7",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 7"
     },
     "rct2ww.scenery_wall.wtudor08": {
         "reference-name": "Tudor Ground Floor Wall Piece 8",
-        "name": "Деталь стены"
+        "name": "Стена первого этажа Тюдора 8"
     },
     "rct2ww.scenery_wall.wtudor09": {
         "reference-name": "Tudor Wall Piece 1",
-        "name": "Деталь стены"
+        "name": "Стена Тюдора 1"
     },
     "rct2ww.scenery_wall.wtudor10": {
         "reference-name": "Tudor Wall Piece 2",
-        "name": "Деталь стены"
+        "name": "Стена Тюдора 2"
     },
     "rct2ww.scenery_wall.wtudor11": {
         "reference-name": "Tudor Wall Piece 3",
-        "name": "Деталь стены"
+        "name": "Стена Тюдора 3"
     },
     "rct2ww.scenery_wall.wwdaub01": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub02": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub03": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub04": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub05": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub06": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwdaub07": {
         "reference-name": "Wattle & Daub Wall",
-        "name": "Стена"
+        "name": "Стена Wattle & Daub"
     },
     "rct2ww.scenery_wall.wwind03": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Деталь стены"
+        "name": "Ветренная стена"
     },
     "rct2ww.scenery_wall.wwind04": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Деталь стены"
+        "name": "Ветренная стена"
     },
     "rct2ww.scenery_wall.wwind05": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Деталь стены"
+        "name": "Ветренная стена"
     },
     "rct2ww.scenery_wall.wwind06": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Деталь стены"
+        "name": "Ветренная стена"
     },
     "toontowner.scenery_small.ttpirf02": {
         "reference-name": "Roof",
-        "name": "Roof"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttpirf03": {
         "reference-name": "Roof",
-        "name": "Roof"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttpirf04": {
         "reference-name": "Roof",
-        "name": "Roof"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttpirf07": {
         "reference-name": "Roof",
-        "name": "Roof"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttpirf08": {
         "reference-name": "Roof",
-        "name": "Roof"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfgl01": {
         "reference-name": "Glass Roof",
-        "name": "Крыша"
+        "name": "Стеклянная крыша"
     },
     "toontowner.scenery_small.ttrfgl02": {
         "reference-name": "Glass Roof",
-        "name": "Крыша"
+        "name": "Стеклянная крыша"
     },
     "toontowner.scenery_small.ttrfgl03": {
         "reference-name": "Glass Roof",
-        "name": "Крыша"
+        "name": "Стеклянная крыша"
     },
     "toontowner.scenery_small.ttrftl02": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrftl03": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrftl04": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrftl07": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrftl08": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd01": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd02": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd03": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd04": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd06": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd07": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.ttrfwd08": {
         "reference-name": "Roof",
-        "name": "Блок"
+        "name": "Крыша"
     },
     "toontowner.scenery_small.xxbbbr01": {
         "reference-name": "Base Block",
-        "name": "База"
+        "name": "Базовый блок"
     },
     "toontowner.scenery_small.xxbbbr01_fix": {
         "reference-name": "Base Block",
-        "name": "База"
+        "name": "Базовый блок"
     },
     "uces.scenario_text.beneath_the_christmas_tree": {
         "reference-name": "Beneath the Christmas Tree",
@@ -11683,7 +11683,7 @@
         "reference-park_name": "Winter Wonderland",
         "park_name": "Winter Wonderland",
         "reference-details": "Mum built this scene under our tree. Now she wants a park made in it! Can you help?",
-        "details": "Mum built this scene under our tree. Now she wants a park made in it! Can you help?"
+        "details": "Мама построила сценку под нашей ёлкой. Теперь она хочет, чтобы мы сделали в ней парк! Не могли бы вы помочь?"
     },
     "uces.scenario_text.bigrock_blast": {
         "reference-name": "Bigrock Blast",
@@ -11691,7 +11691,7 @@
         "reference-park_name": "Bigrock Blast",
         "park_name": "Bigrock Blast",
         "reference-details": "After an explosion at the Bigrock Mining Co., the people of Bigrock have to build an amusement park to keep their town alive.",
-        "details": "After an explosion at the Bigrock Mining Co., the people of Bigrock have to build an amusement park to keep their town alive."
+        "details": "После взрыва в шахтёрской компании города Bigrock, людям пришлось заняться строительством парка для финансирования города."
     },
     "uces.scenario_text.camp_mockingbird": {
         "reference-name": "Camp Mockingbird",
@@ -11699,7 +11699,7 @@
         "reference-park_name": "Camp Mockingbird",
         "park_name": "Camp Mockingbird",
         "reference-details": "Only $500/week to this summer camp! Break open your bank and then have fun and build a park.",
-        "details": "Only $500/week to this summer camp! Break open your bank and then have fun and build a park."
+        "details": "Цена за пребывание в этом летнем лагере - всего $500 в неделю! Откройте свою копилку, веселитесь и стройте парк."
     },
     "uces.scenario_text.cemetery_ridge": {
         "reference-name": "Cemetery Ridge",
@@ -11707,7 +11707,7 @@
         "reference-park_name": "Cemetery Ridge",
         "park_name": "Cemetery Ridge",
         "reference-details": "This is Halloween, UCES Halloween, pumpkins scream in the dead of night! This graveyard is in trouble and it’s up to you to save it, while letting the dead rest in peace! Can you keep the ghosts in their graves and bring chills to your customers?",
-        "details": "This is Halloween, UCES Halloween, pumpkins scream in the dead of night! This graveyard is in trouble and it’s up to you to save it, while letting the dead rest in peace! Can you keep the ghosts in their graves and bring chills to your customers?"
+        "details": "Это Хэллоуин, в UCES хэллоуин, тыквы пляшут меж руин! На кладбище проблемы, и только вы можете спасти его, не нарушая сна покойников! Держите призраков в своих гробах, но дайте страхов вашим покупателям!"
     },
     "uces.scenario_text.choochoo_town": {
         "reference-name": "Choo-Choo Town",
@@ -11715,7 +11715,7 @@
         "reference-park_name": "Choo-Choo Town",
         "park_name": "Choo-Choo Town",
         "reference-details": "Mommy! Daddy! I want to go to Choo-Choo Town!",
-        "details": "Mommy! Daddy! I want to go to Choo-Choo Town!"
+        "details": "Мам! Пап! Я хочу чух-чух в город поездов!"
     },
     "uces.scenario_text.dragon_islands": {
         "reference-name": "Dragon Islands",
@@ -11723,7 +11723,7 @@
         "reference-park_name": "Dragon Islands",
         "park_name": "Dragon Islands",
         "reference-details": "Dragon Islands? I’m not sure I want to go there…",
-        "details": "Dragon Islands? I’m not sure I want to go there…"
+        "details": "Острова драконов? Ну не знаю…"
     },
     "uces.scenario_text.kiddie_karnival_ii": {
         "reference-name": "Kiddie Karnival II",
@@ -11731,7 +11731,7 @@
         "reference-park_name": "Kiddie Karnival",
         "park_name": "Kiddie Karnival",
         "reference-details": "Hey kids! Let’s have fun!",
-        "details": "Hey kids! Let’s have fun!"
+        "details": "Эй, детишки! Веселитесь!"
     },
     "uces.scenario_text.luna_park_cleveland": {
         "reference-name": "Luna Park, Cleveland",
@@ -11739,7 +11739,7 @@
         "reference-park_name": "Luna Park",
         "park_name": "Luna Park",
         "reference-details": "As it was on its opening day - 18 May 1905.",
-        "details": "As it was on its opening day - 18 May 1905."
+        "details": "Как в самый день его открытия - 18 мая 1905 года."
     },
     "uces.scenario_text.mount_vesuvius": {
         "reference-name": "Mount Vesuvius",
@@ -11747,7 +11747,7 @@
         "reference-park_name": "Mount Vesuvius",
         "park_name": "Mount Vesuvius",
         "reference-details": "Pompeii and Herculaneum were buried by Mt. Vesuvius in 79 A.D. Visit the excavations and build a park!",
-        "details": "Pompeii and Herculaneum were buried by Mt. Vesuvius in 79 A.D. Visit the excavations and build a park!"
+        "details": "Помпеи и Геркуланум были похоронены извержением Везувия в 79 году. Посетите руины, и постройте там парк!"
     },
     "uces.scenario_text.niagara_falls_gorge": {
         "reference-name": "Niagara Falls & Gorge",
@@ -11755,7 +11755,7 @@
         "reference-park_name": "Niagara Falls",
         "park_name": "Niagara Falls",
         "reference-details": "American Falls, Bridal Falls & Canadian Horseshoe Falls on the Niagara Frontier, 1850.",
-        "details": "American Falls, Bridal Falls & Canadian Horseshoe Falls on the Niagara Frontier, 1850."
+        "details": "Американские и канадские водопады на границе Ниагара, 1850 год."
     },
     "uces.scenario_text.rocky_mountain_miners": {
         "reference-name": "Rocky Mountain Miners",
@@ -11763,7 +11763,7 @@
         "reference-park_name": "Rocky Mountain Miners",
         "park_name": "Rocky Mountain Miners",
         "reference-details": "A rockslide damaged your railway. Your workers have gone prospecting. Is there gold in roller coasters?",
-        "details": "A rockslide damaged your railway. Your workers have gone prospecting. Is there gold in roller coasters?"
+        "details": "Оползень сломала вашу железную дорогу. Ваши работники ушли искать золото в аттракционах."
     },
     "uces.scenario_text.sand_dune": {
         "reference-name": "Sand Dune",
@@ -11771,7 +11771,7 @@
         "reference-park_name": "Sand Dune",
         "park_name": "Sand Dune",
         "reference-details": "As the owner of a small park, you bought a large piece of land along the beach to expand and attract more guests to visit the beautiful sand dunes, but beware: you cannot disturb those ecologically fragile sand dunes.",
-        "details": "As the owner of a small park, you bought a large piece of land along the beach to expand and attract more guests to visit the beautiful sand dunes, but beware: you cannot disturb those ecologically fragile sand dunes."
+        "details": "Вы - владелец маленького парка, купивший большое пространство рядом с пляжем для расширения и привлеченя гостей к этим красивым песчанным дюнам. Но берегитесь: дюны нестабильны, и вы не должны их беспокоить."
     },
     "uces.scenario_text.the_lighthouse_of_alexandria": {
         "reference-name": "The Lighthouse of Alexandria",
@@ -11779,7 +11779,7 @@
         "reference-park_name": "The Lighthouse of Alexandria",
         "park_name": "The Lighthouse of Alexandria",
         "reference-details": "Alexander built the city; Greeks, Romans, Egyptians left their mark. But the biggest honor was a Wonder of the Ancient World - the Lighthouse. Visit and make a park!",
-        "details": "Alexander built the city; Greeks, Romans, Egyptians left their mark. But the biggest honor was a Wonder of the Ancient World - the Lighthouse. Visit and make a park!"
+        "details": "Александр построил этот город. Греки, римляне, и египтяне - все оставили там свой след. Но самая главная достопримечательность здесь - это маяк. Посетите его, и постройте там парк!"
     },
     "uces.scenario_text.the_sandbox": {
         "reference-name": "The Sandbox",
@@ -11787,7 +11787,7 @@
         "reference-park_name": "The Sandbox",
         "park_name": "The Sandbox",
         "reference-details": "What everyone wants - a sandbox! So grab your l’il pail and shovel and build a park!",
-        "details": "What everyone wants - a sandbox! So grab your l’il pail and shovel and build a park!"
+        "details": "Песочница - вот вам то, что хотели! Так берите своё ведёрко и лопату, и стройте парк!"
     },
     "uces.scenario_text.the_time_machine": {
         "reference-name": "The Time Machine",
@@ -11795,7 +11795,7 @@
         "reference-park_name": "The Time Machine",
         "park_name": "The Time Machine",
         "reference-details": "The Time Machine. Build to go - when you want, where you want. Eternity awaits. It’s all relative.",
-        "details": "The Time Machine. Build to go - when you want, where you want. Eternity awaits. It’s all relative."
+        "details": "Машина времени. Стройте что хотите, где хотите и когда хотите. Вас ждет вечность. Всё относительно."
     },
     "uces.scenario_text.tower_of_babel": {
         "reference-name": "Tower of Babel",
@@ -11803,7 +11803,7 @@
         "reference-park_name": "Tower of Babel",
         "park_name": "Tower of Babel",
         "reference-details": "Whoaa! Look where the time machine took us now! Where did everybody go?",
-        "details": "Whoaa! Look where the time machine took us now! Where did everybody go?"
+        "details": "Вау! Смотри куда нас машина времени привезла! А куда все разбежались?"
     },
     "uces.scenario_text.transformation": {
         "reference-name": "Transformation",
@@ -11811,7 +11811,7 @@
         "reference-park_name": "Transformation",
         "park_name": "Transformation",
         "reference-details": "We were expecting you…",
-        "details": "We were expecting you…"
+        "details": "Мы вас ждали…"
     },
     "uces.scenario_text.urbis_incognitus": {
         "reference-name": "Urbis Incognitus",
@@ -11819,6 +11819,6 @@
         "reference-park_name": "Urbis Incognitus",
         "park_name": "Urbis Incognitus",
         "reference-details": "The Romans are tired of boring gladiator fights. Give them a better thrill, turn a Roman city into the greatest amusement park of all time!",
-        "details": "The Romans are tired of boring gladiator fights. Give them a better thrill, turn a Roman city into the greatest amusement park of all time!"
+        "details": "Римлянам надоело смотреть на этих скучных гладиаторов. Дайте им что-то экстремальное, и превратите этот римский город в лучший парк аттракционов, на веки вечные!"
     }
 }


### PR DESCRIPTION
Here's the second part of the Russian localisation update.

You may have noticed the enormous size of this patch... unlike the UI strings, which just needed some minor fixes and updates, this one is a complete rewrite of all the text. This is out of necessity: this file is the *most baffling* array of strings I have seen in my entire life. The problems with the current one can be summarized as follows:

- The scenery elements have had all descriptors stripped from them, reduced to base nouns, and reused as much as possible. You want a "Heavenly Bath Roof"? Sorry mate, all I can give you is a "Pool Part". An Atlas Statue? No, you get a "globe"! Many have been reduced to simply "block" or "part" with no other clarification.
- The ride descriptions, likewise, were stripped of all flavor text, and then re-used across all vaguely-similar rides. Feel excited about "locking horns with others in triceratops dodgems", or, perhaps, "battling" them in dragonhead-shaped ones? Nope, you just get to "ride a small electric car".
- Scenario descriptions, while being *mostly* fine, still suffered from some cuts to the text here and there.
- A *lot* of the terms have been misinterpreted and otherwise badly mangled. Here are just *some* of the horrors you've unknowingly been subjecting your Russian peeps to (someone make a Halloween mod out of these):
  - Tents, *everywhere*, instead of a vast variety of different stalls.
    - Plenty of them sell something completely different from what they do in English.
      - One apparently serves alcohol now! (Wine instead of Sujeonggwa).
  - A park on an "unfamous" island, instead of an "infamous" one.
  - "Dudes" instead of passengers (but only on select rides!).
  - "Microbe-uses", instead of micro-buses.
  - "Triceraptors".
  - Carnivorous plants, instead of grapevines.
  - All of the mushrooms you've been planting? Posion. Pure poison, every single one.
  - The joy of going on a "fire race" instead of a "firecracker ride". 
  - Some lads called Gahdes and Manta Ray walking around your park, instead of Hades statues and, you know, the bloody fish.
  - ***Austrians***. Instead of ostriches... because Österreich? I guess???

Having re-translated the file, I've fixed all of these issues (and *many* more), with the text now closely matching the original English one. Strings that are identical in English should now be identical in Russian as well, for easier maintenance. The missing translations were, of course, also added.

With this merged, the Russian translation will be fully up-to-date.

GitHub seems to be struggling with rendering the diff, by the way, so [here](https://github.com/OpenRCT2/Localisation/pull/2996.patch)'s a raw patch file for easier review.