### PR TITLE
cs-CZ: Improve thrill rides translation

### DIFF
--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -179,9 +179,9 @@
     },
     "rct1.ride.go_karts": {
         "reference-name": "Go-Karts (with helmets)",
-        "name": "Go-Karts (with helmets)",
+        "name": "Motokáry (s přilbami)",
         "reference-description": "Self-driven petrol-engined go-karts that come with safety helmets",
-        "description": "Self-driven petrol-engined go-karts that come with safety helmets",
+        "description": "Návštěvníci v závodních helmách řídí benzínové motokáry",
         "reference-capacity": "single-seater",
         "capacity": "1 místo v každém voze"
     },
@@ -2219,9 +2219,9 @@
         "reference-name": "3D Cinema",
         "name": "3D Kino",
         "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
-        "description": "Kin promítající 3D filmy uvnitř duté kulovité konstrukce",
+        "description": "Kino promítající 3D filmy uvnitř duté kulovité konstrukce",
         "reference-capacity": "20 guests",
-        "capacity": "20 návštěvníků"
+        "capacity": "20 míst"
     },
     "rct2.ride.cboat": {
         "reference-name": "Canoes",
@@ -2359,9 +2359,9 @@
         "reference-name": "Enterprise",
         "name": "Loď Enterprise",
         "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
-        "description": "Otáčející se kolo se zavěšenými kabinami, které se napřed roztočí a pak se zvedne na pomocné podpěře",
+        "description": "Kabiny zavěšené na otáčejícím se kole, které se nejprve roztočí a pak zvedne vzhůru na ramenu",
         "reference-capacity": "16 passengers",
-        "capacity": "16 návštěvníků"
+        "capacity": "16 míst"
     },
     "rct2.ride.faid1": {
         "reference-name": "First Aid Room",
@@ -2401,9 +2401,9 @@
         "reference-name": "Roto-Drop",
         "name": "Roto-pád",
         "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
-        "description": "Kruh sedadel je za pomalé rotace vytažen na vrchol vysoké věže, spuštěn volným pádem k zemi a opatrně zastaven pomocí magnetických brzd",
+        "description": "Kruh se sedadly je za pomalé rotace vytažen na vrchol vysoké věže, spuštěn volným pádem k zemi a opatrně zastaven pomocí magnetických brzd",
         "reference-capacity": "16 passengers",
-        "capacity": "16 návštěvníků"
+        "capacity": "16 míst"
     },
     "rct2.ride.golf1": {
         "reference-name": "Mini Golf",
@@ -2563,7 +2563,7 @@
         "reference-name": "Go-Karts",
         "name": "Motokáry",
         "reference-description": "Self-drive petrol-engined go-karts",
-        "description": "Benzínové ovladatelné motokáry",
+        "description": "Návštěvníci řídí benzínové motokáry",
         "reference-capacity": "single-seater",
         "capacity": "1 místo v každém voze"
     },
@@ -2599,9 +2599,9 @@
         "reference-name": "Magic Carpet",
         "name": "Kouzelný koberec",
         "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
-        "description": "Velký vůz připomínající koberec se pohybuje krouživými pohyby hýbe nahoru a dolů za pomoci 4 ramen",
+        "description": "Velká plošina ve stylu kouzelného létajícího koberce se pohybuje krouživými pohyby nahoru a dolů za pomoci čtyř ramen",
         "reference-capacity": "12 passengers",
-        "capacity": "12 návštěvníků"
+        "capacity": "12 míst"
     },
     "rct2.ride.mft": {
         "reference-name": "Articulated Roller Coaster Trains",
@@ -2945,9 +2945,9 @@
         "reference-name": "Launched Freefall Car",
         "name": "Volný pád",
         "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
-        "description": "Vůz pro volný pád je pneumaticky vystřeleno vzhůru po vysoké ocelové věži a následně volně padá k zemi",
+        "description": "Zařízení pro volný pád je pneumaticky vystřeleno vzhůru po vysoké ocelové věži a následně volně padá k zemi",
         "reference-capacity": "8 passengers",
-        "capacity": "8 návštěvníků"
+        "capacity": "8 míst"
     },
     "rct2.ride.starfrdr": {
         "reference-name": "Star Fruit Drink Stall",
@@ -3009,11 +3009,11 @@
     },
     "rct2.ride.swsh2": {
         "reference-name": "Swinging Inverter Ship",
-        "name": "Houpající se obrácená loď",
+        "name": "Houpací obracecí loď",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
-        "description": "Loď je připevněna na podpěru, která se chová jako protizávaží a otáčí se o 360 stupňů",
+        "description": "Loď přichycená na ramenu s protizávažím houpající se a točící se až o plných 360°",
         "reference-capacity": "12 passengers",
-        "capacity": "12 návštěvníků"
+        "capacity": "12 míst"
     },
     "rct2.ride.thcar": {
         "reference-name": "Air Powered Vertical Coaster Trains",
@@ -3055,7 +3055,7 @@
         "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
         "description": "Návštěvníci sedí v gondole zavěšené na podpěrách, otáčející se dopředu a dozadu vzhůru nohama",
         "reference-capacity": "8 passengers",
-        "capacity": "8 návštěvníků"
+        "capacity": "8 míst"
     },
     "rct2.ride.tram1": {
         "reference-name": "Trams",
@@ -3091,17 +3091,17 @@
         "reference-name": "Twist",
         "name": "Twist",
         "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-        "description": "Návštěvníci sedí po dvou v jedné ze tří kabin, které kolem sebe rotují",
+        "description": "Návštěvníci sedí po dvou na sedačkách otáčejících se okolo konců třech dlouhých ramen",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2.ride.twist2": {
         "reference-name": "Snow Cups",
         "name": "Sněhové kalíšky",
         "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
-        "description": "Návštěvníci sedí po dvou v kalíšcích, které se otáčejí okolo sněhuláka uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách otáčejících se okolo uprostřed umístěného sněhuláka",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2.ride.utcar": {
         "reference-name": "Twister Cars",
@@ -5845,7 +5845,7 @@
         "reference-name": "1920s Racing Cars",
         "name": "Motokáry z 20. let",
         "reference-description": "1920s race car themed go-karts",
-        "description": "Benzínové ovladatelné motokáry ve stylu 20. let",
+        "description": "Motokáry ve stylu 20. let minulého století",
         "reference-capacity": "Single-seater",
         "capacity": "1 místo v každém voze"
     },
