### PR TITLE
Add a wiki link into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Changes to the master branch are merged into the develop branch of OpenRCT2/Open
 
 To contribute to the translation of OpenRCT2, you will need to fork this repository.<br/>
 This allows you to edit and push changes of files to your fork so that you can then open a pull request.<br/>
-For more information, visit GitHub's official [forking guide](https://guides.github.com/activities/forking/).
+For more information, visit GitHub's official [forking guide](https://guides.github.com/activities/forking/) or ours Wiki on how-to [fork and commit using only web browser](https://github.com/OpenRCT2/Localisation/wiki/Committing-basics).
 
 ### Creating a new language
 If you want to begin translating OpenRCT2 for a new language, create a new file in the data directory with the correct two letter [language](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes#Partial_ISO_639_table) and [country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Decoding_table) (e.g. `cs-CZ`), then paste the contents of the [en-GB](https://github.com/OpenRCT2/OpenRCT2/blob/develop/data/language/en-GB.txt) file into it and start translating the strings.


### PR DESCRIPTION
Into README.md add a link to Localisation's Wiki about forking and committing via web browser, in order to offer alternative for (possible) translators not accustomed to concurrent version systems and `git / gh` command line workflow.

Adding a link to recently updated and widened Localisation wiki **will create more welcoming environment for possible newly coming translators**, whom might not be fluent with command line `git` forking.

_Honestly, I myself had great troubles and sweaty buttocks while learning to use GitHub - thankfully Gymnasiast managed to put me thru this process helping me via Discord. And I can tell about myself I am not good at scripting or programming neither, as shown [here](https://github.com/OpenRCT2/Localisation/pull/3309#discussion_r2269373644)_

