### PR TITLE
en-US: Localized text for color schemes and randomizing vehicle colors

### DIFF
--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -231,10 +231,10 @@ STR_6274    :Can’t set color scheme…
 STR_6307    :Color scheme: {BLACK}{STRINGID}
 STR_6328    :With this option enabled, giant screenshots will have a transparent background instead of the default black color.
 STR_6501    :Random color
-STR_6625    :Invalid color
 STR_6529    :Invalid color scheme parameter!
 STR_6575    :Allow special color schemes
 STR_6576    :Adds special colors to color dropdown
+STR_6625    :Invalid color
 
 STR_6629    :Align toolbar buttons horizontally centered
 STR_6630    :This setting will align the toolbar buttons horizontally in the center of the screen. The traditional way of aligning them is in the left and right corner.

--- a/data/language/en-US.txt
+++ b/data/language/en-US.txt
@@ -232,7 +232,14 @@ STR_6307    :Color scheme: {BLACK}{STRINGID}
 STR_6328    :With this option enabled, giant screenshots will have a transparent background instead of the default black color.
 STR_6501    :Random color
 STR_6625    :Invalid color
+STR_6529    :Invalid color scheme parameter!
+STR_6575    :Allow special color schemes
+STR_6576    :Adds special colors to color dropdown
 
 STR_6629    :Align toolbar buttons horizontally centered
 STR_6630    :This setting will align the toolbar buttons horizontally in the center of the screen. The traditional way of aligning them is in the left and right corner.
+
+STR_6661    :Randomize all
+STR_6662    :Randomize colors for every train or vehicle
+
 STR_6732    :Show a button in the toolbar to rotate the view counterclockwise


### PR DESCRIPTION
I added localizations for US English to the text and tooltip of the "Randomise all" button in the vehicle color portion of ride windows. 

I also localized something about color schemes that I can't find in-game or in [UiStringIds.h](https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2-ui/UiStringIds.h) on the core repo. I'm not sure if they're unused, because an override for the nearby [STR_6501](https://github.com/OpenRCT2/OpenRCT2/blob/113928a2512bda915b2d2fd1906403894d61b4cb/data/language/en-GB.txt#L3556) exist in the en-US file. I localized the other strings anyways just to be safe.