### PR TITLE
cs-CZ: Improve transport rides translations

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -9,7 +9,7 @@ STR_0004    :Závěsná houpající se horská dráha
 STR_0005    :Obrácená horská dráha
 STR_0006    :Dorostenecká horská dráha
 STR_0007    :Miniaturní železnice
-STR_0008    :Visutá jednokolejka
+STR_0008    :Monorail
 STR_0009    :Malá zavěšená dráha
 STR_0010    :Půjčovna lodí
 STR_0011    :Dřevěná divoká myš
@@ -66,7 +66,7 @@ STR_0061    :Virginský moták
 STR_0062    :Cákající lodě
 STR_0063    :Mini helikoptéra
 STR_0064    :Horská dráha v leže
-STR_0065    :Visutá jednokolejka
+STR_0065    :Visutá dráha
 STR_0066    :Neznámá atrakce (40)
 STR_0067    :Obrácená horská dráha
 STR_0068    :Heartline Twister Coaster
@@ -106,8 +106,8 @@ STR_0513    :Návštěvníci jedou po horské dráze s loopingy ve stoje
 STR_0514    :Vlaky zavěšené pod kolejí se v zatáčkách houpají do stran
 STR_0515    :Ocelová horská dráha s vlaky držícími zespoda trati s mnoha zatáčkami
 STR_0516    :Pozvolná horská dráha pro ty kdo se zatím neodvažují na větší dráhy
-STR_0517    :Návštěvníci jezdí v miniaturních vlacích po úzkorozchodné koleji.
-STR_0518    :Návštěvníci jedou v elektrických vlacích po visuté jednokolejné dráze.
+STR_0517    :Cestující jedou v miniaturních vlacích po úzkorozchodné koleji
+STR_0518    :Cestující jedou v elektrických vlacích po visuté jednokolejné dráze
 STR_0519    :Návštěvníci jedou zavěšení pod jednou kolejí v malých kabinách, volně se houpajících ze strany na stranu
 STR_0520    :Přístavní molo, kde návštěvníci mohou řídit osobní plavidlo na vodní hladině
 STR_0521    :Rychlá a mrštná horská dráha s ostrými zatáčkami a strmými svahy. Dráha je předurčená k vysoké intenzitě.
@@ -119,7 +119,7 @@ STR_0526    :Otáčející se vyhlídková kabina, která postupně vyjíždí n
 STR_0527    :Plynulá ocelová horská dráha s loopingy
 STR_0528    :Návštěvníci jedou v nafukovacích člunech po tobogánu
 STR_0529    :Ocelová horská dráha ve stylu důlního vlaku s věrně vypadajícími důlními kolejemi.
-STR_0530    :Kabiny visí na ocelovém laně, které nepřetržitě jede z jednoho konce na druhý a zpět
+STR_0530    :Kabiny nebo sedačky jsou zavěšeny na laně obíhajícím mezi stanicemi
 STR_0531    :Malá ocelová horská dráha, na které vlak projíždí smyčky a vývrtky
 STR_0532    :Bludiště z šest stop vysokých zdí nebo živého plotu. Návštěvníci bloudí dokud nenajdou východ
 STR_0533    :Dřevěná budova s krytým schodištěm a venkovní skluzavkou s koberečky
@@ -141,7 +141,7 @@ STR_0551    :3D kino ve velké kopuli
 STR_0552    :Návštěvníci sedí v zavěšených gondolách, které se otáčí dopředu, dozadu a vzhůru nohama
 STR_0553    :Návštěvníci rotují v gyroskopických kruzích zcela volně ve všech směrech
 STR_0554    :Po mocném startu pomocí elektromotorů se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice
-STR_0555    :Návštěvníci jezdí ve výtahu nahoru a dolů
+STR_0555    :Návštěvníci jedou ve výtahu umístěném ve věži nahoru nebo dolů z jednoho patra do druhého
 STR_0556    :Extra široké vozy se vrhají střemhlav dolů za zážitky úplného volného pádu na horské dráze
 STR_0557    :Bankomat, který se návštěvníkům hodí zejména, když utratí všechny peníze
 STR_0558    :Návštěvníci sedí po dvojicích v rotujících kabinách
@@ -159,7 +159,7 @@ STR_0571    :Kulaté vozy se otáčejí dokola při jízdě klikatou dřevěnou 
 STR_0572    :Lodě s velkou kapacitou jedou po širokém vodním kanále, vzhůru poháněné běžícím pásem, zrychlují z prudkých svahů, aby obrovským šplouchnutím namočily všechny návštěvníky
 STR_0573    :Vozy ve tvaru helikoptér, poháněné šlapáním, jezdí po ocelové dráze
 STR_0574    :Návštěvníci ve speciálních postrojích zavěšení v leže pod tratí, jedou přes zatáčky a obraty pozadu nebo čelem k zemi
