### PR TITLE
hi-IN: Add hi-IN to suppress_warning.py

### DIFF
--- a/.github/workflows/suppress_warning.py
+++ b/.github/workflows/suppress_warning.py
@@ -32,6 +32,7 @@ SUPPRESS_WARNING['fr-CA'] = []
 # fr-FR uses em dashes (—) instead of en dashes (-) for separators and must have a non-breaking space before colons
 SUPPRESS_WARNING['fr-FR'] = ['STR_1165', 'STR_1333', 'STR_1334', 'STR_2781', 'STR_6229', 'STR_6230', 'STR_6231']
 SUPPRESS_WARNING['gl-ES'] = []
+SUPPRESS_WARNING['hi-IN'] = []
 # hu-HU needs to change order of {STRINGID}s for news and research to translate them properly.
 SUPPRESS_WARNING['hu-HU'] = ['STR_2235', 'STR_2289']
 SUPPRESS_WARNING['it-IT'] = []


### PR DESCRIPTION
## Summary

- Register Hindi (India) language (`hi-IN`) in the `suppress_warning.py` dictionary
- Without this entry, any PR adding `hi-IN.txt` crashes the translation check CI with `KeyError: 'hi-IN'`
- This is a prerequisite for PR #3432 (Hindi localisation)

## Context

The `suppress_warning.py` file documents this requirement:
> *"Failing to add new language in this dictionary will cause KeyError being raised in translation_check.py and therefore it will break GitHub Action job"*

