### PR TITLE
cs-CZ: Improve translations of large scenery objects

### DIFF
--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -6415,7 +6415,7 @@
     },
     "rct2tt.scenery_large.4x4gmant": {
         "reference-name": "Giant Mangrove Tree",
-        "name": "Obrovský mangrome strom"
+        "name": "Obrovský mangrove strom"
     },
     "rct2tt.scenery_large.4x4stnhn": {
         "reference-name": "Stone Age Temple",


### PR DESCRIPTION
Fix typos, quotation marks, capitalization and generally polish to fit overall translation style