### PR TITLE
cs-CZ: Improve roller coaster translations (1 of 2)

### DIFF
--- a/objects/cs-CZ.json
+++ b/objects/cs-CZ.json
@@ -45,33 +45,33 @@
     },
     "openrct2.ride.alpine_coaster": {
         "reference-name": "Alpine Coaster Cars",
-        "name": "Alpine Coaster Cars",
+        "name": "Vozy alpské dráhy",
         "reference-description": "Wheeled sleds equipped with manually operated brakes",
-        "description": "Wheeled sleds equipped with manually operated brakes",
+        "description": "Saně s kolečky vybavené ručně ovládanými brzdami",
         "reference-capacity": "2 passengers per car",
-        "capacity": "2 passengers per car"
+        "capacity": "2 místa ve voze"
     },
     "openrct2.ride.hybrid_coaster": {
         "reference-name": "Hybrid Coaster Trains",
-        "name": "Hybrid Coaster Trains",
+        "name": "Vlaky hybridní dráhy",
         "reference-description": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
-        "description": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
+        "description": "Vlaky horské dráhy, se sedadly vybavenými opěrkou v klíně, schopné sjíždět strmé klesání a otočit se vzhůru nohama ve výkrutech",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 místa ve voze"
     },
     "openrct2.ride.modern_twister": {
         "reference-name": "Modern Twister Trains",
-        "name": "Modern Twister Trains",
+        "name": "Moderní twister vozy",
         "reference-description": "Spacious trains with lap restraints, capable of tight twists and inversions",
-        "description": "Spacious trains with lap restraints, capable of tight twists and inversions",
+        "description": "Prostorné vlaky vybavené sedačkami s opěrkami v klíně, schopné jet na trati s malými zatáčkami, utaženými přemety a obraty",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 passengers per car"
     },
     "openrct2.ride.single_rail_coaster": {
         "reference-name": "Single Rail Roller Coaster Trains",
-        "name": "Single Rail Roller Coaster Trains",
+        "name": "Vlaky jednokolejné horské dráhy",
         "reference-description": "Roller coaster trains in which riders are seated single file",
-        "description": "Roller coaster trains in which riders are seated single file",
+        "description": "Vlaky horské dráhy se samostatnými sedadly v řadě za sebou",
         "reference-capacity": "1 passenger per car",
         "capacity": "1 passenger per car"
     },
@@ -149,11 +149,11 @@
     },
     "rct1.ride.corkscrew_trains": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Corkscrew Roller Coaster Trains",
+        "name": "Vlaky vývrtkové dráhy",
         "reference-description": "Roller coaster trains with shoulder restraints",
-        "description": "Roller coaster trains with shoulder restraints",
+        "description": "Vlaky horské dráhy se sedadly vybavenými ramenními opěrkami",
         "reference-capacity": "4 passengers per car",
-        "capacity": "4 passengers per car"
+        "capacity": "4 místa v každém voze"
     },
     "rct1.ride.dinghies": {
         "reference-name": "Dinghies",
@@ -195,9 +195,9 @@
     },
     "rct1.ride.inverted_trains": {
         "reference-name": "Inverted Coaster Trains",
-        "name": "Inverted Coaster Trains",
+        "name": "Vlaky otočené dráhy",
         "reference-description": "Inverted roller coaster train, consisting of seats hanging from a supporting frame running on the track above.",
-        "description": "Inverted roller coaster train, consisting of seats hanging from a supporting frame running on the track above.",
+        "description": "Otočený vlak horské dráhy sestávající se z sedadel připevněných k nosném rámu zavěšenému pod trať nad ním",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -227,9 +227,9 @@
     },
     "rct1.ride.mine_cars": {
         "reference-name": "Mine Cars",
-        "name": "Divoká důlní jízda",
+        "name": "Důlní vozy",
         "reference-description": "Cars shaped like an old mine cart",
-        "description": "Horská dráha s vozy, které připomínají klasické důlní vozy",
+        "description": "Vozy ve tvaru důlních vozíků",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -299,9 +299,9 @@
     },
     "rct1.ride.single_person_swinging_cars": {
         "reference-name": "Single-Person Swinging Cars",
-        "name": "Single-Person Swinging Cars",
+        "name": "Jednomístné houpací vozy",
         "reference-description": "Single-seater cars which hang from the rail above, and are free to swing from side to side",
-        "description": "Single-seater cars which hang from the rail above, and are free to swing from side to side",
+        "description": "Jednomístné vozy kývající se ze strany na stranu, zavěšené pod kolejnicí",
         "reference-capacity": "1 passenger per car",
         "capacity": "1 místo v každém voze"
     },
