### PR TITLE
cs-CZ: Remove STR_3140

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -2170,7 +2170,6 @@ STR_3136    :Varování: Tento návrh bude postaven s alternativními vozy, kter
 STR_3137    :Vyberte okolní kulisy
 STR_3138    :Zrušit výběr
 STR_3139    :Řetězový výtah nefunguje v tomto provozním módu
-STR_3140    :Řetězový výtah musí začít hned za stanicí
 STR_3141    :Více kol za jízdu není přípustné současně s řetězovým výtahem
 STR_3142    :{WINDOW_COLOUR_2}Kapacita: {BLACK}{STRINGID}
 STR_3143    :Zobrazit návštěvníky na mapě


### PR DESCRIPTION
Please review with care.

STR_3140 is no more present in en-GB, which renders it redundant in cs-CZ


