### PR TITLE
Update sv-SE with corrected grammar for STR-0024

### DIFF
--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -26,7 +26,7 @@ STR_0020    :Linbana
 STR_0021    :Korkskruvsberg- och dalbana
 STR_0022    :Labyrint
 STR_0023    :Spiralrutschkana
-STR_0024    :Gokart
+STR_0024    :Gokarter
 STR_0025    :Stockfors
 STR_0026    :Forsränning
 STR_0027    :Radiobilar


### PR DESCRIPTION
"_Gokart_" is the singular form.
To match "_Go-Karts_", I changed it to "_Gokarter_"

See [here](https://sv.wiktionary.org/wiki/gokart) for why "_Gokarter_" is used over "_Gokart_" and "_Gokarts_".