### PR TITLE
Remove unexpected translations from all languages

### DIFF
--- a/data/language/ar-EG.txt
+++ b/data/language/ar-EG.txt
@@ -606,8 +606,6 @@ STR_1214    :Select maximum length of time to wait before departing
 STR_1215    :{WINDOW_COLOUR_2}Synchronise with adjacent stations
 STR_1216    :Select whether to synchronise departure with all adjacent stations (for ‘racing’)
 STR_1217    :{COMMA16}ثواني
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :مخرج فقط
 STR_1221    :لا مدخل
 STR_1222    :لا مخرج

--- a/data/language/cs-CZ.txt
+++ b/data/language/cs-CZ.txt
@@ -613,8 +613,6 @@ STR_1214    :Vyberte maximální délku čekání před odjezdem
 STR_1215    :{WINDOW_COLOUR_2}Synchronizovat se sousedícími stanicemi
 STR_1216    :Vyberte, zda synchronizovat odjezdy se sousedícími stanicemi (pro „závodění“)
 STR_1217    :{COMMA16} sekund
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :Jen východ
 STR_1221    :Nemá vchod
 STR_1222    :Chybí východ
@@ -1125,7 +1123,6 @@ STR_1727    :Stavební práva nejsou na prodej!
 STR_1728    :Tyto stavební práva nelze zakoupit…
 STR_1729    :Pozemek není ve vlastnictví parku!
 STR_1730    :{RED}Zavřeno
-STR_1731    :{WHITE}{STRINGID}
 STR_1732    :Stavět
 STR_1733    :Mód
 STR_1734    :{WINDOW_COLOUR_2}Počet kol:

--- a/data/language/da-DK.txt
+++ b/data/language/da-DK.txt
@@ -248,8 +248,6 @@ STR_0831    :Zoom ud
 STR_0832    :Roter synsvinklen 90° med uret
 STR_0833    :Sæt spillet på pause
 STR_0834    :Disk og spil indstillinger
-STR_0839    :{UINT16} x {UINT16}
-STR_0840    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{UINT16} x {UINT16}
 STR_0847    :Om ‘OpenRCT2’
 STR_0850    :{WINDOW_COLOUR_2}Copyright © 2002 Chris Sawyer, alle rettigheder forbeholdt
 STR_0851    :{WINDOW_COLOUR_2}Designet og programmeret af Chris Sawyer

--- a/data/language/eo-ZZ.txt
+++ b/data/language/eo-ZZ.txt
@@ -250,8 +250,6 @@ STR_0831    :Malzomigi vidon
 STR_0832    :Turni vidon 90° dekstrume
 STR_0833    :Paŭzigi ludon
 STR_0834    :Agordoj de disko kaj ludo
-STR_0839    :{UINT16} x {UINT16}
-STR_0840    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{UINT16} x {UINT16}
 STR_0847    :Pri ‘OpenRCT2’
 STR_0850    :{WINDOW_COLOUR_2}Aŭtorrajto © 2002 Chris Sawyer, tutaj rajtoj estas rezervitaj
 STR_0851    :{WINDOW_COLOUR_2}Desegnita kaj programita de Chris Sawyer

--- a/data/language/fr-FR.txt
+++ b/data/language/fr-FR.txt
@@ -252,8 +252,6 @@ STR_0831    :Zoom arrière
 STR_0832    :Tourner la vue de 90° dans le sens des aiguilles d’une montre
 STR_0833    :Mettre en pause le jeu
 STR_0834    :Options du jeu et du disque
-STR_0839    :{UINT16} x {UINT16}
-STR_0840    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{UINT16} x {UINT16}
 # The following six strings were used for display resolutions, but have been replaced.
 #end
 STR_0847    :A propos d’OpenRCT2
@@ -562,7 +560,6 @@ STR_1161    :Positionnement impossible…
 STR_1162    :{OUTLINE}{TOPAZ}{STRINGID}
 STR_1163    :{STRINGID}{NEWLINE}(Clic droit pour modifier)
 STR_1164    :{STRINGID}{NEWLINE}(Clic droit pour supprimer)