-STR_0575    :Poháněné vlaky visící pod visutou kolejí převážejí návštěvníky po parku
+STR_0575    :Trakční vlaky zavěšné pod kolejí převážejí návštěvníky po parku
 STR_0577    :Vozy s dvěma podvozky jedou po dřevěné trati, otáčející se dokola na speciálních místech
 STR_0578    :Horská dráha, která se točí dokola tak, že návštěvníci jsou pořád na stejném místě.
 STR_0579    :Pohodový minigolf

--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -2067,7 +2067,7 @@
         "reference-name": "American Style Steam Trains",
         "name": "Americké parní vlaky",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny s plátěnými střechami",
+        "description": "Miniaturní parní vláčky tvořené replikou parní lokomotivy s tendrem a vagony s plátěnými střechami",
         "reference-capacity": "6 passengers per carriage",
         "capacity": "6 míst v každém vagónu"
     },
@@ -2279,17 +2279,17 @@
     },
     "rct2.ride.clift1": {
         "reference-name": "Chairlift Cars",
-        "name": "Kryté sedačkové lanovky",
+        "name": "Zavěšené sedačky",
         "reference-description": "Open cars for chairlift",
-        "description": "Lanovka se sedačkami se střechou",
+        "description": "Závěsy se sedačkami pro lanovou dráhu",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa na jedné sedačce"
     },
     "rct2.ride.clift2": {
         "reference-name": "Ski-lift Chairs",
-        "name": "Sedačkové lanovky",
+        "name": "Kryté zavěšené sedačky",
         "reference-description": "Open cars for chairlift",
-        "description": "Lanovka se sedačkami",
+        "description": "Zastřešené závěsy se sedačkami pro lanovou dráhu",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa na jedné sedačce"
     },
@@ -2631,7 +2631,7 @@
         "reference-name": "Streamlined Monorail Trains",
         "name": "Aerodynamické jednokolejné vlaky",
         "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
-        "description": "Velkokapacitní jednokolejné vlaky s aerodynamickou přídí a zádí",
+        "description": "Velkokapacitní jednokolejné vlaky s aerodynamickými předními a zadními vozy",
         "reference-capacity": "5 or 10 passengers per car",
         "capacity": "5 nebo 10 míst v každém vagónu"
     },
@@ -2639,7 +2639,7 @@
         "reference-name": "Small Monorail Cars",
         "name": "Malé jednokolejné vozy",
         "reference-description": "Small monorail cars with open sides",
-        "description": "Malé jednokolejné vozy bez dveří",
+        "description": "Malé jednokolejné vozy s otevřenými boky",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2663,7 +2663,7 @@
         "reference-name": "Steam Trains",
         "name": "Parní vlaky",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling open wooden carriages",
-        "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny",
+        "description": "Miniaturní parní vláčky tvořené replikou parní lokomotivy s tendrem a dřevěnými vagóny",
         "reference-capacity": "6 passengers per carriage",
         "capacity": "6 míst v každém vagónu"
     },
@@ -2671,7 +2671,7 @@
         "reference-name": "Steam Trains with Covered Cars",
         "name": "Parní vlaky s krytými vozy",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
-        "description": "Miniaturní replika parní lokomotivy s tendrem táhne dřevěné vagóny s plátěnými střechami",
+        "description": "Miniaturní parní vláčky tvořené replikou parní lokomotivy s tendrem a dřevěnými vagony s plátěnými střechami",
         "reference-capacity": "6 passengers per carriage",
         "capacity": "6 míst v každém vagónu"
     },
@@ -2885,9 +2885,9 @@
     },
     "rct2.ride.smono": {
         "reference-name": "Suspended Monorail Trains",
-        "name": "Zavěšené jednokolejné vlaky",
+        "name": "Vlaky visuté dráhy",
         "reference-description": "Large capacity monorail train cars",
-        "description": "Velkokapacitní jednokolejné vlaky",
+        "description": "Velkokapacitní vlaky visuté dráhy",
         "reference-capacity": "8 passengers per car",
         "capacity": "8 míst v každém vozu"
     },
@@ -3061,7 +3061,7 @@
         "reference-name": "Trams",
         "name": "Tramvaje",
         "reference-description": "Old-timer replica trams",
-        "description": "Retro repliky tramvají",
+        "description": "Repliky historických tramvají",
         "reference-capacity": "10 passengers per car",
         "capacity": "10 míst v každém vozu"
     },
