### PR TITLE
cs-CZ: Improve gentle rides translations

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -112,7 +112,7 @@ STR_0519    :Návštěvníci jedou zavěšení pod jednou kolejí v malých kabi
 STR_0520    :Přístavní molo, kde návštěvníci mohou řídit osobní plavidlo na vodní hladině
 STR_0521    :Rychlá a mrštná horská dráha s ostrými zatáčkami a strmými svahy. Dráha je předurčená k vysoké intenzitě.
 STR_0522    :Menší horská dráha, na které návštěvníci sedí nad dráhou bez kabiny kolem sebe
-STR_0523    :Návštěvníci jedou pomalu ve vozidlech po postavené dráze.
+STR_0523    :Návštěvnící jedou po trati v pomalu jedoucích vozidlech
 STR_0524    :Kabina pro volný pád je pneumaticky vystřelena vzhůru po vysoké ocelové věži a následně volně padá k zemi
 STR_0525    :Návštěvníci jedou po propletené bobové dráze
 STR_0526    :Otáčející se vyhlídková kabina, která postupně vyjíždí na vysokou věž
@@ -165,9 +165,9 @@ STR_0578    :Horská dráha, která se točí dokola tak, že návštěvníci js
 STR_0579    :Pohodový minigolf
 STR_0580    :Gigantická ocelová horská dráha schopna volných pádů a kopců přes 90 metrů dlouhých
 STR_0581    :Kruh sedadel je za pomalé rotace vytažen na vrchol vysoké věže, spuštěn volným pádem k zemi a opatrně zastaven pomocí magnetických brzd
-STR_0582    :Návštěvníci volně jezdí na vznášedlech.
+STR_0582    :Návštěvníci volně jezdí na vznášedlech
 STR_0583    :Budova s pokřivenými chodbami a zvláštními místnostmi, která dezorientuje návštěvníky
-STR_0584    :Speciální kola jezdí po ocelové koleji, poháněná šlapáním jezdců
+STR_0584    :Speciální kola poháněná šlapáním jezdců jezdí po ocelové koleji
 STR_0585    :Návštěvníci sedí po dvou zavěšení pod tratí a jedou skrze loopingy a ostré zatáčky
 STR_0586    :Vozy ve tvaru lodí jedou po trati horské dráhy, což umožňuje ostré zatáčky, strmé klesání a cákající zpomalení pro mírnější říční úseky
 STR_0587    :Po mocném startu na stlačený vzduch se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice
@@ -3195,7 +3195,7 @@ STR_6101    :Hodnota atrakcí časem nedegraduje
 STR_6102    :Hodnota atrakce nebude s postupem času klesat, takže návštěvníci nebudou najednou mít pocit, že je vstupné moc drahé.
 STR_6103    :Tato volba není ve hře více hráčů dostupná.
 STR_6105    :Hyper horská dráha
-STR_6107    :Monster Trucks
+STR_6107    :Monster trucky
 STR_6109    :Hyper-Twister horská dráha
 STR_6111    :Klasická malá horská dráha
 STR_6113    :Vysoká horská dráha s dlouhými pády, velkou rychlostí a pohodlnými vlaky, kde se jezdí s opěrkou v klíně

--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -2057,9 +2057,9 @@
     },
     "rct2.ride.4x4": {
         "reference-name": "Monster Trucks",
-        "name": "Monster Trucks",
+        "name": "Monster trucky",
         "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
-        "description": "Obří auta s pohonem 4x4, které jsou schopna vyjíždět velmi strmé svahy",
+        "description": "Obří auta s pohonem 4x4 schopné vyjet velmi strmé svahy",
         "reference-capacity": "2 passengers per truck",
         "capacity": "2 místa v každém vozu"
     },
@@ -2235,7 +2235,7 @@
         "reference-name": "Crooked House",
         "name": "Křivý dům",
         "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
-        "description": "Budova s pokřivenými místnostmi a nakloněnými chodbami, které dezorientují návštěvníky",
+        "description": "Budova s pokřivenými místnostmi a nakloněnými chodbami, která dezorientuje návštěvníky",
         "reference-capacity": "5 guests",
         "capacity": "5 návštěvníků"
     },