@@ -5897,7 +5897,7 @@
         "reference-name": "Caveman Cars",
         "name": "Prehistorické motokáry",
         "reference-description": "Self-drive go-karts in Stone Age style",
-        "description": "Benzínové ovladatelné motokáry ve stylu pravěku",
+        "description": "Návštěvníci řídí benzínové motokáry ve stylu doby kamenné",
         "reference-capacity": "Single-seater",
         "capacity": "1 místo v každém voze"
     },
@@ -5919,11 +5919,11 @@
     },
     "rct2tt.ride.dinoeggs": {
         "reference-name": "Dinosaur Egg Ride",
-        "name": "Jízda dinsouřích vajec",
+        "name": "Twist s dinosauřím vejcem",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
-        "description": "Návštěvníci sedí po dvou ve vejcích, které se otáčejí okolo dinosauří matky uprostřed",
+        "description": "Návštěvníci sedí po dvou ve vejcích, otáčejících se okolo dinosauří mámy uprostřed",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2tt.ride.dragnfly": {
         "reference-name": "Dragonfly Cars",
@@ -5983,11 +5983,11 @@
     },
     "rct2tt.ride.gintspdr": {
         "reference-name": "B-Movie Giant Spider Ride",
-        "name": "Béčková pavoučí jízda",
+        "name": "Twist s béčkovým pavoukem",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo velkého pavouka z béčkového filmu uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách, otáčejících se okolo uprostřed posazeného velkého pavouka z béčkového filmu",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2tt.ride.halofmrs": {
         "reference-name": "Hall of Mirrors",
@@ -6077,11 +6077,11 @@
     },
     "rct2tt.ride.microbus": {
         "reference-name": "MicroBus Ride",
-        "name": "Jízda v MicroBusu",
+        "name": "Jízda v mikrobusu",
         "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
         "description": "Návštěvníci sledují film uvnitř simulátoru pohybu, zatímco se simulátorem hýbe hydraulika",
         "reference-capacity": "8 passengers",
-        "capacity": "8 návštěvníků"
+        "capacity": "8 cestujících"
     },
     "rct2tt.ride.mktstal1": {
         "reference-name": "Toffee Apple Market Stall",
@@ -6109,11 +6109,11 @@
     },
     "rct2tt.ride.neptunex": {
         "reference-name": "Neptune Ride",
-        "name": "Neptunská jízda",
+        "name": "Neptunův twist",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo suchy Neptuna uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách, otáčejících se okolo sochy Neptuna uprostřed",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2tt.ride.oakbarel": {
         "reference-name": "Oak Barrels",
@@ -6227,19 +6227,19 @@
     },
     "rct2tt.ride.tommygun": {
         "reference-name": "Tommy Gun Ride",
-        "name": "Jízda s Thompsonem",
+        "name": "Twist s Thompsonem",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo velké repliky samopalu Thompson uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách otáčejících se okolo velké repliky samopalu Thompson uprostřed",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2tt.ride.trebucht": {
         "reference-name": "Trebuchet Ride",
-        "name": "Katapultující jízda",
+        "name": "Katapult",
         "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
-        "description": "Návštěvníci sedí v gondole zavěšené na podpěrách, otáčející se dopředu a dozadu vzhůru nohama, která vypadá jako obléhací zbraň z dávných dob",
+        "description": "Návštěvníci sedí v gondole zavěšené na podpěrách, otáčející se dopředu a dozadu vzhůru nohama; ve stylu obléhací zbraně z dávných dob",
         "reference-capacity": "8 passengers",
-        "capacity": "8 návštěvníků"
+        "capacity": "8 míst"
     },
     "rct2tt.ride.tricatop": {
         "reference-name": "Triceratops Dodgems",
@@ -8667,11 +8667,11 @@
     },
     "rct2ww.ride.coffeecu": {
         "reference-name": "Coffee Cup Ride",
-        "name": "Jízda v šálku kávy",
+        "name": "Kávový twist",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo kávomlýnku uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách otáčejících se okolo uprostřed umistěného pohybujícího se kafemlejnku",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2ww.ride.condorrd": {
         "reference-name": "Condor Trains",
@@ -8731,11 +8731,11 @@
     },
     "rct2ww.ride.diamondr": {
         "reference-name": "Diamond Ride",
-        "name": "Diamantová jízda",
+        "name": "Diamantový twist",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo diamantu uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách, otáčejících se okolo uprostřed umístěného diamantu",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2ww.ride.dolphinr": {
         "reference-name": "Dolphin Boats",
@@ -8763,27 +8763,27 @@
     },
     "rct2ww.ride.faberge": {
         "reference-name": "Fabergé Egg Ride",
-        "name": "Jízda Fabergého vejce",
+        "name": "Twist s Fabergého vejcem",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo Fabergého vejce uprostřed",
+        "description": "Návštěvníci sedí po dvou na sedačkách, otáčejících se okolo Fabergého vejce uprostřed",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2ww.ride.fightkit": {
         "reference-name": "Fighting Kite Ride",
-        "name": "Jízda papírového draka",
+        "name": "Twist bitevních draků",
         "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí",
+        "description": "Návštěvníci sedí po dvou na sedačkách otáčejících se okolo třech dlouhých rotujících ramen",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2ww.ride.firecrak": {
         "reference-name": "Fire Cracker Ride",
-        "name": "Jízda rachejtle",
+        "name": "Jízda na rachejtli",
         "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
-        "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí",
+        "description": "Kabiny zavěšené na otáčejícím se kole, které se nejprve roztočí a pak zvedne vzhůru na ramenu",
         "reference-capacity": "16 passengers",
-        "capacity": "16 návštěvníků"
+        "capacity": "16 míst"
     },
     "rct2ww.ride.football": {
         "reference-name": "Football Trains",
@@ -8827,11 +8827,11 @@
     },
     "rct2ww.ride.italypor": {
         "reference-name": "Italian Police Ride",
-        "name": "Italská policejní jízda",
+        "name": "Italský policejní twist",
         "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
         "description": "Návštěvníci sedí po dvou na sedačkách, které se otáčejí okolo italských policistů",
         "reference-capacity": "18 passengers",
-        "capacity": "18 návštěvníků"
+        "capacity": "18 míst"
     },
     "rct2ww.ride.jaguarrd": {
         "reference-name": "Jaguar Cars",
@@ -8843,11 +8843,11 @@
     },
     "rct2ww.ride.junkswng": {
         "reference-name": "Chinese Junk Swing Ride",
-        "name": "Čínská loď",
+        "name": "Houpací čínská džunka",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
-        "description": "Loď je připevněna na podpěru, která se chová jako protizávaží a otáčí se o 360 stupňů",
+        "description": "Loď přichycená na ramenu s protizávažím houpající se a točící se až o plných 360°",
         "reference-capacity": "12 passengers",
-        "capacity": "12 návštěvníků"
+        "capacity": "12 míst"
     },
     "rct2ww.ride.killwhal": {
         "reference-name": "Killer Whale Submarines",


### PR DESCRIPTION
Follow-up to:

- #3275
- #3276
- #3286

Improve legacy translation, improve a few names to be more appealing, improve confusing and out of line descriptions. In some cases, change capacity descriptions to fit overall translation style. Add missing translation for `rct1.ride.go_karts`

_____________

Sample of changes being submitted - gray being the current state, colored being the PR


<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-41-07" src="https://github.com/user-attachments/assets/e6c9f49a-58a1-4ccb-b7d9-101808a862c9" />
<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-41-52" src="https://github.com/user-attachments/assets/44f01209-d2a2-485b-8608-df196163c647" />

____________

<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-46-35" src="https://github.com/user-attachments/assets/1232b53f-5879-479d-98fb-7500c8bb4077" />
<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-47-16" src="https://github.com/user-attachments/assets/2a106628-1094-43de-9ca5-4a73394cd197" />

Notably _Béčková pavoučí jízda_ implied that ride itself is of inferior quality, which gets improved by changing to _Twist s béčkovým pavoukem_, which, well - sounds as you gonna twist with B-grade spider - and thus is much more appealing.
____________

<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-48-12" src="https://github.com/user-attachments/assets/3d576224-7787-40b5-9f69-04698cf5b5ec" />
<img width="334" height="243" alt="Snímek obrazovky z 2025-08-01 12-48-40" src="https://github.com/user-attachments/assets/1620cc9a-1957-4920-94b0-01fc1b594d97" />

Change capacity translation to fit overall translation style. Omit word _jízda_ as unfitting translation of "ride". Slight touch-up to style of description to avoid nesting sentence using sentence joining words such as "_která, který_" - this is common pitfall when translating from English to Czech - so let's not fall into this pit :)

