### PR TITLE
eo-ZZ: "pokey"/"dinky" is supposed to mean "small", "cramped"

### DIFF
--- a/objects/eo-ZZ.json
+++ b/objects/eo-ZZ.json
@@ -553,9 +553,9 @@
     },
     "rct1.scenario_meta.pokey_park": {
         "reference-name": "Pokey Park",
-        "name": "Poki-Parko",
+        "name": "Malvasta Parko",
         "reference-park_name": "Pokey Park",
-        "park_name": "Poki-Parko",
+        "park_name": "Malvasta Parko",
         "reference-details": "A small, cramped amusement park which requires major expansion",
         "details": "Malgranda kaj malvasta amuzparko, kiu bezonas grandan kreskadon"
     },


### PR DESCRIPTION
Right now "Pokey Park" is translated as "Poki-Parko", as if "Pokey" is a proper name. Given that the ~~British~~ American English version of the game has it as "Dinky Park", I assume that the word is meant to be an adjective referring to the park's small size.

This is my first contribution to the Esperanto localization, and I would like to contribute more, if I figure out the correct workflow, as I believe there's space for improvement.