@@ -323,9 +323,9 @@
     },
     "rct1.ride.stand_up_trains": {
         "reference-name": "Stand-up Roller Coaster Trains",
-        "name": "Horská dráha \"na stojáka\"",
+        "name": "Vozy dráhy „na stojáka“",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position",
-        "description": "Návštěvníci jedou po horské dráze ve stoje",
+        "description": "Vlaky horské dráhy vozící návštěvníky vestoje",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -339,9 +339,9 @@
     },
     "rct1.ride.steel_rc_trains": {
         "reference-name": "Roller Coaster Trains",
-        "name": "Roller Coaster Trains",
+        "name": "Vlaky horské dráhy",
         "reference-description": "Roller coaster train with a streamlined front car.",
-        "description": "Roller coaster train with a streamlined front car.",
+        "description": "Vlaky horské dráhy s aerodynamicky tvarovaným prvním vozem",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -401,17 +401,17 @@
     },
     "rct1.ride.wooden_rc_trains": {
         "reference-name": "Wooden Roller Coaster Trains",
-        "name": "Wooden Roller Coaster Trains",
+        "name": "Vlaky dřevěné horské dráhy",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Wooden roller coaster trains with padded seats and lap bar restraints",
+        "description": "Vlaky dřevěné horské dráhy s polstrovanými sedadly a opěrkou v klíně",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct1.ride.wooden_rc_trains_reversed": {
         "reference-name": "Wooden Roller Coaster Trains (Reversed)",
-        "name": "Wooden Roller Coaster Trains (Reversed)",
+        "name": "Vlaky dřevěné horské dráhy (obrácené)",
         "reference-description": "Wooden roller coaster trains, but running in reverse, so that the passengers face backwards.",
-        "description": "Wooden roller coaster trains, but running in reverse, so that the passengers face backwards.",
+        "description": "Vlaky dřevěné horské dráhy s polstrovanými sedadly a opěrkou v klíně, jezdící pozpátku",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -709,9 +709,9 @@
     },
     "rct1aa.ride.lay_down_trains": {
         "reference-name": "Lay-down Roller Coaster Trains",
-        "name": "Horská dráha \"na ležáka\"",
+        "name": "Vozy dráhy „v leže“",
         "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
-        "description": "Návštěvníci jedou v leže zavěšeni do speciálního držení, ve kterém na břiše projedou trať s ostrými zatáčkami",
+        "description": "Návštěvníci jsou umístěni v leže do speciálního závěsu, v němž jedou buďto na zádech nebo obličejem směrem k zemi",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -733,9 +733,9 @@
     },
     "rct1aa.ride.side_friction_cars": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Horská dráha s bočním uchycením",
+        "name": "Dřevěné vozy s bočním vedením",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Po dráze jezdí vozy, které mají kola horizontálně uložená pod podlahou a opírají se jimi o stěny dráhy",
+        "description": "Jednoduché vozy s koly montovanými vodorovně, určené pro horskou dráhu s bočním vedením",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -757,9 +757,9 @@
     },
     "rct1aa.ride.stand_up_twister_trains": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Zakroucená horská dráha \"na stojáka\"",
