### PR TITLE
cs-CZ: Improve transport water rides translation

### DIFF
--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -82,7 +82,7 @@ STR_0077    :Svislá dráha na stlačený vzduch
 STR_0078    :Ostrá zavěšená horská dráha
 STR_0079    :Kouzelný koberec
 STR_0080    :Podmořská jízda
-STR_0081    :Říční rafty
+STR_0081    :Říční vory
 STR_0082    :Neznámá atrakce (50)
 STR_0083    :Loď Enterprise
 STR_0084    :Neznámá atrakce (52)
@@ -124,8 +124,8 @@ STR_0531    :Malá ocelová horská dráha, na které vlak projíždí smyčky a
 STR_0532    :Bludiště z šest stop vysokých zdí nebo živého plotu. Návštěvníci bloudí dokud nenajdou východ
 STR_0533    :Dřevěná budova s krytým schodištěm a venkovní skluzavkou s koberečky
 STR_0534    :Návštěvníci závodí v motokárách po asfaltovém okruhu
-STR_0535    :Lodě plují ve vodním kanále a sjíždí strmé klesání, až z toho jsou návštěvníci mokří.
-STR_0536    :Loď pluje po širokých meandrech, přes stříkající vodopády a po vzrušujících pěnících peřejích
+STR_0535    :Lodě plují ve vodním kanále a sjíždí strmé klesání, voda při tom stříká na všechny strany a smáčí návštěvníky
+STR_0536    :Lodě plují po širokých meandrech, přes stříkající vodopády a po divokých pěnících peřejích
 STR_0537    :Návštěvníci do sebe bourají v autíčcích na autodromu
 STR_0538    :Velká houpající se pirátská kocábka
 STR_0539    :Loď je připevněna k rameni s protiváhou. Loď se houpe a může se zhoupnout až o 360 stupňů
@@ -156,7 +156,7 @@ STR_0566    :Malá horská dráha, na které vozy po jednom projíždí cik-cak 
 STR_0567    :Vozy se sedadly schopny otáčet návštěvníky vzhůru nohama
 STR_0569    :Jízda ve speciálních postrojích zavěšených pod tratí, poskytuje pocit letu jako pták
 STR_0571    :Kulaté vozy se otáčejí dokola při jízdě klikatou dřevěnou tratí
-STR_0572    :Lodě s velkou kapacitou jedou po širokém vodním kanále, vzhůru poháněné běžícím pásem, zrychlují z prudkých svahů, aby obrovským šplouchnutím namočily všechny návštěvníky
+STR_0572    :Velkokapacitní lodě se plaví po širokém kanále, stoupání vyjíždí po dopravníkovém pásu, na konci klesání pořádně šplouchnou a smáčí návštěvníky 
 STR_0573    :Vozy ve tvaru helikoptér, poháněné šlapáním, jezdí po ocelové dráze
 STR_0574    :Návštěvníci ve speciálních postrojích zavěšení v leže pod tratí, jedou přes zatáčky a obraty pozadu nebo čelem k zemi
 STR_0575    :Trakční vlaky zavěšné pod kolejí převážejí návštěvníky po parku
@@ -173,8 +173,8 @@ STR_0586    :Vozy ve tvaru lodí jedou po trati horské dráhy, což umožňuje 
 STR_0587    :Po mocném startu na stlačený vzduch se vozy rozjedou po svislé dráze, přes vrchol a svisle dolů zpět do stanice
 STR_0588    :Vozy po jednom jedou pod cik-cak tratí s ostrými zatáčkami a pády
 STR_0589    :Vozy připomínající létající koberce se pohybují nahoru a dolů
-STR_0590    :Návštěvníci vyrazí na podvodní jízdu v ponorce
-STR_0591    :Rafty se plaví po meandrech na vodním kanále
+STR_0590    :Návštěvníci vyrazí na podvodní plavbu v ponorce
+STR_0591    :Vory se plaví po meandrech na vodním kanále
 STR_0593    :Řetízkáč s náklonem
 STR_0598    :Vozy vyrazí vstříc jednomu konci trati, poté prosviští pozpátku stanicí a vyletí až na druhý konec trati
 STR_0599    :Malá horská dráha, na které vozy po jednom projíždí trať s kroucenými pády

--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -159,9 +159,9 @@
         "reference-name": "Dinghies",
         "name": "Nafukovací čluny",
         "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
-        "description": "Návštěvníci jedou v nafukovacích člunech po tobogánu",
+        "description": "Nafukovací čluny pro tobogánovovu trať",
         "reference-capacity": "2 passengers per dinghy",