-STR_1165    :{STRINGID} — {STRINGID} {COMMA16}
 STR_1166    :Impossible d’abaisser le niveau de l’eau ici…
 STR_1167    :Impossible de surélever le niveau de l’eau ici…
 STR_1168    :Options
@@ -730,8 +727,6 @@ STR_1329    :{WINDOW_COLOUR_2}Vitesse de lancement :
 STR_1330    :Vitesse maximale en quittant la station
 STR_1331    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{VELOCITY}
 STR_1332    :{VELOCITY}
-STR_1333    :{STRINGID} — {STRINGID}{POP16}
-STR_1334    :{STRINGID} — {STRINGID} {COMMA16}
 STR_1335    :{STRINGID} — Entrée{POP16}{POP16}
 STR_1336    :{STRINGID} — Entrée de station {POP16}{COMMA16}
 STR_1337    :{STRINGID} — Sortie{POP16}{POP16}
@@ -1976,7 +1971,6 @@ STR_2778    :»{MOVE_X}{10}{STRING}
 # End of new strings
 STR_2779    :Vue #{COMMA16}
 STR_2780    :Vue supplémentaire
-STR_2781    :{STRINGID} :
 STR_2782    :MAJ + 
 STR_2783    :CTRL + 
 STR_2784    :Modifier raccourci clavier
@@ -3288,9 +3282,6 @@ STR_6225    :Non supporté avec le rendu OpenGL
 STR_6226    :Activer la victoire prématurée d’un scénario
 STR_6227    :Gagne un scénario quand tous les objectifs sont atteints avant la date limite
 STR_6228    :Options du scénario
-STR_6229    :{WINDOW_COLOUR_2}{STRINGID} : {STRINGID}
-STR_6230    :{STRINGID} :
-STR_6231    :{WINDOW_COLOUR_2}{STRINGID} : {MOVE_X}{185}{STRINGID}
 STR_6232    :Immobile
 STR_6233    :Vue en coupe
 STR_6234    :Mettre en évidence les problèmes des chemins

--- a/data/language/gl-ES.txt
+++ b/data/language/gl-ES.txt
@@ -377,8 +377,6 @@ STR_0980    :Novas atraccións emocionantes
 STR_0981    :Novas atraccións acuáticas
 STR_0982    :Novas tendas e postos
 STR_0983    :Investigación e Desenvolvemento
-STR_0984    :{WINDOW_COLOUR_2}▲{BLACK} {CURRENCY2DP}
-STR_0985    :{WINDOW_COLOUR_2}▼{BLACK} {CURRENCY2DP}
 STR_0986    :{BLACK}{CURRENCY2DP}
 STR_0987    :Demasiadas atraccións
 STR_0988    :Non se pode crear unha nova atracción…
@@ -2247,7 +2245,6 @@ STR_3242    :Tamaño máximo do empréstito:
 STR_3243    :Taxa de xuros anual:
 STR_3244    :Prohibir campañas de mercadotecnia
 STR_3245    :Prohibir publicidade, promocións e outras campañas de mercadotecnia
-STR_3246    :{WINDOW_COLOUR_2}{CURRENCY}
 STR_3247    :{WINDOW_COLOUR_2}{COMMA16}%
 STR_3248    :Non se pode aumentar máis o diñeiro inicial!
 STR_3249    :Non se pode reducir máis o diñeiro inicial!

--- a/data/language/hu-HU.txt
+++ b/data/language/hu-HU.txt
@@ -1587,7 +1587,6 @@ STR_2231    :Rögzítőfék eséshez
 STR_2232    :Kábeles felvonószakasz
 STR_2233    :Park információk
 STR_2234    :Legutóbbi üzenetek