+        "name": "Vozy twister „na stojáka“",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
-        "description": "Návštěvníci jedou ve stoje ve vozech vybavenými ramenními opěrkami",
+        "description": "Vlaky horské dráhy vybavené rameními opěrkami vozící návštěvníky vestoje",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -813,9 +813,9 @@
     },
     "rct1aa.ride.wooden_articulated_trains": {
         "reference-name": "Articulated Roller Coaster Trains",
-        "name": "Horská dráha s malými vozy",
+        "name": "Kloubové vozy horské dráhy",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-        "description": "Horská dráha s dvoumístnými vozy bez předků",
+        "description": "Vlaky horské dráhy s krátkými vozy vybavenými jednou řadou sedaček a otevřenými čely",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2073,9 +2073,9 @@
     },
     "rct2.ride.amt1": {
         "reference-name": "Mine Trains",
-        "name": "Důlní horská dráha",
+        "name": "Důlní vlaky",
         "reference-description": "Mine train-themed roller coaster trains",
-        "description": "Horská dráha ve stylu důlních vlaků jezdí po ocelové horské dráze maskované jako staré koleje",
+        "description": "Vlaky horské dráhy ve stylu důlních vlaků",
         "reference-capacity": "2 or 4 passengers per car",
         "capacity": "2 nebo 4 místa v každém voze"
     },
@@ -2083,7 +2083,7 @@
         "reference-name": "Suspended Swinging Cars",
         "name": "Zavěšené houpající se vozy",
         "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
-        "description": "Zavěšená horská dráha z volné zavěšených vozů, které se naklání při jízdě do zatáček",
+        "description": "Závěsné vlaky horské dráhy sestávající se z vozů schopných volně se kývat ze strany na stranu při průjezdu zatáčkami",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2091,31 +2091,31 @@
         "reference-name": "Suspended Swinging Aeroplane Cars",
         "name": "Zavěšené houpající se aeroplány",
         "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
-        "description": "Zavěšená horská dráha z volné zavěšených vozů ve tvaru aeroplánu, které se naklání při jízdě do zatáček",
+        "description": "Závěsné vlaky horské dráhy sestávající se z vozů schopných volně se kývat ze strany na stranu při průjezdu zatáčkami",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.arrt1": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Vývrtková horská dráha",
+        "name": "Vlaky vývrtkové dráhy",
         "reference-description": "Roller coaster trains with shoulder restraints",
-        "description": "Horská dráha s vozy vybavenými ramenními opěrkami",
+        "description": "Vlaky horské dráhy se sedadly vybavenými ramenními opěrkami",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.arrt2": {
         "reference-name": "Hypercoaster Trains",
-        "name": "Hyper horská dráha",
+        "name": "Hyper vlaky",
         "reference-description": "Comfortable trains with only lap bar restraints",
