### PR TITLE
Scripting: Action to comment PR-s touching scripts

### DIFF
--- a/.github/workflows/keys-change-check.yml
+++ b/.github/workflows/keys-change-check.yml
@@ -1,0 +1,93 @@
+name: Keys change check
+
+on: 
+  pull_request_target:
+    paths:
+     - '.github/workflows/**.py'
+
+
+jobs:
+  keys-change-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name:  Get Pull Request
+        uses: actions/checkout@v4
+        with:
+          path: pr
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Get OpenRCT2 develop (for en-GB.txt)
+        uses: actions/checkout@v4
+        with:
+          repository: OpenRCT2/OpenRCT2
+          ref: develop
+          path: OpenRCT2
+
+      - name: Checkout translations before PR changes (for comparsion)
+        uses: actions/checkout@v4
+        with:
+          path: master
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      - name: Checkout commit before branch changes
+        id: merge-base-commit
+        run: |
+          echo "head sha: ${{github.event.pull_request.head.sha}}"
+          cd master
+          git remote add upstream https://github.com/${{github.repository}}
+          git fetch upstream
+          merge_base=$(git merge-base refs/remotes/upstream/master HEAD)
+          echo "merge base sha: ${merge_base}"
+          git checkout $merge_base
+          echo "merge_base=$merge_base" >> $GITHUB_OUTPUT
+          cd ..
+
+      - name: Print debug stuff
+        run: |
+          echo ${{steps.merge-base-commit.outputs.merge_base}}
+          echo ${{github.event.pull_request.head.sha}}
+          echo ${{steps.merge-base-commit.outputs.merge_base == github.event.pull_request.head.sha}}
+
+      - name: Remove master
+        if: ${{ steps.merge-base-commit.outputs.merge_base == github.event.pull_request.head.sha }}
+        run: rm -rf master
+
+      - name: Checkout upstream master as master
+        uses: actions/checkout@v4
+        if: ${{ steps.merge-base-commit.outputs.merge_base == github.event.pull_request.head.sha }}
+        with:
+          ref: master
+          path: master
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Checkout upstream master (in order to use the newest version of the script)
+        uses: actions/checkout@v4
+        with:
+          path: upstream_master
+          ref: master
+
+      - name: Run checks
+        run: python upstream_master/.github/workflows/keys_change_check.py
+
+      - id: get-comment-body
+        run: |
+          delimiter=$(openssl rand -hex 8)
+          {
+            echo "body<<$delimiter"
+            cat result.md
+            echo "$delimiter"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{github.event.pull_request.number}}
+          body: ${{ steps.get-comment-body.outputs.body }}

--- a/.github/workflows/keys_change_check.py
+++ b/.github/workflows/keys_change_check.py
@@ -1,0 +1,79 @@
+import importlib.util
+
+print("keys_change_check.py script text output")
+
+"""
+Load modules to compare and en-GB.txt file
+"""
+module_path = 'pr/.github/workflows/translation_check.py'
+module_name = 'keys_pr'  
+module_spec = importlib.util.spec_from_file_location(module_name, module_path)
+keys_pr_module = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(keys_pr_module)
+
+module_path = 'master/.github/workflows/translation_check.py'
+module_name = 'keys_master'  
+module_spec = importlib.util.spec_from_file_location(module_name, module_path)
+keys_master_module = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(keys_master_module)
+
+keys_list_old = keys_master_module.KEYS_TO_IGNORE
+keys_list_new = keys_pr_module.KEYS_TO_IGNORE
+
+OPENRCT2_EN_GB_FILE = "OpenRCT2/data/language/en-GB.txt"
+
+result_file = open("result.md", "w")
+
+result = "**Comparing changes**\n\n"
+result += "`KEYS_TO_IGNORE` in `translation_check.py` - list items expanded using `develop` version of `en-GB.txt`\n\n"
+
+result += "```diff\n"
+"""
+use github codeblock diff style
+"""
+
+counter_add = 0
+counter_rem = 0
+
+for line in open(OPENRCT2_EN_GB_FILE):
+    if line[0:8] in keys_list_old and line[0:8] in keys_list_new:
+        result += ("  "+line) # =
+    if line[0:8] in keys_list_old and line[0:8] not in keys_list_new:
+        result += ("- "+line)
+        counter_rem += 1
+    if line[0:8] not in keys_list_old and line[0:8] in keys_list_new:
+        result += ("+ "+line)
+        counter_add += 1
+    if line[0:8] in keys_list_new:
+        keys_list_new.remove(line[0:8])
+    if line[0:8] in keys_list_old:
+        keys_list_old.remove(line[0:8])
+
+result += "\n"
+
+result += " "+30*"-"+"\n"
+
+result += "+ "+str(counter_add)+" keys\n"
+result += "- "+str(counter_rem)+" keys\n"
+
+result += " "+30*"="+"\n"+"\n"
+
+for compared_side_name, compared_side_keys in [('MASTER', keys_list_old), ('PR', keys_list_new)]:
+    result += compared_side_name
+    result += " KEYS NOT FOUND IN en-GB.txt"
+    result += "\n"
+
+    for key in compared_side_keys:
+        result += "! "+key
+        result += "\n"
+        
+    result += "\n "+30*"-"+"\n"
+    result += "! "+str(len(compared_side_keys))+" keys\n"
+    result += " "+30*"="+"\n\n"
+
+
+result += "```"
+result += "\n\n\n"
+
+result_file.write(result)
+result_file.close()


### PR DESCRIPTION
Auto-comment PR-s touching scripts with explained diff showing changes to KEYS_TO_IGNORE in translation_check.py

______


Since I found myself helping @tupaschoal with summer cleaning :) of this repository in
- https://github.com/OpenRCT2/Localisation/pull/3302
- https://github.com/OpenRCT2/Localisation/pull/3308

A need to observe what is actually hidden in KEYS_TO_IGNORE and - what possible changes are making - the need araised - since it is quite dull to check 100 indexes by hand. Therefore I made script that does alike locally (thus still requires truckload of copy-pasting) - then I thought it could be useful to set it online.

PR as draft, to review idea and ... I am certain I made some mistake/oversight :)
_______


Screenshot to give idea (made with staged files in staged repository for testing, its just showcase)

<img width="926" height="1747" alt="staged" src="https://github.com/user-attachments/assets/fd531bbe-d055-4414-be50-5edb4e2fd261" />

______