-STR_2235    :{POP16}{STRINGID} {PUSH16}{PUSH16}{STRINGID}
 STR_2236    :január
 STR_2237    :február
 STR_2238    :március
@@ -1641,7 +1640,6 @@ STR_2285    :Kezdeti kutatás
 STR_2286    :Tervezés
 STR_2287    :Terv véglegesítése
 STR_2288    :Ismeretlen
-STR_2289    :{POP16}{STRINGID} {PUSH16}{PUSH16}{STRINGID}
 STR_2291    :Válassz pályát az új játékhoz
 STR_2292    :{WINDOW_COLOUR_2}Az alábbi játékokon volt:
 STR_2293    :{BLACK} Semmi

--- a/data/language/ja-JP.txt
+++ b/data/language/ja-JP.txt
@@ -246,8 +246,6 @@ STR_0831    :ズームイン
 STR_0832    :時計回90°りに移動させる
 STR_0833    :ゲームをポーズする
 STR_0834    :ディスクとゲームオプション
-STR_0839    :{UINT16} x {UINT16}
-STR_0840    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{UINT16} x {UINT16}
 STR_0847    :OpenRCT2について
 STR_0850    :{WINDOW_COLOUR_2}Copyright © 2002 Chris Sawyer, all rights reserved
 STR_0851    :{WINDOW_COLOUR_2}Designed and programmed by Chris Sawyer
@@ -607,8 +605,6 @@ STR_1214    :出発前に最長どのくらい待つか選択
 STR_1215    :{WINDOW_COLOUR_2}全ての直接隣接する乗り場と出発タイミングを同期する
 STR_1216    :レースのために全ての直接隣接する乗り場と出発タイミングを同期するかどうか選択。
 STR_1217    :{COMMA16}分
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :出口のみ
 STR_1221    :入口がない
 STR_1222    :出口がない
@@ -1564,8 +1560,6 @@ STR_2212    :パークの警備員の表示
 STR_2213    :パークのエンターテイナーの表示
 STR_2214    :ゲームが一時停止中で建設はできません。
 STR_2215    :{STRINGID}{NEWLINE}({STRINGID})
-STR_2216    :{WINDOW_COLOUR_2}{COMMA16}℃
-STR_2217    :{WINDOW_COLOUR_2}{COMMA16}℉
 STR_2218    :{RED}{STRINGID}の{STRINGID}が{STRINGID}にまだ戻ってきていません!{NEWLINE}どこかにひっかかったり止まったりしていないか確認してください
 STR_2219    :{RED}{COMMA16}人の来客は{STRINGID}上の事故で死亡してしまいました。
 STR_2220    :{WINDOW_COLOUR_2}パーク評価値: {BLACK}{COMMA16}
@@ -1583,7 +1577,6 @@ STR_2231    :ドロップに・ホールド・ブレーキ
 STR_2232    :ケーブル・リフト・ヒル
 STR_2233    :パーク・インフォメーション
 STR_2234    :最近のメッセージ
-STR_2235    :{POP16}{MONTH} {PUSH16}{PUSH16}{STRINGID}
 STR_2236    :1月
 STR_2237    :2月
 STR_2238    :3月
@@ -1637,7 +1630,6 @@ STR_2285    :初期の研究
 STR_2286    :デサイン中
 STR_2287    :デサインを終わる
 STR_2288    :未知
-STR_2289    :{POP16}{MONTH} {PUSH16}{PUSH16}{STRINGID}
 STR_2291    :新しいシナリオを始める
 STR_2292    :{WINDOW_COLOUR_2}参加したライド:
 STR_2293    :{BLACK} なし
@@ -2067,20 +2059,6 @@ STR_2992    :バナーのテキト
 STR_2993    :テキトを入力してください:
 STR_2994    :看板の文字を変更
 STR_2995    :この看板を除去する