@@ -2321,9 +2321,9 @@
     },
     "rct2.ride.ctcar": {
         "reference-name": "Cheshire Cats",
-        "name": "Autodráha",
+        "name": "Kočky Šklíba",
         "reference-description": "Powered cat-shaped vehicles",
-        "description": "Malá autíčka jezdí po postavené dráze",
+        "description": "Poháněné autíčka ve tvaru koček",
         "reference-capacity": "2 passengers per cat",
         "capacity": "2 místa v každém vozu"
     },
@@ -2337,9 +2337,9 @@
     },
     "rct2.ride.dodg1": {
         "reference-name": "Dodgems",
-        "name": "Autodrom",
+        "name": "Autíčka",
         "reference-description": "Riders bump into each other in self-drive electric dodgems",
-        "description": "Autodrom s elektrickými autíčky",
+        "description": "Návštěvníci do sebe bourají v autíčcích na autodromu",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -2379,7 +2379,7 @@
         "reference-name": "Flying Saucers",
         "name": "Létající talíře",
         "reference-description": "Guests ride in saucer-shaped hovercraft vehicles that they freely control",
-        "description": "Autodrom se vznášedly",
+        "description": "Návštěvníci jedou ve volně ovladatelných vznášedlech ve tvaru létajících talířů",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -2461,15 +2461,15 @@
         "reference-name": "Maze",
         "name": "Bludiště",
         "reference-description": "Maze is constructed from 6-foot tall hedges or walls, and guests wander around the maze leaving only when they find the exit",
-        "description": "Bludiště je postavené z 2 metrů vysokého živého plotu, nebo zdí. Návštěvníci v něm bloudí, dokud nenaleznou východ",
+        "description": "Bludiště je postavené z 2 metrů vysokého živého plotu nebo zdí, a návštěvníci v něm bloudí, dokud nenaleznou východ",
         "reference-capacity": "",
         "capacity": ""
     },
     "rct2.ride.hmcar": {
         "reference-name": "Haunted Mansion Cars",
-        "name": "Jízda domem hrůzy",
+        "name": "Vozy domu hrůzy",
         "reference-description": "Small powered cars that run on a ghost train track",
-        "description": "Vozy jezdí po vícepatrovém okruhu okolo strašidelných kulis a speciálních efektů",
+        "description": "Poháněné vozy jezdící na trati plné duchů",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2677,19 +2677,19 @@
     },
     "rct2.ride.obs1": {
         "reference-name": "Single-deck Cabin",
-        "name": "Vyhlídková věž",
+        "name": "Vyhlídková kabina",
         "reference-description": "Single-deck rotating observation cabin",
-        "description": "Otáčející se vyhlídková kabina, která postupně vyjíždí na vysokou věž",
+        "description": "Otáčející se vyhlídková kabina",
         "reference-capacity": "20 passengers",
-        "capacity": "20 návštěvníků"
+        "capacity": "20 míst"
     },
     "rct2.ride.obs2": {
         "reference-name": "Double-deck Cabin",
-        "name": "Dvoupatrová vyhlídková věž",
+        "name": "Dvoupatrová vyhlídková kabina",
         "reference-description": "Twin-deck rotating observation cabin",
-        "description": "Otáčející se dvoupatrová vyhlídková věž, která postupně vyjíždí na vysokou věž",
+        "description": "Otáčející se dvoupatrová vyhlídková věž",
         "reference-capacity": "32 passengers",
-        "capacity": "32 návštěvníků"
+        "capacity": "32 míst"
     },
     "rct2.ride.pizzs": {
         "reference-name": "Pizza Stall",
@@ -5889,9 +5889,9 @@
         "reference-name": "Blob from Outer Space",
         "name": "Mimozemská hmota",
         "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
-        "description": "Tématická vyhlídková věž s kabinou, která postupně vyjede až na vrchol a zpět dolů",
+        "description": "Tematická vyhlídková kabina ve tvaru mimozemské hmoty z béčkového filmu",
         "reference-capacity": "20 passengers",
-        "capacity": "20 návštěvníků"
+        "capacity": "20 míst"
     },
     "rct2tt.ride.cavmncar": {
         "reference-name": "Caveman Cars",
@@ -5911,9 +5911,9 @@
     },
     "rct2tt.ride.cyclopsx": {
         "reference-name": "Cyclops Dodgems",
-        "name": "Kyklopský autodrom",
+        "name": "Kyklopská autíčka",
         "reference-description": "Riders drive the Eye of a Giant Cyclops",
-        "description": "Autodrom s elektrickými autíčky ve tvaru oka gigantického kyklopa",
+        "description": "Návštěvníci jedou v oku obrovského kyklopaf",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -5935,9 +5935,9 @@
     },
     "rct2tt.ride.figtknit": {
         "reference-name": "Fighting Knights Dodgems",
-        "name": "Rytířský autodrom",
+        "name": "Autíčka s bojujícími rytíři",
         "reference-description": "Riders joust on horse-themed dodgems",
-        "description": "Autodrom s elektrickými autíčky ve tvaru koní",
+        "description": "Návštěvníci se utkávají v autíčkách ve tvaru koní",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -5945,15 +5945,15 @@
         "reference-name": "Mace Ride",
         "name": "Palicová jízda",
         "reference-description": "Riders sit on a themed chair which is attached to a motor driven spinning arm.",
-        "description": "Návštěvníci sedí na židlích připevněných na otáčející se ramena",
+        "description": "Návštěvníci sedí na dobově vyzdobených sedačkách připevněných na otáčející se ramena",
         "reference-capacity": "1 guest per chair",
-        "capacity": "1 místo na každé židli"
+        "capacity": "1 místo na každé sedačcce"
     },
     "rct2tt.ride.flwrpowr": {
         "reference-name": "Flower Power Dodgems",
         "name": "Květinová vznášedla",
         "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
-        "description": "Autodrom se vznášedly ve tvaru květů květin",
+        "description": "Návštěvníci jedou ve volně ovladatelných vznášedlech ve tvaru květin",
         "reference-capacity": "1 passenger per car",
         "capacity": "1 místo v každém voze"
     },
