### PR TITLE
Scripting: Limit triggering Translation Check

### DIFF
--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -1,6 +1,9 @@
 name: Translation Check
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    paths:
+     - 'data/language/**.txt'
 
 jobs:
   build:


### PR DESCRIPTION
**Limit running Translation Check only to PR-s that touch text files in data/language**

Due to reason that it is unnecessary to re-run it when  e.g. GitHub workflows are being modified, or when objects JSONs are being modified, since it does not perform any operations with aforementioned.

_____________

**This change bring benefits:**

  🌿 removes unnecessary actions performed by computers, which consume electricity, therefore it is ecological
  😌 committers and maintainers will receive less unwanted messages, and thus will be calmer
  #️less reports passing thru discord #github

_____________

**I had tested this** (made a [mock-up copy of this repository](https://github.com/tygrysek90/l10n-action-ideas-testing/pulls) and testing modifications on that (since on fork one needs to be in master, which I find inconvenient)