### PR TITLE
sv-SE Added missing translations 6656-6791

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -3694,3 +3694,139 @@ STR_6652    :Felmeddelande
 STR_6653    :Alla källor visas
 STR_6654    :Visar {POP16}{UINT16} källor
 STR_6655    :Endast ‘{POP16}{STRINGID}’
+STR_6656    :Ta bort alla stängsel från parken
+STR_6657    :Marken ägs inte
+STR_6658    :Ställ in marken som inte ägd av parken och inte tillgänglig för köp
+STR_6659    :Gäster ignorerar priser
+STR_6660    :Gäster kommer att ignorera priser på åkattraktioner och stånd
+STR_6661    :Slumpa alla
+STR_6662    :Slumpa färger för varje tåg eller fordon
+STR_6663    :Datumfusk
+STR_6664    :Visa datumfusk
+STR_6665    :Natur/väderfusk
+STR_6666    :Visa natur/väderfusk
+STR_6667    :Fauna
+STR_6668    :Personal fusk
+STR_6669    :Visa personal fusk
+STR_6670    :Gästbeteende
+STR_6671    :Visa “riktiga” namn på personal
+STR_6672    :Växla mellan att visa “riktiga” namn och personalnummer
+STR_6673    :Transparent
+STR_6674    :{MONTH}, År {COMMA16}
+STR_6675    :Peep-namn
+STR_6676    :Minst ett peep-namns objekt måste vara valt
+STR_6677    :Lägg till stränder runt vattendrag
+STR_6678    :Höjdkällkälla:
+STR_6679    :Slättland
+STR_6680    :Simplex-brus
+STR_6681    :Höjdkarta-fil
+STR_6682    :Kartgenerator - Generator
+STR_6683    :Kartgenerator - Terräng
+STR_6684    :Kartgenerator - Vatten
+STR_6685    :Kartgenerator - Skogar
+STR_6686    :Träd till mark förhållande:
+STR_6687    :Min. trädaltitud:
+STR_6688    :Max. trädaltitud:
+STR_6689    :{UINT16}%
+STR_6690    :Minsta markhöjd
+STR_6691    :Ange min. markhöjd mellan {COMMA16} och {COMMA16}
+STR_6692    :Högsta markhöjd
+STR_6693    :Ange max. markhöjd mellan {COMMA16} och {COMMA16}
+STR_6694    :Minsta trädaltitud
+STR_6695    :Ange min. trädaltitud mellan {COMMA16} och {COMMA16}
+STR_6696    :Högsta trädaltitud
+STR_6697    :Ange max. trädaltitud mellan {COMMA16} och {COMMA16}
+STR_6698    :Träd-till-mark-förhållande
+STR_6699    :Ange träd-till-mark-förhållande mellan {COMMA16} och {COMMA16}
+STR_6700    :Simplex Grundfrekvens
+STR_6701    :Ange grundfrekvens mellan {COMMA2DP32} och {COMMA2DP32}
+STR_6702    :Simplex Oktaver
+STR_6703    :Ange antal oktaver mellan {COMMA16} och {COMMA16}
+STR_6704    :{COMMA2DP32}
+STR_6705    :Bläddra...
+STR_6706    :{WINDOW_COLOUR_2}Aktuell bildfil: {BLACK}{STRING}
+STR_6707    :(ingen vald)
+STR_6708    :Utjämningsstyrka
+STR_6709    :Ange utjämningsstyrka mellan {COMMA16} och {COMMA16}
+STR_6710    :Stabil sortering
+STR_6711    :Filnamn:
+STR_6712    :Spara
+STR_6713    :{COMMA32} {STRINGID}
+STR_6714    :Filnamn
+STR_6715    :Ändringsdatum
+STR_6716    :Filstorlek
+STR_6717    :Filstorlek {STRINGID}
+STR_6718    :Gästanimationer
+STR_6719    :Minst ett gästanimationsobjekt måste vara valt
+STR_6720    :Minst ett vaktmästaranimationsobjekt måste vara valt
+STR_6721    :Minst ett mekanikeranimationsobjekt måste vara valt
+STR_6722    :Minst ett säkerhetsanimationsobjekt måste vara valt
+STR_6723    :Minst ett underhållaranimationsobjekt måste vara valt
+STR_6724    :Scenariotexter
+STR_6725    :X:
+STR_6726    :Y:
+STR_6727    :Dykloop (vänster)
+STR_6728    :Dykloop (höger)
+STR_6729    :Kabelhissbacke måste börja direkt efter station eller blockbroms
+STR_6730    :Exportera emscripten-data
+STR_6731    :Importera emscripten-data
+STR_6732    :Visa en knapp i verktygsfältet för att rotera vyn moturs
+STR_6733    :Genomskinlig
+STR_6734    :Kartobjekt vid eller ovanför snitthöjd renderas halvgenomskinliga
+STR_6735    :Gå upp till föräldermapp
+STR_6736    :Förhandsvisning
+STR_6737    :Ingen förhandsvisning tillgänglig
+STR_6738    :{WINDOW_COLOUR_2}Parkbetyg: {BLACK}{UINT16}
+STR_6739    :{WINDOW_COLOUR_2}Datum: {BLACK}{STRINGID}
+STR_6740    :{WINDOW_COLOUR_2}Kassa: {BLACK}{CURRENCY2DP}
+STR_6741    :{WINDOW_COLOUR_2}Antal åkattraktioner: {BLACK}{UINT16}
+STR_6742    :{WINDOW_COLOUR_2}Antal gäster: {BLACK}{UINT16}
+STR_6743    :Klimat
+STR_6744    :{WINDOW_COLOUR_2}{UINT16}%
+STR_6745    :{WINDOW_COLOUR_2}Gästernas intensitetspreferenser:
+STR_6746    :Inga preferenser
+STR_6747    :Preferenser varierar (standard)
+STR_6748    :Endast mindre intensiva åk
+STR_6749    :Endast mer intensiva åk
+STR_6750    :Välj vilken intensitet nya gäster föredrar
+STR_6751    :Kövägar kan inte användas för plankorsningar!
+STR_6752    :Scenarioalternativ - Mål
+STR_6753    :Scenarioalternativ - Detaljer
+STR_6754    :Scenarioalternativ - Markbegränsningar
+STR_6755    :Visa målalternativ
+STR_6756    :Visa scenarioinformation
+STR_6757    :Visa markbegränsningsalternativ
+STR_6758    :Lånealternativ
+STR_6759    :Affärsmodell
+STR_6760    :Intäkter:
+STR_6761    :Scenariodetaljer
+STR_6762    :Gränssnitt
+STR_6763    :RollerCoaster Tycoon 1
+STR_6764    :Sparande och autospar
+STR_6765    :Avancerat
+STR_6766    :Rensa
+STR_6767    :Fönster
+STR_6768    :Rendering
+STR_6769    :Beteende
+STR_6770    :Bildfrekvensgräns:
+STR_6771    :Intern hastighet (standard)
+STR_6772    :Vertikal synkronisering
+STR_6773    :Obegränsad
+STR_6774    :Tid sedan senaste inspektion
+STR_6775    :{COMMA16} minut
+STR_6776    :{COMMA16} minuter
+STR_6777    :mer än 4 timmar
+STR_6778    :Förhandsgranska scenarier med:
+STR_6779    :Välj vilken typ av förhandsbild som ska användas i scenarioskärmen
+STR_6780    :Minikartor
+STR_6781    :Skärmdumpar
+STR_6782    :Parknotiser
+STR_6783    :Åknotiser
+STR_6784    :Gästnotiser
+STR_6785    :Handkontroll
+STR_6786    :Dödzon:
+STR_6787    :Dödzon för analog spak (minsta rörelse som krävs)
+STR_6788    :Känslighet:
+STR_6789    :Känslighet multiplikator för analog spak
+STR_6790    :Dödzon: {COMMA32}%
+STR_6791    :Känslighet: {COMMA32}%


### PR DESCRIPTION
Added missing translations 6656-6791 (inclusive)

Applying for issues:
- #3211 
- #3147 
- #3130 
- #3124 
- #3120 
- #3112 
- #3094 
- #3082 
- #3076
- #3069 
- #3060 
- #3056 
- #3024 
- #3019
- #3014
- #3005 
- #2999 
- #2981 
- #2941 
- #2938 
- #2936 
- #2928 
- #2917
- #2909 
- #2897 
- #2895 
- #2894

Note, I'm unsure about STR_6675 (Peep Names) and STR_6676 (At least one peep names object must be selected). https://github.com/OpenRCT2/OpenRCT2/pull/22758

The Norwegian translation is using "Bezoekersnamen" meaning "Visitor names" while the Danish translation is using "Peep-Namen" meaning "the Peep Name".

Options I have considered are:
- Peep-namn (Peep name)
- Peep-namnen (The Peep names)
- Gästnamn (guest name)
- Gästnamnen (the guest names)

The choice here is "Peep-namn" as it is close to the Danish name.