### PR TITLE
cs-CZ: Add translation for RCT1 scenario meta objects

### DIFF
--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -421,7 +421,7 @@
         "reference-park_name": "Bumbly Beach",
         "park_name": "Bumbly Beach",
         "reference-details": "Develop Bumbly Beach’s small amusement park into a thriving theme park",
-        "details": "Develop Bumbly Beach’s small amusement park into a thriving theme park"
+        "details": "Vybudujte z malého parku na Bumbly Beach úžasný tematický zábavní park"
     },
     "rct1.scenario_meta.crumbly_woods": {
         "reference-name": "Crumbly Woods",
@@ -429,7 +429,7 @@
         "reference-park_name": "Crumbly Woods",
         "park_name": "Crumbly Woods",
         "reference-details": "A large park with well-designed but rather old rides. Replace the old rides or add new rides to make the park more popular.",
-        "details": "A large park with well-designed but rather old rides. Replace the old rides or add new rides to make the park more popular."
+        "details": "Velký park s dobře navrženými, ale poněkud staršími atrakcemi. Pro zvýšení popularity parku nahraďte staré atrakce nebo přidejte nové."
     },
     "rct1.scenario_meta.diamond_heights": {
         "reference-name": "Diamond Heights",
@@ -437,7 +437,7 @@
         "reference-park_name": "Diamond Heights",
         "park_name": "Diamond Heights",
         "reference-details": "Diamond Heights is already a successful theme park with great rides - develop it to double its value",
-        "details": "Diamond Heights is already a successful theme park with great rides - develop it to double its value"
+        "details": "Diamond Heights je úspěšný zábavní park se skvělými atrakcemi - rozviňte jej na dvojnásobek hodnoty parku."
     },
     "rct1.scenario_meta.dynamite_dunes": {
         "reference-name": "Dynamite Dunes",
@@ -445,7 +445,7 @@
         "reference-park_name": "Dynamite Dunes",
         "park_name": "Dynamite Dunes",
         "reference-details": "Built in the middle of the desert, this theme park contains just one roller coaster but has space for expansion",
-        "details": "Built in the middle of the desert, this theme park contains just one roller coaster but has space for expansion"
+        "details": "V tomto parku, uprostřed pouště, je zatím jenom jedna horská dráha, ale spousta místa pro rozvoj"
     },
     "rct1.scenario_meta.evergreen_gardens": {
         "reference-name": "Evergreen Gardens",
@@ -453,7 +453,7 @@
         "reference-park_name": "Evergreen Gardens",
         "park_name": "Evergreen Gardens",
         "reference-details": "Convert the beautiful Evergreen Gardens into a thriving theme park",
-        "details": "Convert the beautiful Evergreen Gardens into a thriving theme park"
+        "details": "Přestavějte krásné Evergreen Gardens na prosperující zábavní park"
     },
     "rct1.scenario_meta.forest_frontiers": {
         "reference-name": "Forest Frontiers",
@@ -461,7 +461,7 @@
         "reference-park_name": "Forest Frontiers",
         "park_name": "Forest Frontiers",
         "reference-details": "Deep in the forest, build a thriving theme park in a large cleared area",
-        "details": "Deep in the forest, build a thriving theme park in a large cleared area"
+        "details": "Postavte prosperující zábavní park na obrovské mýtině v srdci lesa"
     },
     "rct1.scenario_meta.ivory_towers": {
         "reference-name": "Ivory Towers",
@@ -469,7 +469,7 @@
         "reference-park_name": "Ivory Towers",
         "park_name": "Ivory Towers",
         "reference-details": "A well-established park, which has a few problems",
-        "details": "A well-established park, which has a few problems"
+        "details": "Dobře zavedený park, který má pár problémů"
     },
     "rct1.scenario_meta.karts_coasters": {
         "reference-name": "Karts & Coasters",
@@ -477,7 +477,7 @@
         "reference-park_name": "Karts & Coasters",
         "park_name": "Karts & Coasters",
         "reference-details": "A large park hidden in the forest, with only go-kart tracks and wooden roller coasters",
-        "details": "A large park hidden in the forest, with only go-kart tracks and wooden roller coasters"
+        "details": "Velký park skrytý v hloubi lesa, pouze s okruhy pro motokáry a dřevěnými horskými drahami"
     },
     "rct1.scenario_meta.katies_dreamland": {
         "reference-name": "Katie’s Dreamland",
@@ -485,7 +485,7 @@
         "reference-park_name": "Katie’s Dreamland",
         "park_name": "Katie’s Dreamland",
         "reference-details": "A small theme park with a few rides and room for expansion. Your aim is to double the park value.",
-        "details": "A small theme park with a few rides and room for expansion. Your aim is to double the park value."
+        "details": "Malý zábavní park s několika atrakcemi a místem pro rozšíření. Vašim cílem je zdvojnásobit hodnotu parku."
     },
     "rct1.scenario_meta.leafy_lake": {
         "reference-name": "Leafy Lake",
@@ -493,7 +493,7 @@
         "reference-park_name": "Leafy Lake",
         "park_name": "Leafy Lake",
         "reference-details": "Starting from scratch, build a theme park around a large lake",
-        "details": "Starting from scratch, build a theme park around a large lake"
+        "details": "Začněte od píky a postavte zábavní park na březích velkého jezera"
     },
     "rct1.scenario_meta.lightning_peaks": {
         "reference-name": "Lightning Peaks",
@@ -501,7 +501,7 @@
         "reference-park_name": "Lightning Peaks",
         "park_name": "Lightning Peaks",
         "reference-details": "The beautiful mountains of Lightning Peaks are popular with walkers and sightseers. Use the available land to attract a new thrill-seeking clientele.",
-        "details": "The beautiful mountains of Lightning Peaks are popular with walkers and sightseers. Use the available land to attract a new thrill-seeking clientele."
+        "details": "Překrásné hory v Lightning Peaks jsou oblíbeným cílem turistů. Využijte dostupný pozemek k přilákání nové, povyražení hledající klientely."
     },
     "rct1.scenario_meta.mega_park": {
         "reference-name": "Mega Park",
@@ -509,7 +509,7 @@
         "reference-park_name": "Mega Park",
         "park_name": "Mega Park",
         "reference-details": "Just for fun!",
-        "details": "Just for fun!"
+        "details": "Prostě pro zábavu!"
     },
     "rct1.scenario_meta.mels_world": {
         "reference-name": "Mel’s World",
@@ -517,7 +517,7 @@
         "reference-park_name": "Mel’s World",
         "park_name": "Mel’s World",
         "reference-details": "This theme park has some well-designed modern rides, but plenty of space for expansion",
-        "details": "This theme park has some well-designed modern rides, but plenty of space for expansion"
+        "details": "Tento zábavní park má několik dobře navržených atrakcí, ale spoustu místa pro rozšíření"
     },
     "rct1.scenario_meta.millennium_mines": {
         "reference-name": "Millennium Mines",
@@ -533,7 +533,7 @@
         "reference-park_name": "Mystic Mountain",
         "park_name": "Mystic Mountain",
         "reference-details": "In the hilly forests of Mystic Mountain, build a theme park from scratch",
-        "details": "In the hilly forests of Mystic Mountain, build a theme park from scratch"
+        "details": "Vybudujte od píky zábavní park v hornatých lesích Mystic Mountain"
     },
     "rct1.scenario_meta.pacific_pyramids": {
         "reference-name": "Pacific Pyramids",
@@ -541,7 +541,7 @@
         "reference-park_name": "Pacific Pyramids",
         "park_name": "Pacific Pyramids",
         "reference-details": "Convert the Egyptian Ruins tourist attraction into a thriving theme park",
-        "details": "Convert the Egyptian Ruins tourist attraction into a thriving theme park"
+        "details": "Proměňte turistickou atrakci - ruiny z období starého Egypta - na prosperující zábavní park"
     },
     "rct1.scenario_meta.paradise_pier": {
         "reference-name": "Paradise Pier",
@@ -549,7 +549,7 @@
         "reference-park_name": "Paradise Pier",
         "park_name": "Paradise Pier",
         "reference-details": "Convert this sleepy town’s pier into a thriving attraction",
-        "details": "Convert this sleepy town’s pier into a thriving attraction"
+        "details": "Přestavějte molo v ospalém městečku na prosperující atrakci"
     },
     "rct1.scenario_meta.pokey_park": {
         "reference-name": "Pokey Park",
@@ -557,7 +557,7 @@
         "reference-park_name": "Pokey Park",
         "park_name": "Pokey Park",
         "reference-details": "A small, cramped amusement park which requires major expansion",
-        "details": "A small, cramped amusement park which requires major expansion"
+        "details": "Malý a stísněný park potřebuje velké rozšíření"
     },
     "rct1.scenario_meta.rainbow_valley": {
         "reference-name": "Rainbow Valley",
@@ -565,7 +565,7 @@
         "reference-park_name": "Rainbow Valley",
         "park_name": "Rainbow Valley",
         "reference-details": "Rainbow Valley’s local authority won’t allow any landscape changes or large tree removal, but you must develop the area into a large theme park",
-        "details": "Rainbow Valley’s local authority won’t allow any landscape changes or large tree removal, but you must develop the area into a large theme park"
+        "details": "Úřady v Rainbow Valley nepovolí změny terénu nebo kácení velkých stromů, ale přesto musíte v tomto prostoru vybudovat velký zábavní park"
     },
     "rct1.scenario_meta.thunder_rock": {
         "reference-name": "Thunder Rock",
@@ -573,7 +573,7 @@
         "reference-park_name": "Thunder Rock",
         "park_name": "Thunder Rock",
         "reference-details": "Thunder Rock stands in the middle of a desert and attracts many tourists. Use the available space to build rides to attract more people.",
-        "details": "Thunder Rock stands in the middle of a desert and attracts many tourists. Use the available space to build rides to attract more people."
+        "details": "Thunder Rock - Skála hromu - stojí uprostřed pouště a přitahuje turisty. Využijte dostupné místo k postavení atrakcí, které přilákají více lidí."
     },
     "rct1.scenario_meta.trinity_islands": {
         "reference-name": "Trinity Islands",
@@ -581,7 +581,7 @@
         "reference-park_name": "Trinity Islands",
         "park_name": "Trinity Islands",
         "reference-details": "Several islands form the basis for this new park",
-        "details": "Several islands form the basis for this new park"
+        "details": "Základ pro tento nový park tvoří několik ostrůvků"
     },
     "rct1.scenario_meta.white_water_park": {
         "reference-name": "White Water Park",
@@ -589,7 +589,7 @@
         "reference-park_name": "White Water Park",
         "park_name": "White Water Park",
         "reference-details": "A park with some excellent water-based rides requires expansion",
-        "details": "A park with some excellent water-based rides requires expansion"
+        "details": "Je potřeba rozšířit park s několika vynikajícími vodními atrakcemi"
     },
     "rct1.scenery_wall.playing_card_wall_1": {
         "reference-name": "Playing Card Wall",


### PR DESCRIPTION
Notes: Given names of scenarios and parks are not translated by intention, explanation was partialy already given in https://github.com/OpenRCT2/Localisation/commit/3737477407b195e1c0e7f64b82a60a6c38a703fe and in second order: most avalible informations about OpenRCT2 is presented in English, and general audience trying to translate once translated given names back would lead to even greater confusion, maybe even to "confusion of the highest orda"