### PR TITLE
cs-CZ: Fix existing translations of objects in *.footpath_surface.*

### DIFF
--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -93,11 +93,11 @@
     },
     "rct1.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Sloped)",
-        "name": "Šílená cesta"
+        "name": "Bláznivě vydlážděná cesta (se svahy)"
     },
     "rct1.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Square)",
-        "name": "Blátivá cesta"
+        "name": "Prašná cesta (hranaté rohy)"
     },
     "rct1.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Sloped)",
@@ -109,7 +109,7 @@
     },
     "rct1.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Sloped)",
-        "name": "Asfaltová cesta"
+        "name": "Asfaltová cesta (se svahy)"
     },
     "rct1.footpath_surface.tiles_brown": {
         "reference-name": "Brown Tiled Footpath",
@@ -629,7 +629,7 @@
     },
     "rct1aa.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Square)",
-        "name": "Popelavá cesta"
+        "name": "Popelem sypaná cesta (hranatá)"
     },
     "rct1aa.footpath_surface.queue_green": {
         "reference-name": "Green Queue",
@@ -645,7 +645,7 @@
     },
     "rct1aa.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Sloped)",
-        "name": "Hnědá asfaltová cesta"
+        "name": "Hnědá asfaltová cesta (se svahy)"
     },
     "rct1aa.footpath_surface.tarmac_green": {
         "reference-name": "Green Tarmac Footpath",
@@ -1797,15 +1797,15 @@
     },
     "rct2.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Rounded)",
-        "name": "Popelavá cesta"
+        "name": "Popelem sypaná cesta (zakulacená)"
     },
     "rct2.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Stairs)",
-        "name": "Šílená cesta"
+        "name": "Bláznivě vydlážděná cesta (se schody)"
     },
     "rct2.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Rounded)",
-        "name": "Blátivá cesta"
+        "name": "Prašná cesta (zakulacená)"
     },
     "rct2.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Stairs)",
@@ -1829,15 +1829,15 @@
     },
     "rct2.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Stairs)",
-        "name": "Asfaltová cesta"
+        "name": "Asfaltová cesta (se schody)"
     },
     "rct2.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Stairs)",
-        "name": "Hnědá asfaltová cesta"
+        "name": "Hnědá asfaltová cesta (se schody)"
     },
     "rct2.footpath_surface.tarmac_green": {
         "reference-name": "Dark Green Tarmac Footpath",
-        "name": "Zelená asfaltová cesta"
+        "name": "Tmavě zelená asfaltová cesta"
     },
     "rct2.footpath_surface.tarmac_red": {
         "reference-name": "Red Tarmac Footpath (Stairs)",
@@ -5783,11 +5783,11 @@
     },
     "rct2tt.footpath_surface.mosaic": {
         "reference-name": "Mosaic Footpath",
-        "name": "Mosaická cesta"
+        "name": "Mozaiková cesta"
     },
     "rct2tt.footpath_surface.pavement": {
         "reference-name": "Pavement",
-        "name": "Chodník"
+        "name": "Dlažba"
     },
     "rct2tt.footpath_surface.queue_circuitboard": {
         "reference-name": "Circuit Queue",


### PR DESCRIPTION
Fix confusing and misleading translations, filled in missing parts of strings.

Note:
1. parts of strings "(sloped)" "(stairs)" etc. can not be omitted in translations, as once both RCT1 and 2 assets are loaded into single scenario, Footpaths window becomes a confusion of the highest order.
2. Translations containing "crazy paving" had to be changed, as the czech phrase "šílená cesta" can be perceived as having very negative connotations. Translations containing "dirt" had to be changed, since they mistranslated the word as _muddy_