### PR TITLE
Update sv-SE for #3009

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -2196,7 +2196,7 @@ STR_3188    :Gångvägsskyltar
 STR_3189    :Utfasade gångvägar
 STR_3190    :Gångvägsdetaljer
 STR_3191    :Dekorationsgrupper
-STR_3192    :Parkentré
+STR_3192    :Parkingångar
 STR_3193    :Vatten
 STR_3195    :Uppfinningslista
 STR_3196    :{WINDOW_COLOUR_2}Forskningsgrupp: {BLACK}{STRINGID}


### PR DESCRIPTION
Applying for issue:
- #3009

STR_6724 added in #3233

note.
"parkentré" is an unspecified singular form.
While the plural is "parkentréer", it is not what I picked because it is generally used for the area where an entrance is placed.
"Parkingångar" is plural form of "Parkingång". This word specified the entrance itself and not the surrounding area.