@@ -6173,9 +6173,9 @@
     },
     "rct2tt.ride.schoolbs": {
         "reference-name": "School Bus Trams",
-        "name": "Školní autobus - tramvaj",
+        "name": "Školní autobus jako tramvaj",
         "reference-description": "Miniature trams themed to look like North American school buses",
-        "description": "Replika amerických žlutých školních autobusů",
+        "description": "Miniaturní tramvaje ve stylu severoamerických školních autobusů",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
@@ -6213,7 +6213,7 @@
         "reference-name": "Teleporter Cabin",
         "name": "Teleportér",
         "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
-        "description": "Návštěvníci jsou transportování z jednoho patra do druhého",
+        "description": "Futuristická výtahová klec vytvářející iluzi teleportace mezi patry",
         "reference-capacity": "16 passengers",
         "capacity": "16 návštěvníků"
     },
@@ -6267,9 +6267,9 @@
     },
     "rct2tt.ride.zeplelin": {
         "reference-name": "Airship Themed Monorail Trains",
-        "name": "Jednokolejné vlaky připomínající vzducholoď",
+        "name": "Vlaky visuté dráhy ve stylu vzducholodí",
         "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
-        "description": "Velkokapacitní jednokolejné vlaky s aerodynamickou přídí a zádí",
+        "description": "Velkokapacitní vlaky visuté dráhy, s aerodynamickými předními a zadními vozy",
         "reference-capacity": "8 passengers per car",
         "capacity": "8 míst v každém vagónu"
     },
@@ -8875,9 +8875,9 @@
     },
     "rct2ww.ride.londonbs": {
         "reference-name": "Routemaster Buses",
-        "name": "Tramvaj ve tvaru Londýnského autobusu",
+        "name": "Dvoupatrové autobusy",
         "reference-description": "Replicas of the famous London Routemaster bus",
-        "description": "Repliky červených dvoupatrových londýnských autobusů",
+        "description": "Repliky slavných londýnských autobusů Routemaster",
         "reference-capacity": "10 passengers per car",
         "capacity": "10 míst v každém voze"
     },
@@ -8909,7 +8909,7 @@
         "reference-name": "Mine Lift Cabin",
         "name": "Důlní výtah",
         "reference-description": "A steel lift cabin commonly used in mines",
-        "description": "Výtah s ocelovou kabinou připomínající důlní výtah",
+        "description": "Výtah s ocelovou kabinou ve stylu důlní výtahové klece",
         "reference-capacity": "16 passengers",
         "capacity": "16 návštěvníků"
     },
@@ -8971,9 +8971,9 @@
     },
     "rct2ww.ride.sanftram": {
         "reference-name": "San Francisco Trams",
-        "name": "Tramvaj ze San Francisca",
+        "name": "Sanfranciské tramvaje",
         "reference-description": "Replicas of the San Francisco Trams",
-        "description": "Repliky tramvají",
+        "description": "Repliky tramvají ze San Francisca",
         "reference-capacity": "10 passengers per car",
         "capacity": "10 míst v každém voze"
     },
@@ -9011,9 +9011,9 @@
     },
     "rct2ww.ride.steamtrn": {
         "reference-name": "Maharaja Steam Trains",
-        "name": "Mahárádžova parní lokomotiva",
+        "name": "Mahárádžovy parní vlaky",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
-        "description": "Miniaturní replika parní lokomotivy s tendrem táhne kryté dřevěné vagóny",
+        "description": "Miniaturní parní vláčky tvořené replikou parní lokomotivy s tendrem a zastřešenými dřevěnými vagony",
         "reference-capacity": "6 passengers per carriage",
         "capacity": "6 míst v každém vagónu"
     },


### PR DESCRIPTION
Improve legacy transport rides translations, change confusing translations, change translations where car of given ride is mistaken for ride itself.

For ease of review, screenshots included, gray being the current state, colored being the PR
_____________

**Change translation for two different transport rides being translated into same name - it looked like a interface bug:**

<img width="603" height="383" alt="stare_mono" src="https://github.com/user-attachments/assets/167d74cd-251a-41f9-998e-a626a8a5810c" />
<img width="603" height="383" alt="stare_visuta" src="https://github.com/user-attachments/assets/3ac96b9a-a686-4539-a1e3-948258b6ac87" />
<img width="603" height="383" alt="nove_mono" src="https://github.com/user-attachments/assets/03078f82-6205-498d-988f-03b9334d8e9b" />
<img width="603" height="383" alt="nove_visute" src="https://github.com/user-attachments/assets/1431baba-d096-47c1-899c-a3b4d5c39659" />

____________

**Chairlift listed its cars as "chairlift ride":**

<img width="603" height="383" alt="stare_lanovka" src="https://github.com/user-attachments/assets/846411f6-05ef-4d61-becd-f868a390f311" />
<img width="603" height="383" alt="nove_lanovka" src="https://github.com/user-attachments/assets/c18964d2-2925-4d44-b632-dfe1c747e7d6" />

____________

Minor changes not shown in screenshots