-STR_2996    :{BLACK}あいう
-STR_2997    :{GREY}あいう
-STR_2998    :{WHITE}あいう
-STR_2999    :{RED}あいう
-STR_3000    :{GREEN}あいう
-STR_3001    :{YELLOW}あいう
-STR_3002    :{TOPAZ}あいう
-STR_3003    :{CELADON}あいう
-STR_3004    :{BABYBLUE}あいう
-STR_3005    :{PALELAVENDER}あいう
-STR_3006    :{PALEGOLD}あいう
-STR_3007    :{LIGHTPINK}あいう
-STR_3008    :{PEARLAQUA}あいう
-STR_3009    :{PALESILVER}あいう
 STR_3010    :ファイルをロードすることができません…
 STR_3011    :ファイルには無効なデータが含まれています
 STR_3045    :音楽のスタイルの選定

--- a/data/language/ko-KR.txt
+++ b/data/language/ko-KR.txt
@@ -612,8 +612,6 @@ STR_1214    :출발하기 전에 최대한 기다릴 시간
 STR_1215    :{WINDOW_COLOUR_2}인접한 탑승장과 같이 출발시킴
 STR_1216    :체크하면 모든 인접한 탑승장의 차량을 동시에 출발시킵니다
 STR_1217    :{COMMA16}초
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :출구만 있음
 STR_1221    :입구 없음
 STR_1222    :출구 없음
@@ -1591,7 +1589,6 @@ STR_2231    :낙하 브레이크
 STR_2232    :케이블 리프트 힐
 STR_2233    :공원 정보
 STR_2234    :최근 메시지
-STR_2235    :{POP16}{STRINGID} {PUSH16}{PUSH16}{STRINGID}
 STR_2236    :1월
 STR_2237    :2월
 STR_2238    :3월
@@ -1645,7 +1642,6 @@ STR_2285    :초기 연구
 STR_2286    :디자인 중
 STR_2287    :디자인 완성
 STR_2288    :알 수 없음
-STR_2289    :{POP16}{STRINGID} {PUSH16}{PUSH16}{STRINGID}
 STR_2291    :새 게임을 시작할 시나리오를 선택하세요
 STR_2292    :{WINDOW_COLOUR_2}탑승했던 놀이기구:
 STR_2293    :{BLACK} 없음

--- a/data/language/nl-NL.txt
+++ b/data/language/nl-NL.txt
@@ -1569,8 +1569,6 @@ STR_2212    :Toon lijst van bewakers in het park
 STR_2213    :Toon lijst van entertainers in het park
 STR_2214    :Bouwen is niet mogelijk wanneer het spel is gepauzeerd!
 STR_2215    :{STRINGID}{NEWLINE}({STRINGID})
-STR_2216    :{WINDOW_COLOUR_2}{COMMA16} °C
-STR_2217    :{WINDOW_COLOUR_2}{COMMA16} °F
 STR_2218    :{RED}{STRINGID} van {STRINGID} is nog niet teruggekeerd naar de opstapplaats ({STRINGID})!{NEWLINE}Controleer of het is vastgelopen of stil komen te staan
 STR_2219    :{RED}{COMMA16} personen zijn om het leven gekomen bij een ongeluk in {STRINGID}
 STR_2220    :{WINDOW_COLOUR_2}Parkwaardering: {BLACK}{COMMA16}

--- a/data/language/sv-SE.txt
+++ b/data/language/sv-SE.txt
@@ -559,7 +559,6 @@ STR_1161    :Kan inte placera detta här…
 STR_1162    :{OUTLINE}{TOPAZ}{STRINGID}
 STR_1163    :{STRINGID}{NEWLINE}(Högerklicka för att ändra)
 STR_1164    :{STRINGID}{NEWLINE}(Högerklicka för att ta bort)
-STR_1165    :{STRINGID} – {STRINGID} {COMMA16}
 STR_1166    :Kan inte sänka vattennivån…
 STR_1167    :Kan inte höja vattennivån…
 STR_1168    :Inställningar