@@ -5993,7 +5993,7 @@
         "reference-name": "Hall of Mirrors",
         "name": "Zrcadlové bludiště",
         "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
-        "description": "Budova s pokřivenými zrcadly",
+        "description": "Budova s pokřivenými zrcadly zkreslujícími odraz návštevníka",
         "reference-capacity": "5 guests",
         "capacity": "5 návštěvníků"
     },
@@ -6023,9 +6023,9 @@
     },
     "rct2tt.ride.hovercar": {
         "reference-name": "Hover Cars",
-        "name": "Autodráha se vznášedly",
+        "name": "Létající autíčka",
         "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
-        "description": "Vozy ve tvaru futuristických vznášedel jezdí po postavené dráze",
+        "description": "Využití technologie magnetické levitace pro vytvoření iluze futuristických létajících aut",
         "reference-capacity": "1 passenger per car",
         "capacity": "1 místo v každém voze"
     },
@@ -6125,9 +6125,9 @@
     },
     "rct2tt.ride.pegasusx": {
         "reference-name": "Pegasus Cars",
-        "name": "Autodráha s Pegasem",
+        "name": "Povozy s Pegasem",
         "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
-        "description": "Vozy ve tvaru povozů tažených Pegasem jezdí po postavené dráze",
+        "description": "Poháněná vozidla ve tvaru Pegase táhnoucího za sebou vůz",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
@@ -6197,7 +6197,7 @@
         "reference-name": "Haunted Jail House",
         "name": "Strašidelná věznice",
         "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
-        "description": "Budova s podzemím a figurínami vězňů straší procházející návštěvníky",
+        "description": "Budova s bludištěm a figurínami vězňů, kde procházející návštěvníci zažijí pocit strachu",
         "reference-capacity": "16 guests",
         "capacity": "16 návštěvníků"
     },