-        "capacity": "2 místa v každé lodi"
+        "capacity": "2 místa v každém člunu"
     },
     "rct1.ride.dodgems": {
         "reference-name": "Dodgems",
@@ -219,9 +219,9 @@
     },
     "rct1.ride.logs": {
         "reference-name": "Logs",
-        "name": "Divoká řeka",
+        "name": "Klády",
         "reference-description": "Log-shaped boats built for running in water channels",
-        "description": "Lodě ve tvaru klád se plaví po vodním kanálu a cákají. Nikdo nezůstane suchý",
+        "description": "Lodě ve tvaru klád určené pro jízdu ve vodních kanálech",
         "reference-capacity": "4 passengers per boat",
         "capacity": "4 místa v každé lodi"
     },
@@ -283,9 +283,9 @@
     },
     "rct1.ride.river_rapids_boats": {
         "reference-name": "River Rapids Boats",
-        "name": "Divoká voda",
+        "name": "Kulaté lodě",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
-        "description": "Kulaté lodě se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
+        "description": "Točící se kulaté lodě plující skrze zakroucené meandry a rozstřikující vodu",
         "reference-capacity": "8 passengers per boat",
         "capacity": "8 míst v každé lodi"
     },
@@ -1301,19 +1301,19 @@
     },
     "rct1ll.ride.jet_skis": {
         "reference-name": "Jet Skis",
-        "name": "Vodní lyže",
+        "name": "Vodní skútry",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
-        "description": "Návštěvníci jezdí na vodních lyžích",
+        "description": "Jednomístné vodní skútry řízené návštěvníky",
         "reference-capacity": "1 rider per vehicle",
-        "capacity": "1 místo na každých lyžích"
+        "capacity": "1 místo na každém skútru"
     },
     "rct1ll.ride.rafts": {
         "reference-name": "Rafts",
-        "name": "Říční rafty",
+        "name": "Říční vory",
         "reference-description": "Raft-shaped boats built for flat river tracks",
-        "description": "Rafty se plaví po meandrech na vodním kanále",
+        "description": "Lodě ve stylu vorů pro plavbu na plochých tratích",
         "reference-capacity": "4 passengers per raft",
-        "capacity": "4 místa na každém raftu"
+        "capacity": "4 místa na každém voru"
     },
     "rct1ll.ride.steam_trains_american": {
         "reference-name": "American Style Steam Trains",
@@ -2143,7 +2143,7 @@
         "reference-name": "Bumper Boats",
         "name": "Malé čluny",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
-        "description": "Malé čluny s motorovým pohonem ovládaným návštěvníky",
+        "description": "Malé kulaté čluny s uprostřed namontovaným motorovým pohonem ovládaným návštěvníky",
         "reference-capacity": "2 passengers per boat",
         "capacity": "2 místa v každé lodi"
     },
@@ -2227,7 +2227,7 @@
         "reference-name": "Canoes",
         "name": "Kánoe",
         "reference-description": "Long canoes which the passengers paddle themselves",
-        "description": "Dlouhé kánoe, u kterých musí návštěvníci pádlovat",
+        "description": "Dlouhé kánoe poháněné pádlováním návštěvníků",
         "reference-capacity": "2 passengers per canoe",
         "capacity": "2 místa v každé lodi"
     },
@@ -2331,9 +2331,9 @@
         "reference-name": "Dinghies",
         "name": "Nafukovací čluny",
         "reference-description": "Inflatable dinghies that can twist down a semi-circular or completely enclosed tube track",
-        "description": "Návštěvníci jedou v nafukovacích člunech po tobogánu",
+        "description": "Nafukovací čluny na tobogánové trati",
         "reference-capacity": "2 passengers per dinghy",
-        "capacity": "2 místa v každé lodi"
+        "capacity": "2 místa v každém člunu"
     },
     "rct2.ride.dodg1": {
         "reference-name": "Dodgems",
@@ -2545,11 +2545,11 @@
     },
     "rct2.ride.jski": {
         "reference-name": "Jet Skis",
-        "name": "Vodní lyže",
+        "name": "Vodní skútry",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
-        "description": "Návštěvníci jezdí na vodních lyžích",
+        "description": "Jednomístné vodní skútry řízené návštěvníky",
         "reference-capacity": "1 rider per vehicle",
-        "capacity": "1 místo na každých lyžích"
+        "capacity": "1 místo na každém skútru"
     },
     "rct2.ride.jstar1": {
         "reference-name": "Toboggan Cars",
@@ -2575,9 +2575,9 @@
     },
     "rct2.ride.lfb1": {
         "reference-name": "Logs",
-        "name": "Divoká řeka",
+        "name": "Klády",
         "reference-description": "Log-shaped boats built for running in water channels",
-        "description": "Lodě ve tvaru klád se plaví po vodním kanálu a cákají. Nikdo nezůstane suchý",
+        "description": "Lodě ve tvaru klád určené pro jízdu ve vodních kanálech",
         "reference-capacity": "4 passengers per boat",
         "capacity": "4 místa v každé lodi"
     },