@@ -727,8 +726,6 @@ STR_1329    :{WINDOW_COLOUR_2}Starthastighet:
 STR_1330    :Maxhastighet när tåget lämnar stationen
 STR_1331    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{VELOCITY}
 STR_1332    :{VELOCITY}
-STR_1333    :{STRINGID} – {STRINGID}{POP16}
-STR_1334    :{STRINGID} – {STRINGID} {COMMA16}
 STR_1335    :{STRINGID} – Ingång{POP16}{POP16}
 STR_1336    :{STRINGID} – Station {POP16}{COMMA16} Ingång
 STR_1337    :{STRINGID} – Utgång{POP16}{POP16}

--- a/data/language/uk-UA.txt
+++ b/data/language/uk-UA.txt
@@ -720,8 +720,6 @@ STR_1329    :{WINDOW_COLOUR_2}Швидкість запуску:
 STR_1330    :Максимальна швидкість при відправлені зі станції
 STR_1331    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{VELOCITY}
 STR_1332    :{VELOCITY}
-STR_1333    :{STRINGID} — {STRINGID}{POP16}
-STR_1334    :{STRINGID} — {STRINGID} {COMMA16}
 STR_1335    :{STRINGID} — Вхід{POP16}{POP16}
 STR_1336    :{STRINGID} — Станція {POP16}{COMMA16} Вхід
 STR_1337    :{STRINGID} — Вихід{POP16}{POP16}
@@ -2065,20 +2063,6 @@ STR_2992    :Текст знаку
 STR_2993    :Уведіть текст для знаку:
 STR_2994    :Змінити текст на знаку
 STR_2995    :Знести цей знак
-STR_2996    :{BLACK}АБВ
-STR_2997    :{GREY}АБВ
-STR_2998    :{WHITE}АБВ
-STR_2999    :{RED}АБВ
-STR_3000    :{GREEN}АБВ
-STR_3001    :{YELLOW}АБВ
-STR_3002    :{TOPAZ}АБВ
-STR_3003    :{CELADON}АБВ
-STR_3004    :{BABYBLUE}АБВ
-STR_3005    :{PALELAVENDER}АБВ
-STR_3006    :{PALEGOLD}АБВ
-STR_3007    :{LIGHTPINK}АБВ
-STR_3008    :{PEARLAQUA}АБВ
-STR_3009    :{PALESILVER}АБВ
 STR_3010    :Не вдалося завантажити файл…
 STR_3011    :Файл містить невірні дані
 STR_3045    :Select style of music to play

--- a/data/language/vi-VN.txt
+++ b/data/language/vi-VN.txt
@@ -377,8 +377,6 @@ STR_0980    :Trò chơi cảm giác mạnh mới
 STR_0981    :Trò chơi dưới nước mới
 STR_0982    :Cửa hàng & Quầy hàng mới
 STR_0983    :Nghiên cứu & Phát triển
-STR_0984    :{WINDOW_COLOUR_2}▲{BLACK} {CURRENCY2DP}
-STR_0985    :{WINDOW_COLOUR_2}▼{BLACK} {CURRENCY2DP}
 STR_0986    :{BLACK}{CURRENCY2DP}
 STR_0987    :Quá nhiều trò chơi/điểm tham quan
 STR_0988    :Không thể tạo trò chơi/điểm tham quan mới…

--- a/data/language/zh-CN.txt
+++ b/data/language/zh-CN.txt
@@ -377,8 +377,6 @@ STR_0980    :新的刺激类游乐设施
 STR_0981    :新的水上游乐设施
 STR_0982    :新的商店及摊贩
 STR_0983    :研究及开发
-STR_0984    :{WINDOW_COLOUR_2}▲{BLACK} {CURRENCY2DP}
-STR_0985    :{WINDOW_COLOUR_2}▼{BLACK} {CURRENCY2DP}
 STR_0986    :{BLACK}{CURRENCY2DP}
 STR_0987    :过多游乐设施/店铺
 STR_0988    :不能新建游乐设施/店铺……
