### PR TITLE
cs-CZ: Fix translation of 'block brakes'

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -489,9 +489,9 @@ STR_1091    :Mód cirkusového představení
 STR_1092    :Start dolů
 STR_1093    :Mód křivého domu
 STR_1094    :Mód volného pádu
-STR_1095    :Mód okruhu se sekcemi
+STR_1095    :Mód okruhu rozděleného na bloky
 STR_1096    :Rychlý start (bez průjezdu stanicí)
-STR_1097    :Rychlý start módu se sekcemi
+STR_1097    :Rychlý start do módu rozděl. na bloky
 STR_1098    :Přesouvá se na konec {POP16}{STRINGID}
 STR_1099    :Čeká na návštěvníky na {POP16}{STRINGID}
 STR_1100    :Čeká na odjezd {POP16}{STRINGID}
@@ -522,7 +522,7 @@ STR_1124    :Startuje
 STR_1125    :V provozu
 STR_1126    :Zastavuje
 STR_1127    :Vykládá návštěvníky
-STR_1128    :Zastavuje na brzdících blocích
+STR_1128    :Zastavuje na blokových brzdách
 STR_1129    :Všechny vozidla mají stejnou barvu
 STR_1130    :Rozdílné barvy pro každý {STRINGID}
 STR_1131    :Rozdílné barvy pro každé vozidlo
@@ -1083,7 +1083,7 @@ STR_1685    :Velikost podstavy 2 × 4
 STR_1686    :Velikost podstavy 5 × 1
 STR_1687    :Průjezd vodou
 STR_1688    :Velikost podstavy 4 × 1
-STR_1689    :Brzdící blok
+STR_1689    :Bloková brzda
 STR_1690    :{WINDOW_COLOUR_2}{STRINGID}{NEWLINE}{BLACK}{STRINGID}
 STR_1691    :{WINDOW_COLOUR_2}  Cena: {BLACK}{CURRENCY}
 STR_1692    :{WINDOW_COLOUR_2}  Cena: {BLACK}již od {CURRENCY}
@@ -2140,7 +2140,7 @@ STR_3106    :Seznam kiosků a jiných zařízení
 STR_3107    :Zavřít
 STR_3108    :Testovat
 STR_3109    :Otevřít
-STR_3110    :{WINDOW_COLOUR_2}Sekce: {BLACK}{COMMA16}
+STR_3110    :{WINDOW_COLOUR_2}Bloková sekce: {BLACK}{COMMA16}
 STR_3111    :Pro postavení klikněte na návrh
 STR_3112    :Pro přejmenování nebo smazaní klikněte na návrh
 STR_3113    :Vybrat jiný návrh
@@ -2238,9 +2238,9 @@ STR_3225    :Přepnout stavění skupiny náhodných objektů okolo vybrané poz
 STR_3226    :Postavit vstup do parku
 STR_3227    :Příliš mnoho vstupů do parku
 STR_3228    :Nastavit počáteční pozice návštěvníků
-STR_3229    :Brzdící bloky nelze použít hned za stanicí
-STR_3230    :Brzdící bloky nelze použít v řadě za sebou
-STR_3231    :Brzdící bloky nelze použít hned za řetězovým výtahem
+STR_3229    :Blokové brzdy nelze použít hned za stanicí
+STR_3230    :Blokové brzdy nelze použít v řadě za sebou
+STR_3231    :Blokové brzdy nelze použít hned za řetězovým výtahem
 STR_3232    :Nastavení scénaře - Finance
 STR_3233    :Nastavení scénáře - Návštěvníci
 STR_3235    :Zobrazit nastavení financí
@@ -2418,7 +2418,7 @@ STR_5152    :,
 STR_5153    :Upravit motivy…
 STR_5154    :Hardwarové zobrazování
 STR_5155    :Povolit testování nedostavěných atrakcí
-STR_5156    :Povolí testování většiny typů atrakcí, i přesto, že atrakce není dostavěna. Netýká se módu sekcí
+STR_5156    :Povolí testování většiny typů atrakcí, i přesto, že atrakce není dostavěna. Netýká se módu okruhu rozděleného na bloky
 STR_5158    :Odejít do menu
 STR_5159    :Vypnout OpenRCT2
 STR_5160    :{POP16}{MONTH} {PUSH16}{PUSH16}{STRINGID}, Rok {POP16}{COMMA16}
@@ -3361,7 +3361,7 @@ STR_6315    :{WINDOW_COLOUR_2}Cíl hledání cesty: {BLACK}{INT32}, {INT32}, {IN
 STR_6316    :{WINDOW_COLOUR_2}Historie hledání cest:
 STR_6317    :{BLACK}{INT32}, {INT32}, {INT32} směr {INT32}
 STR_6318    :Detekována síťová desynchronizace.{NEWLINE}Log: {STRING}
-STR_6319    :Uzavřený brzdný blok
+STR_6319    :Bloková brzda zavřena
 STR_6320    :Nezničitelné
 STR_6321    :Rozbitá část
 STR_6322    :{WINDOW_COLOUR_2}Entity ID: {BLACK}{INT32}
@@ -3719,7 +3719,7 @@ STR_6725    :X:
 STR_6726    :Y:
 STR_6727    :Smyčka (levá)
 STR_6728    :Smyčka (pravá)
-STR_6729    :Řetězový výtah musí začít hned za stanicí nebo brzdícím blokem
+STR_6729    :Řetězový výtah musí začít hned za stanicí nebo blokovou brzdou
 STR_6730    :Exportovat data emscripten
 STR_6731    :Importovat data emscripten
 STR_6732    :Zobrazit v nástrojové liště tlačítko pro otočení pohledu proti směru hodinových ručiček


### PR DESCRIPTION
Fix translation of  ` STR_1689 :Block brakes  ` and subsequent use of this phrase.
Fix translation of `STR_1095 :Continuous circuit block sectioned mode` and subsequent use of phrase "block sectioned"