@@ -2751,9 +2751,9 @@
     },
     "rct2.ride.rapboat": {
         "reference-name": "River Rapids Boats",
-        "name": "Divoká voda",
+        "name": "Kulaté lodě",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
-        "description": "Kulaté lodě se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
+        "description": "Točící se kulaté lodě plující skrze zakroucené meandry a rozstřikující vodu",
         "reference-capacity": "8 passengers per boat",
         "capacity": "8 míst v každé lodi"
     },
@@ -2761,7 +2761,7 @@
         "reference-name": "Rowing Boats",
         "name": "Veslice",
         "reference-description": "Rowing boats which passengers row themselves",
-        "description": "Veslice, u kterých musí návštěvníci veslovat",
+        "description": "Návštevníci si sami veslují na lodičkách",
         "reference-capacity": "2 passengers per boat",
         "capacity": "2 místa v každé lodi"
     },
@@ -2799,11 +2799,11 @@
     },
     "rct2.ride.rftboat": {
         "reference-name": "Rafts",
-        "name": "Říční rafty",
+        "name": "Říční vory",
         "reference-description": "Raft-shaped boats built for flat river tracks",
-        "description": "Rafty se plaví po meandrech na vodním kanále",
+        "description": "Lodě vypadající jako vory pro plavbu na plochých tratích",
         "reference-capacity": "4 passengers per raft",
-        "capacity": "4 místa na každém raftu"
+        "capacity": "4 místa na každém voru"
     },
     "rct2.ride.rsaus": {
         "reference-name": "Roast Sausage Stall",
@@ -2977,7 +2977,7 @@
         "reference-description": "Riders ride in a submerged submarine through an underwater course",
         "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce",
         "reference-capacity": "5 passengers per submarine",
-        "capacity": "5 návštěvníci v každé ponorce"
+        "capacity": "5 míst v každé ponorce"
     },
     "rct2.ride.substl": {
         "reference-name": "Sub Sandwich Stall",
@@ -2995,9 +2995,9 @@
         "reference-name": "Swans",
         "name": "Labutě",
         "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
-        "description": "Lodě ve tvaru labutí, ovládané šlapáním návštěvníků",
+        "description": "Šlapadla ve tvaru labutí poháněné návštěvníky sedícími vepředu",
         "reference-capacity": "4 passengers per boat",
-        "capacity": "4 místa na každém raftu"
+        "capacity": "4 místa na každé lodi"
     },
     "rct2.ride.swsh1": {
         "reference-name": "Pirate Ship",
@@ -6117,9 +6117,9 @@
     },
     "rct2tt.ride.oakbarel": {
         "reference-name": "Oak Barrels",
-        "name": "Jízda v dubovém sudu",
+        "name": "Dubové sudy",
         "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
-        "description": "Lodě ve tvaru dubových barelů se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
+        "description": "Lodě ve tvaru dubových sudů se plaví po meandrech na vodním kanále a sjíždějí pěnící peřeje",
         "reference-capacity": "8 passengers per boat",
         "capacity": "8 míst v každé lodi"
     },
@@ -6165,9 +6165,9 @@
     },
     "rct2tt.ride.rivrstyx": {
         "reference-name": "River Styx boats",
-        "name": "Řeka Styx",
+        "name": "Cháronovy čluny",
         "reference-description": "Boats with an Underworld theme, built for flat river tracks",
-        "description": "Rafty se plaví po meandrech na vodním kanále",
+        "description": "Lodě ve stylu řeckého podsvětí pro plavbu na plochých tratích",
         "reference-capacity": "4 passengers per raft",
         "capacity": "4 místa na každém raftu"
     },
@@ -8715,17 +8715,17 @@
     },
     "rct2ww.ride.crocflum": {
         "reference-name": "Crocodile Boats",
-        "name": "Krokodýlí jízda",
+        "name": "Krokodýlí lodě",
         "reference-description": "Crocodile-shaped boats built for running in water channels",
-        "description": "Lodě ve tvaru krokodýlů se plaví po vodním kanálu a cákají. Nikdo nezůstane suchý",
+        "description": "Lodě ve tvaru krokodýlů určené pro jízdu ve vodních kanálech",
         "reference-capacity": "4 passengers per boat",
         "capacity": "4 místa na každé lodi"
     },
     "rct2ww.ride.dhowwatr": {
         "reference-name": "Dhow Boats",
-        "name": "Plachetnice",
+        "name": "Arabské plachetnice",
         "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
-        "description": "Ozdobné plachetnice, u kterých musí návštěvníci pádlovat",
+        "description": "Ozdobné rybářské plachetnice poháněné pádlováním návštěvníků",
         "reference-capacity": "2 passengers per boat",
         "capacity": "2 místa na každé lodi"
     },