@@ -558,7 +556,6 @@ STR_1161    :不能放置于此……
 STR_1162    :{OUTLINE}{TOPAZ}{STRINGID}
 STR_1163    :{STRINGID}{NEWLINE}（按右键修改）
 STR_1164    :{STRINGID}{NEWLINE}（按右键移除）
-STR_1165    :{STRINGID}——{STRINGID} {COMMA16}
 STR_1166    :无法降低此处水位……
 STR_1167    :无法升高此处水位……
 STR_1168    :选项
@@ -611,8 +608,6 @@ STR_1214    :选择发车前最长等待时长
 STR_1215    :{WINDOW_COLOUR_2}与相邻站同步
 STR_1216    :选择是否与所有相邻车站同步发车（用于“赛车”模式）
 STR_1217    :{COMMA16}秒
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :出口
 STR_1221    :没有入口
 STR_1222    :没有出口
@@ -726,8 +721,6 @@ STR_1329    :{WINDOW_COLOUR_2}发车速度：
 STR_1330    :离站时最高速度
 STR_1331    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{VELOCITY}
 STR_1332    :{VELOCITY}
-STR_1333    :{STRINGID}——{STRINGID}{POP16}
-STR_1334    :{STRINGID}——{STRINGID}{COMMA16}
 STR_1335    :{STRINGID}——入口{POP16}{POP16}
 STR_1336    :{STRINGID}——车站{POP16}{COMMA16}入口
 STR_1337    :{STRINGID}——出口{POP16}{POP16}
@@ -781,8 +774,6 @@ STR_1384    :{YELLOW}{STRINGID}
 STR_1385    :其他轨道选项
 STR_1386    :特殊……
 STR_1387    :无法改变土地类型……
-STR_1388    :{OUTLINE}{GREEN}+{CURRENCY}
-STR_1389    :{OUTLINE}{RED}-{CURRENCY}
 STR_1390    :{CURRENCY2DP}
 STR_1391    :{RED}{CURRENCY2DP}
 STR_1392    :观看游乐设施/店铺
@@ -842,9 +833,6 @@ STR_1445    :正在观看{STRINGID}的建造
 STR_1446    :正在欣赏景物
 STR_1447    :正在离开游乐园
 STR_1448    :正在观看新游乐设施的建造过程
-STR_1449    :{SPRITE} {STRINGID}{NEWLINE}（{STRINGID}）
-STR_1450    :{INLINE_SPRITE}{09}{20}{00}{00}{SPRITE} {STRINGID}{NEWLINE}（{STRINGID}）
-STR_1451    :{STRINGID}{NEWLINE}（{STRINGID}）
 STR_1452    :游客命名
 STR_1453    :请输入这名游客的姓名:
 STR_1454    :不能命名该游客……
@@ -1122,7 +1110,6 @@ STR_1727    :建筑权不供购买！
 STR_1728    :不能在此购买建权……
 STR_1729    :非游乐园所属地块！
 STR_1730    :{RED}已关闭
-STR_1731    :{WHITE}{STRINGID}——- 
 STR_1732    :建造
 STR_1733    :模式
 STR_1734    :{WINDOW_COLOUR_2}圈数：
@@ -1190,7 +1177,6 @@ STR_1813    :其他物体
 STR_1814    :动作
 STR_1815    :想法
 STR_1816    :选择游客列表中要显示的信息类别
-STR_1817    :（{COMMA32}）
 STR_1818    :{WINDOW_COLOUR_2}所有游客
 STR_1819    :{WINDOW_COLOUR_2}所有游客（汇总）
 STR_1820    :{WINDOW_COLOUR_2}{STRINGID}的游客
@@ -1567,7 +1553,6 @@ STR_2211    :列出游乐园内的维修人员
 STR_2212    :列出游乐园内的安全警卫
 STR_2213    :列出游乐园内的表演人员
 STR_2214    :你不能在游戏暂停时建造！