@@ -6243,9 +6243,9 @@
     },
     "rct2tt.ride.tricatop": {
         "reference-name": "Triceratops Dodgems",
-        "name": "Autodrom s Triceratopsem",
+        "name": "Autíčka s triceratopsem",
         "reference-description": "Riders lock horns with each other in triceratops dodgems",
-        "description": "Autodrom s vozy ve tvaru Triceratopsů",
+        "description": "Návštěvníci si potrkají rohy v autíčkách ve tvaru triceratopse",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -8635,9 +8635,9 @@
     },
     "rct2ww.ride.blackcab": {
         "reference-name": "Black Cabs",
-        "name": "Autodráha s Londýnskými taxíky",
+        "name": "Londýnské taxíky",
         "reference-description": "Powered vehicles in the shape of London Taxis",
-        "description": "Vozy ve tvaru Londýnských taxíků jezdí po postavené dráze",
+        "description": "Poháněná vozidla ve tvaru londýnských taxíků",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
@@ -8691,25 +8691,25 @@
     },
     "rct2ww.ride.crnvbfly": {
         "reference-name": "Carnival Butterfly Cars",
-        "name": "Motýlková autodráha",
+        "name": "Motýlková auta",
         "reference-description": "Cars in the shape of butterfly carnival floats",
-        "description": "Vozy ve tvaru motýlů jezdí po postavené dráze",
+        "description": "Motýlí alegorické vozy",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
     "rct2ww.ride.crnvfrog": {
         "reference-name": "Carnival Frog Cars",
-        "name": "Žabí autodráha",
+        "name": "Žabí auta",
         "reference-description": "Cars in the shape of frog carnival floats",
-        "description": "Vozy ve tvaru žab jezdí po postavené dráze",
+        "description": "Žabí alegorické vozy",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
     "rct2ww.ride.crnvlzrd": {
         "reference-name": "Carnival Lizard Cars",
-        "name": "Ještěrčí autodráha",
+        "name": "Ještěrčí auta",
         "reference-description": "Cars in the shape of lizard carnival floats",
-        "description": "Vozy ve tvaru ještěrek jezdí po postavené dráze",
+        "description": "Ještěrčí alegorické vozy",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
@@ -8747,9 +8747,9 @@
     },
     "rct2ww.ride.dragdodg": {
         "reference-name": "Chinese Dragonhead Dodgems",
-        "name": "Čínská dračí hlava",
+        "name": "Čínské dračí hlavy",
         "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
-        "description": "Autodrom s vozy ve tvaru dračích hlav",
+        "description": "Návštěvníci mezi sebou bojují v autíčkách ve tvaru dračích hlav",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },
@@ -8819,9 +8819,9 @@
     },
     "rct2ww.ride.huskie": {
         "reference-name": "Huskie Car",
-        "name": "Autodráha se saněmi",
+        "name": "Psí spřežení",
         "reference-description": "Powered vehicles in the shape of Huskie sleds",
-        "description": "Vozy ve tvaru sněžných saní jezdí po postavené dráze",
+        "description": "Poháněná vozidla ve tvaru psích spřežení",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém voze"
     },
@@ -8987,9 +8987,9 @@
     },
     "rct2ww.ride.skidoo": {
         "reference-name": "Snowmobile Dodgems",
-        "name": "Sněžné vozy",
+        "name": "Sněžné skůtry",
         "reference-description": "Guests slide around in snowmobile-shaped vehicles that they freely control",
-        "description": "Autodrom s vozy ve tvaru sněžných vozů",
+        "description": "Návštěvníci se klouzají ve volně ovladatelných sněžných skůtrech",
         "reference-capacity": "1 person per car",
         "capacity": "1 místo v každém voze"
     },


### PR DESCRIPTION
Improve legacy gentle rides translations, change confusing translations, change translations where car of given ride is mistaken for ride itself.

For ease of review, screenshots with two examples of conducted changes are folowing, gray being the current state, colored being the PR

________

<img width="336" height="241" alt="stara autodraha" src="https://github.com/user-attachments/assets/c801ceca-6c13-45a5-b87c-c10d09293a84" />
<img width="336" height="241" alt="nova autodraha" src="https://github.com/user-attachments/assets/e72ea355-a7b9-4a46-9cb6-aaa8314f516f" />

_________

<img width="336" height="241" alt="stary autodrom" src="https://github.com/user-attachments/assets/ffaf157c-584e-42eb-8982-06025d2700c9" />
<img width="336" height="241" alt="novy autodrom" src="https://github.com/user-attachments/assets/2c5efe1e-75db-4210-bf94-69340e8d968c" />