-        "description": "Horská dráha s pohodlnými vozy vybavenými opěrkou v klíně",
+        "description": "Pohodlné vlaky se sedadly vybavenými opěrkou v klíně",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
     "rct2.ride.arrx": {
         "reference-name": "Multi-Dimension Coaster Trains",
-        "name": "Vícerozměrná horská dráha",
+        "name": "Vlaky mnohorozměrné horské dráhy",
         "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
-        "description": "Vozy se sedadly schopny otáčet návštěvníky vzhůru nohama",
+        "description": "Vozy se sedadly schopné otáčet návštěvníky vzhůru nohama",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2133,9 +2133,9 @@
     },
     "rct2.ride.batfl": {
         "reference-name": "Swinging Cars",
-        "name": "Houpající se vozy",
+        "name": "Houpací vozy",
         "reference-description": "Small cars which swing from the rail above",
-        "description": "Malé houpající se vozy zavěšené na kolejnici",
+        "description": "Malé houpající se vozy zavěšené pod kolejnici",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2149,7 +2149,7 @@
     },
     "rct2.ride.bmair": {
         "reference-name": "Flying Roller Coaster Trains",
-        "name": "Létající horská dráha",
+        "name": "Vlaky létající horské dráhy",
         "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
         "description": "Návštěvníci sedí v pohodlných sedadlech pod tratí cestující skrze propletenou dráhu, poskytující pocit letu",
         "reference-capacity": "4 passengers per car",
@@ -2165,7 +2165,7 @@
     },
     "rct2.ride.bmrb": {
         "reference-name": "Hyper-Twister Trains (wide cars)",
-        "name": "Hyperzakroucená dráha (široké vozy)",
+        "name": "Hyper-twister vlaky (široké vozy)",
         "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
         "description": "Široké 4-místné vozy s vystouplým sezením a jednoduchou opěrkou v klíně",
         "reference-capacity": "4 passengers per car",
@@ -2173,27 +2173,27 @@
     },
     "rct2.ride.bmsd": {
         "reference-name": "Twister Trains",
-        "name": "Zakroucená horská dráha",
+        "name": "Twister vlaky",
         "reference-description": "Spacious trains with shoulder restraints",
-        "description": "Rozměrná horská dráha s vozy vybavenými ramenními opěrkami",
+        "description": "Prostorné vlaky s vozy vybavenými ramenními opěrkami",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.bmsu": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Zakroucená horská dráha \"na stojáka\"",
+        "name": "Twister vlaky „na stojáka“",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
-        "description": "Návštěvníci jedou ve stoje ve vozech vybavenými ramenními opěrkami",
+        "description": "Prostorné vlaky s vozy vybavenými ramenními opěrkami, návštěvnící jedou ve stoje",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.bmvd": {
         "reference-name": "Six-seater Twister Trains",
-        "name": "Šestimístná zakroucená horská dráha",
+        "name": "Šestimístné twister vlaky",
         "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
-        "description": "Extra-široké vozy letí dolů po zcela kolmé dráze a poskytují tím pocit volného pádu",
+        "description": "Vlaky horské dráhy s extra širokými vozy konstruované pro pády svisle dolů",
         "reference-capacity": "6 passengers per car",
-        "capacity": "4 místa v každém voze"
+        "capacity": "6 míst v každém voze"
     },
     "rct2.ride.bnoodles": {
         "reference-name": "Beef Noodles Stall",
@@ -2203,9 +2203,9 @@
     },
     "rct2.ride.bob1": {
         "reference-name": "Bobsleigh Trains",
-        "name": "Horská bobová dráha",
+        "name": "Vlaky z bobů",
         "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
-        "description": "Návštěvníci sedí za sebou ve dvojmístných vozech",
+        "description": "Vlaky složené z dvojmístných vozu se sedadly uspořádanými za sebou",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2415,7 +2415,7 @@
     },
     "rct2.ride.goltr": {
         "reference-name": "Hyper-Twister Trains",
-        "name": "Hyperzakroucená dráha",
+        "name": "Hyper-twister vlaky",
         "reference-description": "Spacious trains with simple lap restraints",
         "description": "Prostorné vozy s jednoduchou opěrkou v klíně",
         "reference-capacity": "6 passengers per car",
@@ -2513,31 +2513,31 @@
     },
     "rct2.ride.intbob": {
         "reference-name": "6-seater Bobsleighs",
-        "name": "Létající zatáčky",
+        "name": "Šestimístné boby",
         "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
-        "description": "Návštěvníci v šestimístných vozech sedí vedle sebe po dvou ve třech řadách",
+        "description": "Boby se třemi řadami dvoumístných sedaček",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
     "rct2.ride.intinv": {
         "reference-name": "Impulse Trains",
-        "name": "Horská dráha ve tvaru \"U\"",
+        "name": "Impulzní vlaky",
         "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
-        "description": "Vozy vyrazí vstříc jednomu konci trati, poté prosviští pozpátku stanicí a vyletí až na druhý konec trati",
+        "description": "Vzhůru nohama otočené vlaky horské dráhy pro obrácenou impulzní horskou dráhu",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.intst": {
         "reference-name": "Giga Coaster Trains",
-        "name": "Giga dráha",
+        "name": "Vlaky obří dráhy",
         "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
-        "description": "Gigantická horská dráha schopna volných pádů a kopců přes 90 metrů dlouhých",
+        "description": "Vlaky pro obří horskou dráhu, schopné sjíždět hladké klesání",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.ivmc1": {
         "reference-name": "Four-seater Cars",
-        "name": "Čtyřmístná horská dráha",
+        "name": "Čtyřmístné vozy",
         "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
         "description": "Vozy jsou zavěšeny na kolejnicích s ostrými zatáčkami a ostrými pády",
         "reference-capacity": "4 passengers per car",
@@ -2553,9 +2553,9 @@
     },
     "rct2.ride.jstar1": {
         "reference-name": "Toboggan Cars",
-        "name": "Tobogánová horská dráha",
+        "name": "Tobogánové sáňkové vozy",
         "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
-        "description": "Horská dráha ve stylu tobogánu s vozy se sedačkami za sebou",
+        "description": "Vozy horské dráhy se sedačkami za sebou, ve stylu amerických saní „toboggan“",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2605,9 +2605,9 @@
     },
     "rct2.ride.mft": {
         "reference-name": "Articulated Roller Coaster Trains",
-        "name": "Horská dráha s malými vozy",
+        "name": "Malé vozy s kloubovými podvozky",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
-        "description": "Horská dráha s dvoumístnými vozy bez předků",
+        "description": "Vlaky horské dráhy s krátkými vozy vybavenými jednou řadou sedaček a otevřenými čely",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2653,9 +2653,9 @@
     },
     "rct2.ride.nemt": {
         "reference-name": "4-across Inverted Roller Coaster Trains",
-        "name": "Čtyřmístná zavěšená horská dráha",
+        "name": "Vlaky z čtyřmístných vozů pro otočenou dráhu",
         "reference-description": "Suspended trains in which riders sit in rows",
-        "description": "Vozy jsou zavěšeny na kolejnicích se zatáčkami, pády a loopingy",
+        "description": "Závěsné vlaky s místy k sezení v řadách",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2699,9 +2699,9 @@
     },
     "rct2.ride.pmt1": {
         "reference-name": "Powered Mine Trains",
-        "name": "Důlní jízda",
+        "name": "Poháněné důlní vozíky",
         "reference-description": "Mine train-themed roller coaster trains that propel themselves",
-        "description": "Horská dráha s vozy ve stylu důlních vagónů, které jedou po hladkých kolejnicích skrze propletenou dráhu",
+        "description": "Vlaky horské dráhy, ve stylu důlních vozíků, s vlastním pohonem",
         "reference-capacity": "2 or 4 passengers per car",
         "capacity": "2 nebo 4 místa v každém voze"
     },
@@ -2713,9 +2713,9 @@
     },
     "rct2.ride.premt1": {
         "reference-name": "LIM Launched Roller Coaster Trains",
-        "name": "Horská dráha s elektromotorem",
+        "name": "Vozy startující pomocí LIM",
         "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
-        "description": "Horská dráha s vozy poháněnými elektromotorem, které sviští skrze propletenou dráhu",
+        "description": "Vlaky horské dráhy využívající ke zrychlení lineární indukční elektromotory",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2727,25 +2727,25 @@
     },
     "rct2.ride.ptct1": {
         "reference-name": "Wooden Roller Coaster Trains",
-        "name": "Dřevěná horská dráha",
+        "name": "Vlaky dřevěné horské dráhy",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína",
+        "description": "Vlaky dřevěné horské dráhy s polstrovanými sedadly a opěrkou v klíně",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.ptct2": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater)",
-        "name": "Dřevěná horská dráha (6 sedadel)",
+        "name": "Vlaky dřevěné horské dráhy (6 míst)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
-        "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína",
+        "description": "Vlaky dřevěné horské dráhy s polstrovanými sedadly a opěrkou v klíně",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
     "rct2.ride.ptct2r": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
-        "name": "Dřevěná horská dráha (6 sedadel, pozpátku)",
+        "name": "Vlaky dřevěné horské dráhy (6 míst, obrácené)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
-        "description": "Dřevěná horská dráha s vozy s polstrovanými sedadly a opěrkou v klína, na které se jezdí pozpátku",
+        "description": "Vlaky dřevěné horské dráhy s polstrovanými sedadly a opěrkou v klíně, obrácené - cestující sedí proti směru jízdy",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
@@ -2767,9 +2767,9 @@
     },
     "rct2.ride.rckc": {
         "reference-name": "Rocket Cars",
-        "name": "Raketová auta",
+        "name": "Raketové vozy",
         "reference-description": "Roller coaster cars themed to look like rockets",
-        "description": "Horská dráha s vozy vypadajícími jako rakety",
+        "description": "Vozy horské dráhy, ve stylu raket",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2783,19 +2783,19 @@
     },
     "rct2.ride.revcar": {
         "reference-name": "Reverser Cars",
-        "name": "Otáčivá horská dráha",
+        "name": "Vozy se změnou směru jízdy",
         "reference-description": "Bogied cars capable of turning around on special reversing sections",
-        "description": "Horská dráha s vozy, které se ve speciálních místech se otočí a jedou pozpátku",
+        "description": "Vozy schopné změnit směr jízdy na speciálních úsecích",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
     "rct2.ride.revf1": {
         "reference-name": "Reverse Freefall Car",
-        "name": "Volný pád pozpátku",
+        "name": "Vozidlo pro volný pád pozpátku",
         "reference-description": "Large coaster car for the Reverse Freefall Coaster",
-        "description": "Velká dráha s vozem pro volný pád pozpátku",
+        "description": "Velké vozidlo určené pro Horskou dráhu s volným pádem pozpátku",
         "reference-capacity": "8 passengers",
-        "capacity": "8 návštěvníků"
+        "capacity": "8 míst"
     },
     "rct2.ride.rftboat": {
         "reference-name": "Rafts",
@@ -2813,25 +2813,25 @@
     },
     "rct2.ride.sbox": {
         "reference-name": "Soap Boxes",
-        "name": "Závodní krabičky od mýdla",
+        "name": "Krabičky na mýdlo",
         "reference-description": "Single cars shaped like a soap box",
-        "description": "Návštěvníci jezdí v závodních vozech ve tvaru dávných krabiček od mýdla",
+        "description": "Samostatné v závodní vozy ve tvaru historických krabiček na mýdlo",
         "reference-capacity": "4 riders per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.scht1": {
         "reference-name": "Looping Roller Coaster Trains",
-        "name": "Horská dráha",
+        "name": "Vlaky dráhy s loopingy",
         "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
-        "description": "Horská dráha s loopingy, po které jezdí vozy s opěrkou v klíně",
+        "description": "Vlaky horské dráhy, se sedadly vybavenými opěrkou v klíně, schopné projíždět svislé smyčky",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.sfric1": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Horská dráha s bočním uchycením",
+        "name": "Dřevěné vozy s bočním vedením",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Po dráze jezdí vozy, které mají kola horizontálně uložená pod podlahou a opírají se jimi o stěny dráhy",
+        "description": "Jednoduché vozy s koly montovanými vodorovně, určené pro horskou dráhu s bočním vedením",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2845,25 +2845,25 @@
     },
     "rct2.ride.skytr": {
         "reference-name": "Lay-down Cars",
-        "name": "Zavěšená horská dráha na \"ležáka\"",
+        "name": "Vozy „na ležáka“",
         "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
-        "description": "Návštěvníci jedou na jednokolejné trati vleže hlavou dolů, zavěšeni ve speciálním voze, který se v zatáčkách houpe",
+        "description": "Malé závěsné vozy, houpající se volně ze strany na stranu s návštěvníky ležícími obličejem k zemi",
         "reference-capacity": "1 passenger per car",
         "capacity": "1 místo v každém voze"
     },
     "rct2.ride.slcfo": {
         "reference-name": "Face-off Cars",
-        "name": "Tvář-rvoucí zavěšená horská dráha",
+        "name": "Tvář-rvoucí vozy",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
-        "description": "Návštěvníci sedí po dvou zavěšení pod tratí a vidí dopředu nebo dozadu podle toho, jak zrovna jedou skrze loopingy a ostré zatáčky",
+        "description": "Návštěvníci sedí v dvojicích proti sobě a projíždí skrze loopingy a ostré zatáčky",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.slct": {
         "reference-name": "Compact Inverted Coaster Trains",
-        "name": "Malá zavěšená horská dráha",
+        "name": "Vlaky malé obrácené horské dráhy",
         "reference-description": "Riders sit in pairs of seats suspended beneath the track",
-        "description": "Návštěvníci sedí po dvou zavěšení pod tratí a jedou skrze loopingy a ostré zatáčky",
+        "description": "Návštěvníci sedí v sedačkách po dvou zavěšených pod tratí",
         "reference-capacity": "2 passengers per car",
         "capacity": "2 místa v každém vozu"
     },
@@ -2871,15 +2871,15 @@
         "reference-name": "Mouse Cars",
         "name": "Myší vozy",
         "reference-description": "Individual cars shaped like mice",
-        "description": "Vozy ve tvaru myší",
+        "description": "Samostatné vozy ve tvaru myší",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
     "rct2.ride.smc2": {
         "reference-name": "Mine Cars",
-        "name": "Důlní vozy",
+        "name": "Důlní vozíky",
         "reference-description": "Individual cars shaped like wooden mine trucks",
-        "description": "Vozy ve tvaru dřevěných důlních vagónů",
+        "description": "Samostatné vozy ve tvaru dřevěných důlních vagónů",
         "reference-capacity": "4 passengers per car",
         "capacity": "4 místa v každém voze"
     },
@@ -2921,9 +2921,9 @@
     },
     "rct2.ride.spdrcr": {
         "reference-name": "Spiral Roller Coaster Trains",
-        "name": "Spirální horská dráha",
+        "name": "Spirální vlaky",
         "reference-description": "Compact roller coaster trains with cars with in-line seating",
-        "description": "Malá ocelová horská dráha se spirálovitým profilem a vozy se sedadly za sebou",
+        "description": "Malé vlaky horské dráhy, se sedadly v řadě za sebou",
         "reference-capacity": "6 passengers per car",
         "capacity": "6 míst v každém voze"
     },
@@ -2957,9 +2957,9 @@
     },
     "rct2.ride.steep1": {
         "reference-name": "Horses",
-        "name": "Dostihy",
+        "name": "Koně",
         "reference-description": "Single cars shaped like a horse",
-        "description": "Vozy ve tvaru koní vozí návštěvníky po jednokolejné trati",
+        "description": "Samostatné vozy ve tvaru koní",
         "reference-capacity": "2 riders per horse",
         "capacity": "2 místa na každém koni"
     },


### PR DESCRIPTION
Follow-up to:

- #3275
- #3276
- #3286
- #3288

Fix "My hovercraft is full of eels" grade confusing and mismatched translations. Improve legacy translation, improve a few names to be more appealing and more understandable. Fix translations where car of given ride is wrongly translated as ride itself. Add a few missing translations.

__________

Showing overview of changes, left gray current, right colored PR (a lot of description edits not shown)

<img width="1181" height="1470" alt="screen-coastery" src="https://github.com/user-attachments/assets/09fa5110-e763-4913-a6ae-b53defba7b55" />

PR continues with part 2, half of the strings shown in screenshots are there, as it was split for ease of review.