-STR_2215    :{STRINGID}{NEWLINE}（{STRINGID}）
 STR_2216    :{WINDOW_COLOUR_2}{COMMA16}°C
 STR_2217    :{WINDOW_COLOUR_2}{COMMA16}°F
 STR_2218    :{RED}{STRINGID} ，{STRINGID}的一部份，尚未返回到{STRINGID}！{NEWLINE}检查是否被卡住或被停止了
@@ -1969,7 +1954,6 @@ STR_2778    :»{MOVE_X}{10}{STRING}
 STR_2779    :查看窗口 #{COMMA16}
 STR_2780    :额外的查看窗口
 # End of new strings
-STR_2781    :{STRINGID}：
 STR_2782    :SHIFT + 
 STR_2783    :CTRL + 
 STR_2784    :变更快捷键
@@ -3149,8 +3133,6 @@ STR_6058    :静音
 STR_6059    :»
 STR_6060    :将游客的购买行为用动画表现
 STR_6061    :当游客购买时播放金钱动画效果。
-STR_6062    :{OUTLINE}{GREEN}+{CURRENCY2DP}
-STR_6063    :{OUTLINE}{RED}-{CURRENCY2DP}
 STR_6064    :拥有所有土地
 STR_6065    :记录用户操作
 STR_6066    :在你的用户文件夹下用文件记录所有用户的操作。
@@ -3279,9 +3261,6 @@ STR_6225    :不支持OpenGL渲染
 STR_6226    :允许剧情提前完成
 STR_6227    :当所有剧情目标在预定时间之前达成时将触发剧情完成。
 STR_6228    :剧情选项
-STR_6229    :{WINDOW_COLOUR_2}{STRINGID}：{STRINGID}
-STR_6230    :{BLACK}{STRINGID}：
-STR_6231    :{WINDOW_COLOUR_2}{STRINGID}：{MOVE_X}{185}{STRINGID}
 STR_6232    :一动不动
 STR_6233    :剖视图视角
 STR_6234    :高亮道路相关物

--- a/data/language/zh-TW.txt
+++ b/data/language/zh-TW.txt
@@ -250,8 +250,6 @@ STR_0831    :縮小檢視區域
 STR_0832    :將檢視區域順時針旋轉90°
 STR_0833    :暫停遊戲
 STR_0834    :硬碟及遊戲選項
-STR_0839    :{UINT16} x {UINT16}
-STR_0840    :{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{POP16}{UINT16} x {UINT16}
 # The following six strings were used for display resolutions, but have been replaced.
 STR_0847    :有關‘OpenRCT2’
 STR_0850    :{WINDOW_COLOUR_2}版權商標 © 2002 Chris Sawyer, 版權所有
@@ -612,8 +610,6 @@ STR_1214    :選擇發車前最多的等待時長
 STR_1215    :{WINDOW_COLOUR_2}與鄰近車站同步發車
 STR_1216    :選擇是否與全部鄰近車站同步發車 (以便‘競賽’)
 STR_1217    :{COMMA16}秒
-STR_1218    :{BLACK}➕
-STR_1219    :{BLACK}➖
 STR_1220    :只准卸客
 STR_1221    :尚未建造入口
 STR_1222    :尚未建造出口
@@ -3286,7 +3282,6 @@ STR_6227    :當劇情目前於指定日期前完成時便立即完成劇情.
 STR_6228    :劇情選項
 STR_6229    :{WINDOW_COLOUR_2}{STRINGID}: {STRINGID}
 STR_6230    :{BLACK}{STRINGID}:
-STR_6231    :{WINDOW_COLOUR_2}{STRINGID}:
 STR_6232    :涷結
 STR_6233    :切入檢視
 STR_6234    :高亮道路問題


### PR DESCRIPTION
I'm removing all translations reported as "unexpected" because they were not needed. Opening as draft because I want to review if there are more "keys to ignore" that we haven't been maintaining