@@ -8739,9 +8739,9 @@
     },
     "rct2ww.ride.dolphinr": {
         "reference-name": "Dolphin Boats",
-        "name": "Delfíní jízda",
+        "name": "Delfíní loďky",
         "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
-        "description": "Lodě ve tvaru delfínů, které mohou návštěvníci ovládat",
+        "description": "Návštěvníci si sami veslují na jednomístných lodičkách ve tvaru delfína",
         "reference-capacity": "1 rider per vehicle",
         "capacity": "1 místo v každé lodi"
     },
@@ -8811,9 +8811,9 @@
     },
     "rct2ww.ride.hipporid": {
         "reference-name": "Hippo Submarines",
-        "name": "Hroší jízda",
+        "name": "Hroší ponorky",
         "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
-        "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce",
+        "description": "Návštěvníci vyrazí na podvodní plavbu v ponorce ve tvaru hrocha afrického",
         "reference-capacity": "5 passengers per submarine",
         "capacity": "5 míst v každé ponorce"
     },
@@ -8851,9 +8851,9 @@
     },
     "rct2ww.ride.killwhal": {
         "reference-name": "Killer Whale Submarines",
-        "name": "Zabijácká velryba",
+        "name": "Kosatčí ponorky",
         "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
-        "description": "Návštěvníci vyrazí na podvodní jízdu v ponorce ve tvaru",
+        "description": "Návštěvníci vyrazí na podvodní plavbu v ponorce ve tvaru kosatky dravé",
         "reference-capacity": "5 passengers per submarine",
         "capacity": "5 míst v každé ponorce"
     },
@@ -8885,7 +8885,7 @@
         "reference-name": "Mandarin Duck Boats",
         "name": "Čínské kachny",
         "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
-        "description": "Lodě ve tvaru kachen, ovládané šlapáním návštěvníků sedících vepředu",
+        "description": "Šlapadla ve tvaru kachen poháněné šlapáním návštěvníků",
         "reference-capacity": "2 passengers per boat",
         "capacity": "2 místa na každé lodi"
     },
@@ -8923,9 +8923,9 @@
     },
     "rct2ww.ride.outriggr": {
         "reference-name": "Outrigger Canoes",
-        "name": "Loď s vahadly",
+        "name": "Kánoe s vahadlem",
         "reference-description": "Long canoes which the passengers paddle themselves",
-        "description": "Dlouhé kánoe s postranními vahadly, u kterých musí návštěvníci pádlovat",
+        "description": "Dlouhé kánoe s postranním vahadlem poháněné pádlováním návštěvníků",
         "reference-capacity": "2 passengers per canoe",
         "capacity": "2 místa v každé lodi"
     },
@@ -9059,7 +9059,7 @@
     },
     "rct2ww.ride.tutlboat": {
         "reference-name": "Turtle Boats",
-        "name": "Želví jízda",
+        "name": "Želví loďky",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Malé čluny ve tvaru mořských želv s motorovým pohonem ovládaným návštěvníky",
         "reference-capacity": "2 passengers per boat",


### PR DESCRIPTION
Follow-up to:
- #3275 
- #3276

Improve legacy transport rides translations, change translations that were out of line, change translations where car of given ride is mistaken for ride itself. 

_________________

Sample of changes being submitted - gray being the current state, colored being the PR

<img width="616" height="397" alt="1g" src="https://github.com/user-attachments/assets/1bbec39b-8ad7-447c-a9cb-a9d598351328" />
<img width="616" height="397" alt="1n" src="https://github.com/user-attachments/assets/bff67a43-5901-44d2-b428-77728e131cd3" />

Note: "raft" translates to Czech as "vor", whereas "raft" in czech is used only for (semi)inflatable whitewater vessels, thus forming example of "false friends".

_______________

<img width="338" height="244" alt="2g" src="https://github.com/user-attachments/assets/2d03e19d-8d4f-41e8-aa09-a4246738a5f1" />
<img width="338" height="244" alt="2n" src="https://github.com/user-attachments/assets/a331f2b5-f120-4b16-9ea8-9487f56cd05a" />

______________

<img width="338" height="244" alt="3g" src="https://github.com/user-attachments/assets/0d17924c-480b-4a57-a3dd-6f11542b23b6" />
<img width="338" height="244" alt="3n" src="https://github.com/user-attachments/assets/23fe6d44-27ba-4d25-9f01-fc9bbc09d945" />

(Not only) improve translation of "water jets", which were were mistaken for 'water skis' in legacy translations; change translations where car of given ride is translated completely out-of-line.
