### PR TITLE
eo-ZZ: removal of Title Case and rewording for objects

### DIFF
--- a/data/language/eo-ZZ.txt
+++ b/data/language/eo-ZZ.txt
@@ -86,8 +86,8 @@ STR_0089    :Miniatura onda fervojo
 STR_0090    :Minrajdo
 STR_0092    :Onda fervojo lanĉita per linearaj induktaj motoroj
 STR_0093    :Hibrida onda fervojo
-STR_0094    :Onda fervojo kun unuopa relo
-STR_0095    :Alpa onda fervojo
+STR_0094    :Unurela onda fervojo
+STR_0095    :Alpeca onda fervojo
 STR_0096    :Klasika ligna onda fervojo
 STR_0097    :Klasika staranta onda fervojo
 STR_0098    :Onda fervojo lanĉita per linearaj sinkronaj motoroj

--- a/objects/eo-ZZ.json
+++ b/objects/eo-ZZ.json
@@ -4313,7 +4313,7 @@
     },
     "rct2.scenery_small.tdt1": {
         "reference-name": "Dead Tree",
-        "name": "Morta arbo"
+        "name": "Senviva arbo"
     },
     "rct2.scenery_small.tdt2": {
         "reference-name": "Dead Tree",

--- a/objects/eo-ZZ.json
+++ b/objects/eo-ZZ.json
@@ -1,19 +1,19 @@
 {
     "couger.scenery_wall.acww33": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "couger.scenery_wall.acwwf32": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "mamabear.scenery_wall.mg-prar": {
         "reference-name": "Wall with Passageway",
-        "name": "Muro kun Koridoro"
+        "name": "Muro kun koridoro"
     },
     "official.scenery_small.support_structure_half": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "official.scenery_wall.post_flipped": {
         "reference-name": "Post",
@@ -21,11 +21,11 @@
     },
     "official.scenery_wall.support_structure_full": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "official.scenery_wall.support_structure_half": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "official.terrain_edge.void": {
         "reference-name": "Void",
@@ -33,19 +33,19 @@
     },
     "openrct2.footpath_railings.invisible": {
         "reference-name": "Invisible Railings",
-        "name": "Nevideblaj Balustradoj"
+        "name": "Nevideblaj balustradoj"
     },
     "openrct2.footpath_surface.invisible": {
         "reference-name": "Invisible Footpath",
-        "name": "Nevidebla Trotuaro"
+        "name": "Nevidebla trotuaro"
     },
     "openrct2.footpath_surface.queue_invisible": {
         "reference-name": "Invisible Queue",
-        "name": "Nevidebla Atendovico"
+        "name": "Nevidebla atendovico"
     },
     "openrct2.ride.alpine_coaster": {
         "reference-name": "Alpine Coaster Cars",
-        "name": "Alpaj Ĉaroj de Onda Fervojo",
+        "name": "Ĉaroj de alpeca onda fervojo",
         "reference-description": "Wheeled sleds equipped with manually operated brakes",
         "description": "Radaj sledoj ekipita per mane funkciigitaj bremsoj",
         "reference-capacity": "2 passengers per car",
@@ -53,7 +53,7 @@
     },
     "openrct2.ride.hybrid_coaster": {
         "reference-name": "Hybrid Coaster Trains",
-        "name": "Trajnoj de Hibrida Onda Fervojo",
+        "name": "Trajnoj de hibrida onda fervojo",
         "reference-description": "Roller coaster trains with lap restraints, capable of steep drops and inversions",
         "description": "Trajnoj de onda fervojo kun sinobridoj, kapablaj je krutaj malleviĝoj kaj inversigoj",
         "reference-capacity": "4 passengers per car",
@@ -61,7 +61,7 @@
     },
     "openrct2.ride.modern_twister": {
         "reference-name": "Modern Twister Trains",
-        "name": "Modernaj Tvisto-Trajnoj",
+        "name": "Modernaj tvisto-trajnoj",
         "reference-description": "Spacious trains with lap restraints, capable of tight twists and inversions",
         "description": "Grandspacaj trajnoj kun sinobridoj, kapablaj je krutaj tvistoj kaj inversigoj",
         "reference-capacity": "4 passengers per car",
@@ -69,7 +69,7 @@
     },
     "openrct2.ride.single_rail_coaster": {
         "reference-name": "Single Rail Roller Coaster Trains",
-        "name": "Trajnoj de Onda Fervojo kun Unuopa Relo",
+        "name": "Trajnoj de unurela onda fervojo",
         "reference-description": "Roller coaster trains in which riders are seated single file",
         "description": "Trajnoj de onda fervojo, kiuj rajdantoj sidas anservice",
         "reference-capacity": "1 passenger per car",
@@ -93,15 +93,15 @@
     },
     "rct1.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Sloped)",
-        "name": "Freneza-Pavima Trotuaro (Dekliva)"
+        "name": "Freneza-pavima trotuaro (dekliva)"
     },
     "rct1.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Square)",
-        "name": "Tera Trotuaro (Kvadrata)"
+        "name": "Tera trotuaro (kvadrata)"
     },
     "rct1.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Sloped)",
-        "name": "Blua Atendovico (Dekliva)"
+        "name": "Blua atendovico (dekliva)"
     },
     "rct1.footpath_surface.road": {
         "reference-name": "Road",
@@ -109,15 +109,15 @@
     },
     "rct1.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Sloped)",
-        "name": "Asfalta Trotuaro (Dekliva)"
+        "name": "Asfalta trotuaro (dekliva)"
     },
     "rct1.footpath_surface.tiles_brown": {
         "reference-name": "Brown Tiled Footpath",
-        "name": "Bruna Kahelita Trotuaro"
+        "name": "Bruna kahelita trotuaro"
     },
     "rct1.ride.bobsleigh_trains": {
         "reference-name": "Bobsleigh Trains",
-        "name": "Bobsledo-Trajnoj",
+        "name": "Bobsledaj trajnoj",
         "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Trajnoj, konsistaj de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
         "reference-capacity": "2 passengers per car",
@@ -125,7 +125,7 @@
     },
     "rct1.ride.bumper_boats": {
         "reference-name": "Bumper Boats",
-        "name": "Doĝemo-Boatoj",
+        "name": "Kunfrapemaj boatoj",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Malgrandaj rondaj boatetoj ŝaltitaj per centra motoro, kiun la pasaĝeroj funkciigas",
         "reference-capacity": "2 passengers per boat",
@@ -133,7 +133,7 @@
     },
     "rct1.ride.cat_cars": {
         "reference-name": "Cheshire Cats",
-        "name": "Ĉeŝiraj Katoj",
+        "name": "Ĉeŝiraj katoj",
         "reference-description": "Powered cat-shaped vehicles",
         "description": "Ŝaltitaj katformaj veturiloj",
         "reference-capacity": "2 passengers per cat",
@@ -141,7 +141,7 @@
     },
     "rct1.ride.chairlift_cars": {
         "reference-name": "Chairlift Cars",
-        "name": "Ĉaroj de Seĝlifto",
+        "name": "Ĉaroj de seĝlifto",
         "reference-description": "Open cars for chairlift",
         "description": "Subĉielaj ĉaroj de seĝlifto",
         "reference-capacity": "2 passengers per car",
@@ -149,7 +149,7 @@
     },
     "rct1.ride.corkscrew_trains": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Trajnoj de Korktirila Onda Fervojo",
+        "name": "Trajnoj de korktirila onda fervojo",
         "reference-description": "Roller coaster trains with shoulder restraints",
         "description": "Trajnoj de onda fervojo kun ŝultrobridoj",
         "reference-capacity": "4 passengers per car",
@@ -165,25 +165,25 @@
     },
     "rct1.ride.dodgems": {
         "reference-name": "Dodgems",
-        "name": "Doĝemoj",
+        "name": "Kunfrapemaj aŭtetoj",
         "reference-description": "Riders bump into each other in self-drive electric dodgems",
-        "description": "Rajdantoj albatiĝas al unu la alian per elektraj doĝemoj",
+        "description": "Rajdantoj albatiĝas al unu la alian per elektraj aŭtetoj",
         "reference-capacity": "1 person per car",
         "capacity": "Po 1 ulo por ĉaro"
     },
     "rct1.ride.fruity_ices_stall": {
         "reference-name": "Fruity Ices Stall",
-        "name": "Frukto-Glaciaĵobudo",
+        "name": "Frukto-glaciaĵobudo",
         "reference-description": "A themed stall selling fruity ice creams",
         "description": "Temita budo vendanta frukto-glaciaĵojn"
     },
     "rct1.ride.go_karts": {
         "reference-name": "Go-Karts (with helmets)",
-        "name": "Gokartoj (kun kaskoj)",
+        "name": "Vetkuraj aŭtetoj (kun kaskoj)",
         "reference-description": "Self-driven petrol-engined go-karts that come with safety helmets",
-        "description": "Gokartoj kun benzinmotoroj kaj protektaj kaskoj, kiujn pasaĝeroj stiras per si mem",
+        "description": "Vetkuraj aŭtetoj kun benzinmotoroj kaj protektaj kaskoj, kiujn pasaĝeroj stiras per si mem",
         "reference-capacity": "single-seater",
-        "capacity": "single-seater"
+        "capacity": "unu-seĝa"
     },
     "rct1.ride.horses": {
         "reference-name": "Horses",
@@ -195,7 +195,7 @@
     },
     "rct1.ride.inverted_trains": {
         "reference-name": "Inverted Coaster Trains",
-        "name": "Trajnoj de Inversigita Onda Fervojo",
+        "name": "Trajnoj de inversigita onda fervojo",
         "reference-description": "Inverted roller coaster train, consisting of seats hanging from a supporting frame running on the track above.",
         "description": "Inversigita trajno de onda fervojo, kiuj konsistas el seĝoj pendantaj de subtena kadro veturanta sur la trako supre.",
         "reference-capacity": "2 passengers per car",
@@ -203,7 +203,7 @@
     },
     "rct1.ride.ladybird_trains": {
         "reference-name": "Ladybird Trains",
-        "name": "Kokcineloj-Trajnoj",
+        "name": "Kokcinelo-trajnoj",
         "reference-description": "Roller coaster trains with small ladybird-shaped cars",
         "description": "Trajnoj de onda fervojo kun malgrandaj kokcineloformaj ĉaroj",
         "reference-capacity": "2 passengers per car",
@@ -211,7 +211,7 @@
     },
     "rct1.ride.log_trains": {
         "reference-name": "Log Trains",
-        "name": "Ŝtipo-Trajnoj",
+        "name": "Ŝtipo-trajnoj",
         "reference-description": "Roller coaster trains with small log-shaped cars",
         "description": "Trajnoj de onda fervojo kun malgrandaj ŝtipoformaj ĉaroj",
         "reference-capacity": "2 passengers per car",
@@ -229,7 +229,7 @@
         "reference-name": "Mine Cars",
         "name": "Minĉaroj",
         "reference-description": "Cars shaped like an old mine cart",
-        "description": "Ĉaroj formitaj kiel malnova minĉaro",
+        "description": "Ĉaroj, formitaj kiel malnova minĉaro",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
@@ -245,7 +245,7 @@
         "reference-name": "Motorbikes",
         "name": "Motorbicikloj",
         "reference-description": "Single cars shaped like a motorbike",
-        "description": "Unuopaj ĉaroj formitaj kiel motorbiciklo",
+        "description": "Unuopaj ĉaroj, formitaj kiel motorbiciklo",
         "reference-capacity": "2 riders per bike",
         "capacity": "Po 2 rajdantoj por biciklo"
     },
@@ -253,7 +253,7 @@
         "reference-name": "Mouse Cars",
         "name": "Musoĉaroj",
         "reference-description": "Individual cars shaped like a mouse",
-        "description": "Individualaj ĉaroj formitaj kiel muso",
+        "description": "Individualaj ĉaroj, formitaj kiel muso",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
@@ -261,7 +261,7 @@
         "reference-name": "Pickup Trucks",
         "name": "Kamionetoj",
         "reference-description": "Powered vehicles in the shape of pickup trucks",
-        "description": "Ŝaltitaj veturiloj formitaj kiel kamionetoj",
+        "description": "Ŝaltitaj veturiloj, formitaj kiel kamionetoj",
         "reference-capacity": "1 passenger per truck",
         "capacity": "Po 1 pasaĝero por kamiono"
     },
@@ -269,21 +269,21 @@
         "reference-name": "Racing Cars",
         "name": "Vetkuraŭtoj",
         "reference-description": "Powered vehicles in the shape of racing cars",
-        "description": "Ŝaltitaj veturiloj formitaj kiel vetkuraŭtoj",
+        "description": "Ŝaltitaj veturiloj, formitaj kiel vetkuraŭtoj",
         "reference-capacity": "1 passenger per car",
         "capacity": "Po 1 pasaĝero por ĉaro"
     },
     "rct1.ride.reverse_freefall_car": {
         "reference-name": "Reverse Freefall Car",
-        "name": "Ĉaro de Onda Fervojo kun Dorsantaŭa Libera Falo",
+        "name": "Ĉaro de onda fervojo kun dorsantaŭa libera falo",
         "reference-description": "Large coaster car for the Reverse Freefall Coaster",
-        "description": "Granda ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
+        "description": "Granda ĉaro por la onda fervojo kun dorsantaŭa libera falo",
         "reference-capacity": "8 passengers",
         "capacity": "8 pasaĝeroj"
     },
     "rct1.ride.river_rapids_boats": {
         "reference-name": "River Rapids Boats",
-        "name": "Boatoj de Rapidfluorajdo",
+        "name": "Boatoj de rapidfluorajdo",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
         "description": "Rondaj boatoj, kiuj turniĝas kaj plaŭdas vagante laŭ la rapidfluoj",
         "reference-capacity": "8 passengers per boat",
@@ -291,7 +291,7 @@
     },
     "rct1.ride.rocket_cars": {
         "reference-name": "Rocket Cars",
-        "name": "Raketo-Ĉaroj",
+        "name": "Raketo-ĉaroj",
         "reference-description": "Roller coaster cars themed to look like rockets",
         "description": "Ĉaroj de onda fervojo, temitaj por aspekti kiel raketoj",
         "reference-capacity": "2 passengers per car",
@@ -299,7 +299,7 @@
     },
     "rct1.ride.single_person_swinging_cars": {
         "reference-name": "Single-Person Swinging Cars",
-        "name": "Unusidlokaj Svingiĝantaj Ĉaroj",
+        "name": "Unusidlokaj svingiĝantaj ĉaroj",
         "reference-description": "Single-seater cars which hang from the rail above, and are free to swing from side to side",
         "description": "Unusidlokaj ĉaroj, kiuj pendas de la relo supre, kaj povas libere svingiĝi de unu flanko al la alia",
         "reference-capacity": "1 passenger per car",
@@ -307,7 +307,7 @@
     },
     "rct1.ride.small_monorail_cars": {
         "reference-name": "Small Monorail Cars",
-        "name": "Malgrandaj Monorelaj Ĉaroj",
+        "name": "Malgrandaj monorelaj ĉaroj",
         "reference-description": "Small monorail cars with open sides",
         "description": "Malgrandaj monorelaj ĉaroj kun subĉielaj flankoj",
         "reference-capacity": "4 passengers per car",
@@ -315,7 +315,7 @@
     },
     "rct1.ride.spinning_cars": {
         "reference-name": "Spinning Cars",
-        "name": "Turniĝantaj Ĉaroj",
+        "name": "Turniĝantaj ĉaroj",
         "reference-description": "Circular roller coaster cars which are free to spin around their central axis.",
         "description": "Cirklaj ĉaroj de onda fervojo, kiuj povas libere turniĝi ĉirkaŭ sia centra akso.",
         "reference-capacity": "4 passengers per car",
@@ -325,13 +325,13 @@
         "reference-name": "Sports Cars",
         "name": "Sportaŭtoj",
         "reference-description": "Powered vehicles in the shape of sports cars",
-        "description": "Ŝaltitaj veturiloj formitaj kiel sportaŭtoj",
+        "description": "Ŝaltitaj veturiloj, formitaj kiel sportaŭtoj",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct1.ride.stand_up_trains": {
         "reference-name": "Stand-up Roller Coaster Trains",
-        "name": "Stariĝantaj Trajnoj de Onda Fervojo",
+        "name": "Stariĝantaj trajnoj de onda fervojo",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position",
         "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio",
         "reference-capacity": "4 passengers per car",
@@ -347,7 +347,7 @@
     },
     "rct1.ride.steel_rc_trains": {
         "reference-name": "Roller Coaster Trains",
-        "name": "Trajnoj de Onda Fervojo",
+        "name": "Trajnoj de onda fervojo",
         "reference-description": "Roller coaster train with a streamlined front car.",
         "description": "Trajno de onda fervojo kun flulinia antaŭa ĉaro.",
         "reference-capacity": "4 passengers per car",
@@ -355,7 +355,7 @@
     },
     "rct1.ride.steel_rc_trains_reversed": {
         "reference-name": "Roller Coaster Trains (Reversed)",
-        "name": "Trajnoj de Onda Fervojo (Inversigita)",
+        "name": "Trajnoj de onda fervojo (inversigita)",
         "reference-description": "Roller coaster train running in reverse, so that the passengers face backwards.",
         "description": "Trajno de onda fervojo veturanta inverse, tiel ke la pasaĝeroj rigardas dorsantaŭen.",
         "reference-capacity": "4 riders per car",
@@ -363,7 +363,7 @@
     },
     "rct1.ride.streamlined_monorail_trains": {
         "reference-name": "Streamlined Monorail Trains",
-        "name": "Aerodinamikaj Monorelaj Trajnoj",
+        "name": "Aerodinamikaj monorelaj trajnoj",
         "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
         "description": "Grandspacaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
         "reference-capacity": "5 or 10 passengers per car",
@@ -371,7 +371,7 @@
     },
     "rct1.ride.suspended_swinging_aeroplane_cars": {
         "reference-name": "Suspended Swinging Aeroplane Cars",
-        "name": "Penditaj Svingiĝantaj Aeroplano-Ĉaroj",
+        "name": "Penditaj svingiĝantaj aeroplano-ĉaroj",
         "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el aeroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "4 passengers per car",
@@ -379,7 +379,7 @@
     },
     "rct1.ride.suspended_swinging_cars": {
         "reference-name": "Suspended Swinging Cars",
-        "name": "Penditaj Svingiĝantaj Ĉaroj",
+        "name": "Penditaj svingiĝantaj ĉaroj",
         "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "4 passengers per car",
@@ -387,7 +387,7 @@
     },
     "rct1.ride.swinging_lay_down_cars": {
         "reference-name": "Lay-down Cars",
-        "name": "Kuŝiĝantaj Ĉaroj",
+        "name": "Kuŝiĝantaj ĉaroj",
         "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
         "description": "Malgrandaj penditaj ĉaroj, en kiuj la pasaĝeroj rajdas kuŝiĝante, frontas al la tero, kaj svingiĝas libere de unu flanko al la alia",
         "reference-capacity": "1 passenger per car",
@@ -401,7 +401,7 @@
     },
     "rct1.ride.vertical_drop_trains": {
         "reference-name": "Six-seater Twister Trains",
-        "name": "Tvisto-Trajnoj kun Ses Seĝoj",
+        "name": "Ses-seĝaj tvisto-trajnoj",
         "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
         "description": "Trajnoj de onda fervojo kun ekstra-larĝaj ĉaroj, konstruitaj por vertikalaj faloj",
         "reference-capacity": "6 passengers per car",
@@ -409,7 +409,7 @@
     },
     "rct1.ride.wooden_rc_trains": {
         "reference-name": "Wooden Roller Coaster Trains",
-        "name": "Trajnoj de Ligna Onda Fervojo",
+        "name": "Trajnoj de ligna onda fervojo",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
         "description": "Trajnoj de ligna onda fervojo kun komfortaj seĝoj kaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -417,7 +417,7 @@
     },
     "rct1.ride.wooden_rc_trains_reversed": {
         "reference-name": "Wooden Roller Coaster Trains (Reversed)",
-        "name": "Trajnoj de Ligna Onda Fervojo (Inversigita)",
+        "name": "Trajnoj de ligna onda fervojo (inversigita)",
         "reference-description": "Wooden roller coaster trains, but running in reverse, so that the passengers face backwards.",
         "description": "Trajnoj de ligna onda fervojo, sed veturantaj inverse, tiel ke la pasaĝeroj rigardas dorsantaŭen.",
         "reference-capacity": "4 passengers per car",
@@ -425,27 +425,27 @@
     },
     "rct1.scenario_meta.bumbly_beach": {
         "reference-name": "Bumbly Beach",
-        "name": "Burda Plaĝo",
+        "name": "Plumpa Plaĝo",
         "reference-park_name": "Bumbly Beach",
-        "park_name": "Burda Plaĝo",
+        "park_name": "Plumpa Plaĝo",
         "reference-details": "Develop Bumbly Beach’s small amusement park into a thriving theme park",
-        "details": "Ellaboru la malgrandan amuzparkon de Burda Plaĝo en prosperan amuzparkon"
+        "details": "Ellaboru la malgrandan amuzparkon de Plumpa Plaĝo en prosperan amuzparkon"
     },
     "rct1.scenario_meta.crumbly_woods": {
         "reference-name": "Crumbly Woods",
-        "name": "Ĉifaj Arbaroj",
+        "name": "Kadukaj Arbaroj",
         "reference-park_name": "Crumbly Woods",
-        "park_name": "Ĉifaj Arbaroj",
+        "park_name": "Kadukaj Arbaroj",
         "reference-details": "A large park with well-designed but rather old rides. Replace the old rides or add new rides to make the park more popular.",
-        "details": "Granda parko kun bone-desegnitaj sed iomete malnovaj atrakcioj. Anstataŭigu la malnovajn atrakciojn aŭ alkonstruu novajn atrakciojn, por farigi la parkon pli populara."
+        "details": "Granda parko kun bone-desegnitaj, sed iomete malnovaj atrakcioj. Anstataŭigu la malnovajn atrakciojn aŭ alkonstruu novajn atrakciojn, por farigi la parkon pli populara."
     },
     "rct1.scenario_meta.diamond_heights": {
         "reference-name": "Diamond Heights",
-        "name": "Diamanto-Altaĵoj",
+        "name": "Diamantaj Altaĵoj",
         "reference-park_name": "Diamond Heights",
-        "park_name": "Diamanto-Altaĵoj",
+        "park_name": "Diamantaj Altaĵoj",
         "reference-details": "Diamond Heights is already a successful theme park with great rides - develop it to double its value",
-        "details": "Diamanto-Altaĵoj jam estas sukcesa amuzparko kun bonegaj atrakcioj - ellaboru la parkon por duobligi sian valoron"
+        "details": "Diamantaj Altaĵoj jam estas sukcesa amuzparko kun bonegaj atrakcioj - ellaboru la parkon por duobligi sian valoron"
     },
     "rct1.scenario_meta.dynamite_dunes": {
         "reference-name": "Dynamite Dunes",
@@ -465,9 +465,9 @@
     },
     "rct1.scenario_meta.forest_frontiers": {
         "reference-name": "Forest Frontiers",
-        "name": "Arbaro-Limoj",
+        "name": "Arbaraj Krudlandoj",
         "reference-park_name": "Forest Frontiers",
-        "park_name": "Arbaro-Limoj",
+        "park_name": "Arbaraj Krudlandoj",
         "reference-details": "Deep in the forest, build a thriving theme park in a large cleared area",
         "details": "En profunda arbaro, konstruu prosperan amuzparkon en granda vakigita areo"
     },
@@ -481,11 +481,11 @@
     },
     "rct1.scenario_meta.karts_coasters": {
         "reference-name": "Karts & Coasters",
-        "name": "Gokartoj k Ondaj Fervojoj",
+        "name": "Vetkuraj Aŭtetoj k Ondaj Fervojoj",
         "reference-park_name": "Karts & Coasters",
-        "park_name": "Gokartoj k Ondaj Fervojoj",
+        "park_name": "Vetkuraj Aŭtetoj k Ondaj Fervojoj",
         "reference-details": "A large park hidden in the forest, with only go-kart tracks and wooden roller coasters",
-        "details": "Granda parko kaŝita en la arbaro, kiu enhavas nur trakojn de gokartoj kaj lignajn ondajn fervojojn"
+        "details": "Granda parko kaŝita en la arbaro, kiu enhavas nur trakojn de vetkuraj aŭtetoj kaj lignajn ondajn fervojojn"
     },
     "rct1.scenario_meta.katies_dreamland": {
         "reference-name": "Katie’s Dreamland",
@@ -505,11 +505,11 @@
     },
     "rct1.scenario_meta.lightning_peaks": {
         "reference-name": "Lightning Peaks",
-        "name": "Fulmo-Montopintoj",
+        "name": "Fulmaj Montopintoj",
         "reference-park_name": "Lightning Peaks",
-        "park_name": "Fulmo-Montopintoj",
+        "park_name": "Fulmaj Montopintoj",
         "reference-details": "The beautiful mountains of Lightning Peaks are popular with walkers and sightseers. Use the available land to attract a new thrill-seeking clientele.",
-        "details": "La belaj montoj de Fulmo-Montopintoj estas populara por marŝantoj kaj rigardantoj. Uzu la disponeblan teron por allogi novan klientaron, kiu volas ekscitaĵojn."
+        "details": "La belaj montoj de Fulmaj Montopintoj estas populara por marŝantoj kaj rigardantoj. Uzu la disponeblan teron por allogi novan klientaron, kiu volas ekscitaĵojn."
     },
     "rct1.scenario_meta.mega_park": {
         "reference-name": "Mega Park",
@@ -553,9 +553,9 @@
     },
     "rct1.scenario_meta.paradise_pier": {
         "reference-name": "Paradise Pier",
-        "name": "Paradizo-Enŝipigejo",
+        "name": "Paradiza Enŝipigejo",
         "reference-park_name": "Paradise Pier",
-        "park_name": "Paradizo-Enŝipigejo",
+        "park_name": "Paradiza Enŝipigejo",
         "reference-details": "Convert this sleepy town’s pier into a thriving attraction",
         "details": "Konvertu la enŝipigejon de ĉi tiu dormema urbeto en prosperan atrakcion"
     },
@@ -569,19 +569,19 @@
     },
     "rct1.scenario_meta.rainbow_valley": {
         "reference-name": "Rainbow Valley",
-        "name": "Ĉielarko-Valo",
+        "name": "Ĉielarka Valo",
         "reference-park_name": "Rainbow Valley",
-        "park_name": "Ĉielarko-Valo",
+        "park_name": "Ĉielarka Valo",
         "reference-details": "Rainbow Valley’s local authority won’t allow any landscape changes or large tree removal, but you must develop the area into a large theme park",
-        "details": "La loka aŭtoritato de Ĉielarko-Valo ne permesos iun ajn ŝanĝadon de tero aŭ forigadon de grandaj arboj, sed vi devas ellabori la areon en grandan amuzparkon"
+        "details": "La loka aŭtoritato de Ĉielarka Valo ne permesos iun ajn ŝanĝadon de tero aŭ forigadon de grandaj arboj, sed vi devas ellabori la areon en grandan amuzparkon"
     },
     "rct1.scenario_meta.thunder_rock": {
         "reference-name": "Thunder Rock",
-        "name": "Tondro-Ŝtonego",
+        "name": "Tondra Ŝtonego",
         "reference-park_name": "Thunder Rock",
-        "park_name": "Tondro-Ŝtonego",
+        "park_name": "Tondra Ŝtonego",
         "reference-details": "Thunder Rock stands in the middle of a desert and attracts many tourists. Use the available space to build rides to attract more people.",
-        "details": "Tondro-Ŝtonego troviĝas en la mezo de dezerto, kaj allogas multajn turistojn. Uzu la spacon disponeblan por konstrui atrakciojn por allogi pli da homoj."
+        "details": "Tondra Ŝtonego troviĝas en la mezo de dezerto, kaj allogas multajn turistojn. Uzu la spacon disponeblan por konstrui atrakciojn por allogi pli da homoj."
     },
     "rct1.scenario_meta.trinity_islands": {
         "reference-name": "Trinity Islands",
@@ -601,31 +601,31 @@
     },
     "rct1.scenery_wall.playing_card_wall_1": {
         "reference-name": "Playing Card Wall",
-        "name": "Muro el Ludkartoj"
+        "name": "Muro el ludkartoj"
     },
     "rct1.scenery_wall.playing_card_wall_2": {
         "reference-name": "Playing Card Wall",
-        "name": "Muro el Ludkartoj"
+        "name": "Muro el ludkartoj"
     },
     "rct1.scenery_wall.roman_column_wall": {
         "reference-name": "Roman Column Wall",
-        "name": "Muro de Roma Kolono"
+        "name": "Muro de romia kolono"
     },
     "rct1.scenery_wall.wooden_fence_brown": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1.scenery_wall.wooden_fence_brown_gate": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1.scenery_wall.wooden_fence_red": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1.scenery_wall.wooden_fence_white": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1.terrain_edge.brick": {
         "reference-name": "Brick",
@@ -633,39 +633,39 @@
     },
     "rct1.terrain_edge.iron": {
         "reference-name": "Iron",
-        "name": "Fero"
+        "name": "Fera"
     },
     "rct1aa.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Square)",
-        "name": "Trotuaro el Cindropovo (Kvadrata)"
+        "name": "Trotuaro el cindro (kvadrata)"
     },
     "rct1aa.footpath_surface.queue_green": {
         "reference-name": "Green Queue",
-        "name": "Verda Atendovico"
+        "name": "Verda atendovico"
     },
     "rct1aa.footpath_surface.queue_red": {
         "reference-name": "Red Queue (Sloped)",
-        "name": "Ruĝa Atendovico (Dekliva)"
+        "name": "Ruĝa atendovico (dekliva)"
     },
     "rct1aa.footpath_surface.queue_yellow": {
         "reference-name": "Yellow Queue (Sloped)",
-        "name": "Flava Atendovico (Dekliva)"
+        "name": "Flava atendovico (dekliva)"
     },
     "rct1aa.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Sloped)",
-        "name": "Bruna Asfalta Trotuaro (Dekliva)"
+        "name": "Bruna asfalta trotuaro (dekliva)"
     },
     "rct1aa.footpath_surface.tarmac_green": {
         "reference-name": "Green Tarmac Footpath",
-        "name": "Verda Asfalta Trotuaro"
+        "name": "Verda asfalta trotuaro"
     },
     "rct1aa.footpath_surface.tarmac_red": {
         "reference-name": "Red Tarmac Footpath (Sloped)",
-        "name": "Ruĝa Asfalta Trotuaro (Dekliva)"
+        "name": "Ruĝa asfalta trotuaro (dekliva)"
     },
     "rct1aa.footpath_surface.tiles_grey": {
         "reference-name": "Grey Tiled Footpath",
-        "name": "Griza Kahelita Trotuaro"
+        "name": "Griza kahelita trotuaro"
     },
     "rct1aa.ride.bicycles": {
         "reference-name": "Bicycles",
@@ -677,7 +677,7 @@
     },
     "rct1aa.ride.floorless_twister_trains": {
         "reference-name": "Floorless Twister Trains",
-        "name": "Senplankaj Tvisto-Trajnoj",
+        "name": "Senplankaj tvisto-trajnoj",
         "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
         "description": "Grandspaca trajno kun ŝultrobridoj kaj neniu planko, por fariĝi pli ekscita atrakcio",
         "reference-capacity": "4 passengers per car",
@@ -693,7 +693,7 @@
     },
     "rct1aa.ride.ghost_train_cars": {
         "reference-name": "Ghost Train Cars",
-        "name": "Ĉaroj de Fantomo-Trajno",
+        "name": "Ĉaroj de fantomo-trajno",
         "reference-description": "Powered monster-shaped cars that run on a ghost train track",
         "description": "Ŝaltitaj monstroformaj ĉaroj, kiuj veturas sur trako de fantomo-trajno",
         "reference-capacity": "2 passengers per car",
@@ -701,7 +701,7 @@
     },
     "rct1aa.ride.heartline_twister_cars": {
         "reference-name": "Twister Cars",
-        "name": "Tvisto-Ĉaroj",
+        "name": "Tvisto-ĉaroj",
         "reference-description": "Roller coaster cars capable of heartline twists",
         "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn",
         "reference-capacity": "4 passengers per car",
@@ -709,7 +709,7 @@
     },
     "rct1aa.ride.hyper_twister_trains": {
         "reference-name": "Hyper-Twister Trains (wide cars)",
-        "name": "Trajnoj de Hiper-Tvisto (larĝaj ĉaroj)",
+        "name": "Trajnoj de hiper-tvisto (larĝaj ĉaroj)",
         "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
         "description": "Larĝaj ĉaroj kun po 4 seĝoj por vico, pli altaj seĝoj, kaj simplaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -717,7 +717,7 @@
     },
     "rct1aa.ride.lay_down_trains": {
         "reference-name": "Lay-down Roller Coaster Trains",
-        "name": "Trajnoj de Kuŝiĝanta Onda Fervojo",
+        "name": "Trajnoj de kuŝiĝanta onda fervojo",
         "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
         "description": "Rajdantoj kuŝiĝantaj estas tenitaj en specialaj jungaĵoj, kaj veturas aŭ fronte al la ĉielo aŭ fronte al la tero",
         "reference-capacity": "4 passengers per car",
@@ -725,7 +725,7 @@
     },
     "rct1aa.ride.mini_helicopters": {
         "reference-name": "Mini Helicopters",
-        "name": "Miniaturaj Helikopteroj",
+        "name": "Miniaturaj helikopteroj",
         "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
         "description": "Ŝaltitaj helikopteroformaj ĉaroj, kiujn la pedalado de la rajdantoj funkciigas",
         "reference-capacity": "2 passengers per car",
@@ -733,23 +733,23 @@
     },
     "rct1aa.ride.reverser_cars": {
         "reference-name": "Reverser Cars",
-        "name": "Inversiĝantaj Ĉaroj",
+        "name": "Inversiĝantaj ĉaroj",
         "reference-description": "Bogied cars capable of turning around on special reversing sections",
-        "description": "Boĝiĉaroj kapablas je turniĝi ĉirkaŭ specialaj inversigantaj partoj",
+        "description": "Boĝiĉaroj, kapablaj turniĝi ĉirkaŭ sur specialaj inversigantaj sekcioj",
         "reference-capacity": "6 passengers per car",
         "capacity": "Po 6 pasaĝeroj por ĉaro"
     },
     "rct1aa.ride.side_friction_cars": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Ĉaroj de Ligna Onda Fervojo kun Flanka Froto",
+        "name": "Ĉaroj de ligna onda fervojo kun flanka froto",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Bazaj ĉaroj por la Ligna Onda Fervojo kun Flanka Froto",
+        "description": "Bazaj ĉaroj por la ligna onda fervojo kun flanka froto",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct1aa.ride.ski_lift_cars": {
         "reference-name": "Ski-lift Chairs",
-        "name": "Skilifto-Seĝoj",
+        "name": "Skilifto-seĝoj",
         "reference-description": "Open cars for chairlift",
         "description": "Subĉielaj ĉaroj de seĝlifto",
         "reference-capacity": "2 passengers per car",
@@ -757,7 +757,7 @@
     },
     "rct1aa.ride.splash_boats": {
         "reference-name": "Splash Boats",
-        "name": "Plaŭdantaj Boatoj",
+        "name": "Plaŭdantaj boatoj",
         "reference-description": "Large capacity boats, built for water tracks with very steep drops",
         "description": "Grandspacaj boatoj, konstruitaj por akvotrakoj kun tre krutaj faloj",
         "reference-capacity": "16 passengers per boat",
@@ -765,7 +765,7 @@
     },
     "rct1aa.ride.stand_up_twister_trains": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Stariĝantaj Tvisto-Trajnoj",
+        "name": "Stariĝantaj tvisto-trajnoj",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
         "description": "Trajno kun ŝultrobridoj, en kiuj la rajdantoj stariĝas",
         "reference-capacity": "4 passengers per car",
@@ -773,7 +773,7 @@
     },
     "rct1aa.ride.steam_trains_covered": {
         "reference-name": "Steam Trains with Covered Cars",
-        "name": "Vaporlokomotivoj kun Kovritaj Ĉaroj",
+        "name": "Vaporlokomotivoj kun kovritaj ĉaroj",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
         "description": "Miniaturaj lokomotivoj, kiuj konsistas el replikaĵo de lokomotivo kaj tendro, kaj tiras lignajn kaleŝojn kun fabrikaj tegmentoj",
         "reference-capacity": "6 passengers per carriage",
@@ -783,13 +783,13 @@
         "reference-name": "Mouse Cars",
         "name": "Musoĉaroj",
         "reference-description": "Individual cars shaped like mice",
-        "description": "Individualaj ĉaroj formitaj kiel musoj",
+        "description": "Individuaj ĉaroj, formitaj kiel musoj",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct1aa.ride.suspended_monorail_trains": {
         "reference-name": "Suspended Monorail Trains",
-        "name": "Penditaj Monorelaj Trajnoj",
+        "name": "Penditaj monorelaj trajnoj",
         "reference-description": "Large capacity monorail train cars",
         "description": "Grandspacaj monorelaj trajnoĉaroj",
         "reference-capacity": "8 passengers per car",
@@ -797,7 +797,7 @@
     },
     "rct1aa.ride.twister_trains": {
         "reference-name": "Twister Trains",
-        "name": "Tvisto-Trajnoj",
+        "name": "Tvisto-trajnoj",
         "reference-description": "Spacious trains with shoulder restraints",
         "description": "Grandspacaj trajnoj kun ŝultrobridoj",
         "reference-capacity": "4 passengers per car",
@@ -805,7 +805,7 @@
     },
     "rct1aa.ride.vintage_cars": {
         "reference-name": "Vintage Cars",
-        "name": "Malnovaj Aŭtoj",
+        "name": "Malnovaj aŭtoj",
         "reference-description": "Powered vehicles in the shape of vintage cars",
         "description": "Ŝaltitaj veturiloj en la formo de malnovaj aŭtoj",
         "reference-capacity": "2 passengers per car",
@@ -821,7 +821,7 @@
     },
     "rct1aa.ride.wooden_articulated_trains": {
         "reference-name": "Articulated Roller Coaster Trains",
-        "name": "Artikaj Trajnoj de Onda Fervojo",
+        "name": "Artikaj trajnoj de onda fervojo",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
         "description": "Trajnoj de onda fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj subĉielajn frontojn",
         "reference-capacity": "2 passengers per car",
@@ -829,41 +829,41 @@
     },
     "rct1aa.scenario_meta.adrenaline_heights": {
         "reference-name": "Adrenaline Heights",
-        "name": "Adrenalino-Altaĵoj",
+        "name": "Adrenalinaj Altaĵoj",
         "reference-park_name": "Adrenaline Heights",
-        "park_name": "Adrenalino-Altaĵoj",
+        "park_name": "Adrenalinaj Altaĵoj",
         "reference-details": "Build a park to appeal to the high-intensity thrill-seeking local people",
         "details": "Konstruu parkon por allogi lokajn homojn, kiuj volas altajn-intensajn ekscitaĵojn"
     },
     "rct1aa.scenario_meta.barony_bridge": {
         "reference-name": "Barony Bridge",
-        "name": "Baronlando-Ponto",
+        "name": "Baronlanda Ponto",
         "reference-park_name": "Barony Bridge",
-        "park_name": "Baronlando-Ponto",
+        "park_name": "Baronlanda Ponto",
         "reference-details": "An old redundant bridge is yours to develop into an amusement park",
         "details": "Malnova senutila ponto estas via por ellabori en amuzparkon"
     },
     "rct1aa.scenario_meta.butterfly_dam": {
         "reference-name": "Butterfly Dam",
-        "name": "Papilio-Akvobaraĵo",
+        "name": "Papilia Akvobaraĵo",
         "reference-park_name": "Butterfly Dam",
-        "park_name": "Papilio-Akvobaraĵo",
+        "park_name": "Papilia Akvobaraĵo",
         "reference-details": "The area around a dam is available for you to develop into an amusement park",
         "details": "La areo ĉirkaŭ akvobaraĵo estas disponebla, por ke vi ellaboru ĝin en amuzparkon"
     },
     "rct1aa.scenario_meta.canary_mines": {
         "reference-name": "Canary Mines",
-        "name": "Kanario-Minoj",
+        "name": "Kanariaj Minoj",
         "reference-park_name": "Canary Mines",
-        "park_name": "Kanario-Minoj",
+        "park_name": "Kanariaj Minoj",
         "reference-details": "This abandoned mine already has the makings of a tourist attraction with its miniature railway and a pair of vertical drop roller coasters",
         "details": "Ĉi tiu forlasita mino jam havas la potencialon de vidindaĵo, kun ĝia miniatura fervojo kaj paro da ondaj fervojoj kun vertikalaj malleviĝoj"
     },
     "rct1aa.scenario_meta.coaster_canyon": {
         "reference-name": "Coaster Canyon",
-        "name": "Onda-Fervojo-Kanjono",
+        "name": "Kanjono de Ondaj Fervojoj",
         "reference-park_name": "Coaster Canyon",
-        "park_name": "Onda-Fervojo-Kanjono",
+        "park_name": "Kanjono de Ondaj Fervojoj",
         "reference-details": "A vast canyon is yours to turn into a theme park",
         "details": "Vasta kanjono estas via por ŝanĝiĝi al amuzparko"
     },
@@ -877,25 +877,25 @@
     },
     "rct1aa.scenario_meta.fiasco_forest": {
         "reference-name": "Fiasco Forest",
-        "name": "Fiasko-Arbaro",
+        "name": "Fiaska Arbaro",
         "reference-park_name": "Fiasco Forest",
-        "park_name": "Fiasko-Arbaro",
+        "park_name": "Fiaska Arbaro",
         "reference-details": "Full of badly designed and dangerous rides, you have a very limited budget and time to fix the problems and turn the park around",
         "details": "Plene je malbone-desegnitaj kaj danĝeraj atrakcioj, vi havas tre limigitan buĝeton kaj tempon por ripari la problemojn kaj rebonigi la parkon"
     },
     "rct1aa.scenario_meta.fruit_farm": {
         "reference-name": "Fruit Farm",
-        "name": "Frukto-Farmo",
+        "name": "Frukta Farmo",
         "reference-park_name": "Fruit Farm",
-        "park_name": "Frukto-Farmo",
+        "park_name": "Frukta Farmo",
         "reference-details": "A thriving fruit farm has built a railroad to boost its income, your job is to develop it into a full-blown amusement park",
         "details": "Prospera fruktofarmo konstruis fervojon por gajni pli da enspezo. Via celo estas ellabori ĝin en kompletan amuzparkon."
     },
     "rct1aa.scenario_meta.fun_fortress": {
         "reference-name": "Fun Fortress",
-        "name": "Amuza Fortreso",
+        "name": "Amuza Fortikaĵo",
         "reference-park_name": "Fun Fortress",
-        "park_name": "Amuza Fortreso",
+        "park_name": "Amuza Fortikaĵo",
         "reference-details": "This castle is all yours to turn into a theme park",
         "details": "Ĉi tiu fortreso estas tute via por ŝanĝiĝi al amuzparko"
     },
@@ -933,9 +933,9 @@
     },
     "rct1aa.scenario_meta.giggle_downs": {
         "reference-name": "Giggle Downs",
-        "name": "Subrido-Malaltaĵoj",
+        "name": "Subridaj Malaltaĵoj",
         "reference-park_name": "Giggle Downs",
-        "park_name": "Subrido-Malaltaĵoj",
+        "park_name": "Subridaj Malaltaĵoj",
         "reference-details": "A four lane steeplechase ride is the centrepiece of this expanding park",
         "details": "Kvaropa-traka stipoĉejso estas la ĉefaĵo de ĉi tiu ellaborata parko"
     },
@@ -997,11 +997,11 @@
     },
     "rct1aa.scenario_meta.roman_village": {
         "reference-name": "Roman Village",
-        "name": "Romana Vilaĝo",
+        "name": "Romia Vilaĝo",
         "reference-park_name": "Roman Village",
-        "park_name": "Romana Vilaĝo",
+        "park_name": "Romia Vilaĝo",
         "reference-details": "Develop this Roman-themed park by adding rides and roller coasters",
-        "details": "Ellaboru ĉi tiun parkon kun romana temo, per aldoni atrakciojn kaj ondajn fervojojn"
+        "details": "Ellaboru ĉi tiun parkon kun romia temo per aldoni atrakciojn kaj ondajn fervojojn"
     },
     "rct1aa.scenario_meta.rotting_heights": {
         "reference-name": "Rotting Heights",
@@ -1021,25 +1021,25 @@
     },
     "rct1aa.scenario_meta.swamp_cove": {
         "reference-name": "Swamp Cove",
-        "name": "Marĉejo-Golfeto",
+        "name": "Marĉeja Golfeto",
         "reference-park_name": "Swamp Cove",
-        "park_name": "Marĉejo-Golfeto",
+        "park_name": "Marĉeja Golfeto",
         "reference-details": "Built partly on a series of small islands, this park already has a pair of large roller coasters as its centrepiece",
         "details": "Konstruita parte sur serio de malgrandaj insuloj, ĉi tiu parko jam havas paron da grandaj ondaj fervojoj kiel ĝiaj ĉefaĵo"
     },
     "rct1aa.scenario_meta.three_monkeys_park": {
         "reference-name": "Three Monkeys Park",
-        "name": "Tri-Simioj-Parko",
+        "name": "Parko de Tri Simioj",
         "reference-park_name": "Three Monkeys Park",
-        "park_name": "Tri-Simioj-Parko",
+        "park_name": "Parko de Tri Simioj",
         "reference-details": "Central to this large developing park is a giant triple-track racing/duelling steel coaster",
         "details": "La ĉefa atrakcio de ĉi tiu granda ellaborata parko estas giganta triopa-traka vetkuranta ŝtala onda fervojo"
     },
     "rct1aa.scenario_meta.thunderstorm_park": {
         "reference-name": "Thunderstorm Park",
-        "name": "Fulmotondro-Parko",
+        "name": "Fulmotondra Parko",
         "reference-park_name": "Thunderstorm Park",
-        "park_name": "Fulmotondro-Parko",
+        "park_name": "Fulmotondra Parko",
         "reference-details": "The weather is so wet here that a giant pyramid has been built to allow some rides to be built under cover",
         "details": "La vetero estas tiel malseka ĉi tie, ke giganta piramido estis konstruita por permesi kelkajn atrakciojn konstruatajn subtere"
     },
@@ -1053,7 +1053,7 @@
     },
     "rct1aa.scenario_meta.utopia_park": {
         "reference-name": "Utopia Park",
-        "name": "Utopio-Parko",
+        "name": "Utopia Parko",
         "reference-park_name": "Utopia",
         "park_name": "Utopio",
         "reference-details": "An oasis in the middle of the desert provides an unusual opportunity to build an amusement park",
@@ -1069,43 +1069,43 @@
     },
     "rct1aa.scenery_wall.glass_wall": {
         "reference-name": "Glass Wall",
-        "name": "Vitra Muro"
+        "name": "Vitra muro"
     },
     "rct1aa.scenery_wall.wooden_post_wall_1": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "rct1aa.scenery_wall.wooden_post_wall_2": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "rct1aa.terrain_edge.grey": {
         "reference-name": "Stucco (Grey)",
-        "name": "Stukaĵo (Griza)"
+        "name": "Stukaĵa (griza)"
     },
     "rct1aa.terrain_edge.red": {
         "reference-name": "Stucco (Red)",
-        "name": "Stukaĵo (Ruĝa)"
+        "name": "Stukaĵa (ruĝa)"
     },
     "rct1aa.terrain_edge.yellow": {
         "reference-name": "Stucco (Yellow)",
-        "name": "Stukaĵo (Flava)"
+        "name": "Stukaĵa (flava)"
     },
     "rct1aa.terrain_surface.roof_red": {
         "reference-name": "Roof (Red)",
-        "name": "Tegmento (Ruĝa)"
+        "name": "Tegmento (ruĝa)"
     },
     "rct1beta.terrain_edge.brick": {
         "reference-name": "Brick (Brown)",
-        "name": "Brick (Brown)"
+        "name": "Brika (bruna)"
     },
     "rct1beta.terrain_edge.rock": {
         "reference-name": "Rock (Brown)",
-        "name": "Rock (Brown)"
+        "name": "Roka (bruna)"
     },
     "rct1beta.terrain_surface.wildflowers": {
         "reference-name": "Wildflowers",
-        "name": "Wildflowers"
+        "name": "Sovaĝaj floroj"
     },
     "rct1dlc.scenario_meta.bobsled_roller_coaster_competition": {
         "reference-name": "Bobsled Roller Coaster Competition",
@@ -1245,23 +1245,23 @@
     },
     "rct1ll.footpath_railings.bamboo": {
         "reference-name": "Bamboo Railings (Yellow)",
-        "name": "Bambuaj Balustradoj (Flava)"
+        "name": "Bambuaj balustradoj (flavaj)"
     },
     "rct1ll.footpath_railings.space": {
         "reference-name": "Space Style Railings (Grey)",
-        "name": "Kosmo-Stilaj Balustradoj (Griza)"
+        "name": "Kosmo-stilaj balustradoj (grizaj)"
     },
     "rct1ll.footpath_surface.tiles_green": {
         "reference-name": "Green and Brown Tiled Footpath",
-        "name": "Verda kaj Bruna Kahelita Trotuaro"
+        "name": "Verda kaj bruna kahelita trotuaro"
     },
     "rct1ll.footpath_surface.tiles_red": {
         "reference-name": "Red and Brown Tiled Footpath",
-        "name": "Ruĝa kaj Bruna Kahelita Trotuaro"
+        "name": "Ruĝa kaj bruna kahelita trotuaro"
     },
     "rct1ll.ride.4_across_inverted_trains": {
         "reference-name": "4-across Inverted Roller Coaster Trains",
-        "name": "4-horizontalaj Trajnoj de Inversigita Onda Fervojo",
+        "name": "4-horizontalaj trajnoj de inversigita onda fervojo",
         "reference-description": "Suspended trains in which riders sit in rows",
         "description": "Penditaj trajnoj, en kiuj rajdantoj sidas en vicoj",
         "reference-capacity": "4 passengers per car",
@@ -1269,7 +1269,7 @@
     },
     "rct1ll.ride.air_powered_trains": {
         "reference-name": "Air Powered Vertical Coaster Trains",
-        "name": "Trajnoj de Aerofunkciigita Vertikala Onda Fervojo",
+        "name": "Trajnoj de aerofunkciigita vertikala onda fervojo",
         "reference-description": "Air-powered launched roller coaster trains",
         "description": "Trajnoj de onda fervojo lanĉitaj per aero",
         "reference-capacity": "2 passengers per car",
@@ -1277,7 +1277,7 @@
     },
     "rct1ll.ride.coaster_boats": {
         "reference-name": "Coaster Boats",
-        "name": "Boato-Ĉaroj",
+        "name": "Boato-ĉaroj",
         "reference-description": "Boat-shaped roller coaster cars",
         "description": "Boatoformaj ĉaroj de onda fervojo",
         "reference-capacity": "6 passengers per boat",
@@ -1285,7 +1285,7 @@
     },
     "rct1ll.ride.face_off_cars": {
         "reference-name": "Face-off Cars",
-        "name": "Alfrontantaj Aŭtoj",
+        "name": "Alfrontantaj aŭtoj",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
         "description": "Rapidirante tra krutaj inversigoj, rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
         "reference-capacity": "4 passengers per car",
@@ -1293,7 +1293,7 @@
     },
     "rct1ll.ride.hypercoaster_trains": {
         "reference-name": "Hypercoaster Trains",
-        "name": "Trajnoj de Hipergiganta Onda Fervojo",
+        "name": "Trajnoj de hipergiganta onda fervojo",
         "reference-description": "Comfortable trains with only lap bar restraints",
         "description": "Komfortaj trajnoj kun nur sinobridoj",
         "reference-capacity": "6 passengers per car",
@@ -1301,7 +1301,7 @@
     },
     "rct1ll.ride.inverted_hairpin_cars": {
         "reference-name": "Four-seater Cars",
-        "name": "Ĉaroj kun Kvar Seĝoj",
+        "name": "Kvar-seĝaj ĉaroj",
         "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
         "description": "Individuaj ĉaroj de onda fervojo, konstruitaj por trakoj kun harpingloformaj kurboj kaj krutaj malleviĝoj",
         "reference-capacity": "4 passengers per car",
@@ -1309,7 +1309,7 @@
     },
     "rct1ll.ride.jet_skis": {
         "reference-name": "Jet Skis",
-        "name": "Akvo-Motorsledoj",
+        "name": "Akvo-motorsledoj",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
         "description": "Akvo-motorsledoj, kiujn rajdantoj povas stiri per si mem",
         "reference-capacity": "1 rider per vehicle",
@@ -1325,7 +1325,7 @@
     },
     "rct1ll.ride.steam_trains_american": {
         "reference-name": "American Style Steam Trains",
-        "name": "Amerikaj Lokomotivoj",
+        "name": "Amerikaj lokomotivoj",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
         "description": "Miniaturaj lokomotivoj, kiuj konsistas el replikaĵo de lokomotivo kaj tendro, kaj tiras lignajn kaleŝojn kun fabrikaj tegmentoj",
         "reference-capacity": "6 passengers per carriage",
@@ -1357,9 +1357,9 @@
     },
     "rct1ll.scenario_meta.crater_lake": {
         "reference-name": "Crater Lake",
-        "name": "Kratero-Lago",
+        "name": "Kratera Lago",
         "reference-park_name": "Crater Lake",
-        "park_name": "Kratero-Lago",
+        "park_name": "Kratera Lago",
         "reference-details": "A large lake in an ancient crater is the setting for this park",
         "details": "Granda lago en praa kratero estas la okazejo de ĉi tiu parko"
     },
@@ -1429,17 +1429,17 @@
     },
     "rct1ll.scenario_meta.iceberg_islands": {
         "reference-name": "Iceberg Islands",
-        "name": "Glacimonto-Insuloj",
+        "name": "Glacimontaj Insuloj",
         "reference-park_name": "Iceberg Islands",
-        "park_name": "Glacimonto-Insuloj",
+        "park_name": "Glacimontaj Insuloj",
         "reference-details": "A collection of icebergs make a cold setting for this ambitious theme park",
         "details": "Aro da glacimontoj fariĝas malvarma okazejo por ĉi tiu ambicia amuzparko"
     },
     "rct1ll.scenario_meta.icicle_worlds": {
         "reference-name": "Icicle Worlds",
-        "name": "Glacikonuso-Mondoj",
+        "name": "Glacikonusaj Mondoj",
         "reference-park_name": "Icicle Worlds",
-        "park_name": "Glacikonuso-Mondoj",
+        "park_name": "Glacikonusaj Mondoj",
         "reference-details": "An icy landscape needs turning into a thriving theme park",
         "details": "Vi devas ŝanĝi glacian pejzaĝon al prospera amuzparko"
     },
@@ -1485,17 +1485,17 @@
     },
     "rct1ll.scenario_meta.paradise_pier_2": {
         "reference-name": "Paradise Pier 2",
-        "name": "Paradizo-Enŝipigejo 2",
+        "name": "Paradiza Enŝipigejo 2",
         "reference-park_name": "Paradise Pier 2",
-        "park_name": "Paradizo-Enŝipigejo 2",
+        "park_name": "Paradiza Enŝipigejo 2",
         "reference-details": "Paradise Pier has expanded its network of walkways over the sea, and your task is to expand the park to use the extra space",
-        "details": "Paradizo-Enŝipigejo etendis sian reton de troturaroj super la maro, kaj via celo estas ellabori la parkon por uzi la ekstran spacon"
+        "details": "Paradiza Enŝipigejo etendis sian reton de troturaroj super la maro, kaj via celo estas ellabori la parkon por uzi la ekstran spacon"
     },
     "rct1ll.scenario_meta.pleasure_island": {
         "reference-name": "Pleasure Island",
-        "name": "Plezuro-Insulo",
+        "name": "Plezura Insulo",
         "reference-park_name": "Pleasure Island",
-        "park_name": "Plezuro-Insulo",
+        "park_name": "Plezura Insulo",
         "reference-details": "A long thin island makes a challenging setting to build a selection of coasters",
         "details": "Longa mallarĝa insulo fariĝas defia okazejo por konstrui elektaron da ondaj fervojoj"
     },
@@ -1533,9 +1533,9 @@
     },
     "rct1ll.scenario_meta.thunder_rocks": {
         "reference-name": "Thunder Rocks",
-        "name": "Tondro-Rokoj",
+        "name": "Tondraj Rokoj",
         "reference-park_name": "Thunder Rocks",
-        "park_name": "Tondro-Rokoj",
+        "park_name": "Tondraj Rokoj",
         "reference-details": "Two large hunks of rock stick out of the sand, upon which the beginnings of a theme park are constructed",
         "details": "La komenco de ĉi tiu amuzparko estas sur du grandaj eroj da ŝtonego, kiuj elstaras el la sablo"
     },
@@ -1557,9 +1557,9 @@
     },
     "rct1ll.scenario_meta.venus_ponds": {
         "reference-name": "Venus Ponds",
-        "name": "Venuso-Lagetoj",
+        "name": "Venusaj Lagetoj",
         "reference-park_name": "Venus Ponds",
-        "park_name": "Venuso-Lagetoj",
+        "park_name": "Venusaj Lagetoj",
         "reference-details": "On a far-away planet this area of land needs turning into a theme park",
         "details": "Sur malproksima planedo, vi bezonas ŝanĝi ĉi tiun bienoareon al amuzparko"
     },
@@ -1597,19 +1597,19 @@
     },
     "rct1ll.scenery_wall.medieval_wooden_fence": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1ll.scenery_wall.wooden_fence_brown_snow": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct1ll.terrain_edge.green": {
         "reference-name": "Stucco (Green)",
-        "name": "Stukaĵo (Verda)"
+        "name": "Stukaĵa (verda)"
     },
     "rct1ll.terrain_edge.purple": {
         "reference-name": "Stucco (Purple)",
-        "name": "Stukaĵo (Purpura)"
+        "name": "Stukaĵa (purpura)"
     },
     "rct1ll.terrain_edge.skyscraper_a": {
         "reference-name": "Skyscraper (A)",
@@ -1621,15 +1621,15 @@
     },
     "rct1ll.terrain_edge.stone_brown": {
         "reference-name": "Sandstone (Brown)",
-        "name": "Sabloŝtono (Bruna)"
+        "name": "Sabloŝtona (bruna)"
     },
     "rct1ll.terrain_edge.stone_grey": {
         "reference-name": "Sandstone (Grey)",
-        "name": "Sabloŝtono (Griza)"
+        "name": "Sabloŝtona (griza)"
     },
     "rct1ll.terrain_surface.roof_grey": {
         "reference-name": "Roof (Grey)",
-        "name": "Tegmento (Griza)"
+        "name": "Tegmento (griza)"
     },
     "rct1ll.terrain_surface.rust": {
         "reference-name": "Rust",
@@ -1657,7 +1657,7 @@
     },
     "rct2.audio.circus": {
         "reference-name": "Ambient sound effects for the Circus attraction.",
-        "name": "Mediaj sonefikoj por la Cirko-atrakcio."
+        "name": "Mediaj sonefikoj por la atrakcio Cirko."
     },
     "rct2.audio.title": {
         "reference-name": "Title screen music for RollerCoaster Tycoon 2.",
@@ -1685,35 +1685,35 @@
     },
     "rct2.footpath_banner.bn2": {
         "reference-name": "Jungle Style Sign",
-        "name": "Afiŝo de Ĝangalo-Stilo"
+        "name": "Ĝangalo-stila afiŝo"
     },
     "rct2.footpath_banner.bn3": {
         "reference-name": "Classical Style Sign",
-        "name": "Afiŝo de Klasika Stilo"
+        "name": "Klasika-stila afiŝo"
     },
     "rct2.footpath_banner.bn4": {
         "reference-name": "Egyptian Style Sign",
-        "name": "Afiŝo de Egipta Stilo"
+        "name": "Egipto-stila afiŝo"
     },
     "rct2.footpath_banner.bn5": {
         "reference-name": "Wooden Sign",
-        "name": "Ligna Afiŝo"
+        "name": "Ligna afiŝo"
     },
     "rct2.footpath_banner.bn6": {
         "reference-name": "Jurassic Style Sign",
-        "name": "Afiŝo de Ĵurasa Stilo"
+        "name": "Ĵurasa-stila afiŝo"
     },
     "rct2.footpath_banner.bn7": {
         "reference-name": "Pagoda Style Sign",
-        "name": "Afiŝo de Pagodo-Stilo"
+        "name": "Pagodo-stila afiŝo"
     },
     "rct2.footpath_banner.bn8": {
         "reference-name": "Snow Covered Sign",
-        "name": "Neĝkovrita Afiŝo"
+        "name": "Neĝkovrita afiŝo"
     },
     "rct2.footpath_banner.bn9": {
         "reference-name": "Space Style Sign",
-        "name": "Afiŝo de Kosma Stilo"
+        "name": "Kosmo-stila afiŝo"
     },
     "rct2.footpath_item.bench1": {
         "reference-name": "Bench",
@@ -1733,15 +1733,15 @@
     },
     "rct2.footpath_item.benchstn": {
         "reference-name": "Stone Bench",
-        "name": "Ŝtona Benko"
+        "name": "Ŝtona benko"
     },
     "rct2.footpath_item.jumpfnt1": {
         "reference-name": "Jumping Fountains",
-        "name": "Saltantaj Fontanoj"
+        "name": "Saltantaj fontanoj"
     },
     "rct2.footpath_item.jumpsnw1": {
         "reference-name": "Jumping Snowballs",
-        "name": "Saltantaj Neĝbuloj"
+        "name": "Saltantaj neĝbuloj"
     },
     "rct2.footpath_item.lamp1": {
         "reference-name": "Lamp",
@@ -1761,7 +1761,7 @@
     },
     "rct2.footpath_item.lampdsy": {
         "reference-name": "Daisy Lamp",
-        "name": "Leŭkanta Lampo"
+        "name": "Leŭkanta lampo"
     },
     "rct2.footpath_item.lamppir": {
         "reference-name": "Lamp",
@@ -1785,59 +1785,59 @@
     },
     "rct2.footpath_item.qtv1": {
         "reference-name": "Queue Line TV",
-        "name": "Televizio de Atendovico"
+        "name": "Televizio de atendovico"
     },
     "rct2.footpath_railings.bamboo_black": {
         "reference-name": "Bamboo Railings (Black)",
-        "name": "Bambuaj Balustradoj (Nigra)"
+        "name": "Bambuaj balustradoj (nigraj)"
     },
     "rct2.footpath_railings.bamboo_brown": {
         "reference-name": "Bamboo Railings (Brown)",
-        "name": "Bambuaj Balustradoj (Bruna)"
+        "name": "Bambuaj balustradoj (brunaj)"
     },
     "rct2.footpath_railings.concrete": {
         "reference-name": "Concrete Railings (Grey-Brown)",
-        "name": "Betonaj Balustradoj (Griza-Bruna)"
+        "name": "Betonaj balustradoj (griza-brunaj)"
     },
     "rct2.footpath_railings.concrete_green": {
         "reference-name": "Concrete Railings (Dark Green)",
-        "name": "Betonaj Balustradoj (Malhela Verda)"
+        "name": "Betonaj balustradoj (malhela-verdaj)"
     },
     "rct2.footpath_railings.space": {
         "reference-name": "Space Style Railings (Red)",
-        "name": "Kosmo-Stilaj Balustradoj (Ruĝa)"
+        "name": "Kosmo-stilaj balustradoj (ruĝaj)"
     },
     "rct2.footpath_railings.wood": {
         "reference-name": "Wooden Railings",
-        "name": "Lignaj Balustradoj"
+        "name": "Lignaj balustradoj"
     },
     "rct2.footpath_surface.ash": {
         "reference-name": "Ash Footpath (Rounded)",
-        "name": "Trotuaro el Cindropovo (Rondigita)"
+        "name": "Trotuaro el cindro (rondigita)"
     },
     "rct2.footpath_surface.crazy_paving": {
         "reference-name": "Crazy Paving Footpath (Stairs)",
-        "name": "Freneza-Pavima Trotuaro (Ŝtuparo)"
+        "name": "Freneza-pavima trotuaro (ŝtuparo)"
     },
     "rct2.footpath_surface.dirt": {
         "reference-name": "Dirt Footpath (Rounded)",
-        "name": "Tera Trotuaro (Rondigita)"
+        "name": "Tera trotuaro (rondigita)"
     },
     "rct2.footpath_surface.queue_blue": {
         "reference-name": "Blue Queue (Stairs)",
-        "name": "Blua Atendovico (Ŝtuparo)"
+        "name": "Blua atendovico (ŝtuparo)"
     },
     "rct2.footpath_surface.queue_green": {
         "reference-name": "Dark Green Queue",
-        "name": "Malhela Verda Atendovico"
+        "name": "Malhela verda atendovico"
     },
     "rct2.footpath_surface.queue_red": {
         "reference-name": "Red Queue (Stairs)",
-        "name": "Ruĝa Atendovico (Ŝtuparo)"
+        "name": "Ruĝa atendovico (ŝtuparo)"
     },
     "rct2.footpath_surface.queue_yellow": {
         "reference-name": "Yellow Queue (Stairs)",
-        "name": "Flava Atendovico (Ŝtuparo)"
+        "name": "Flava atendovico (ŝtuparo)"
     },
     "rct2.footpath_surface.road": {
         "reference-name": "Road",
@@ -1845,19 +1845,19 @@
     },
     "rct2.footpath_surface.tarmac": {
         "reference-name": "Tarmac Footpath (Stairs)",
-        "name": "Asfalta Trotuaro (Ŝtuparo)"
+        "name": "Asfalta trotuaro (ŝtuparo)"
     },
     "rct2.footpath_surface.tarmac_brown": {
         "reference-name": "Brown Tarmac Footpath (Stairs)",
-        "name": "Bruna Asfalta Trotuaro (Ŝtuparo)"
+        "name": "Bruna asfalta trotuaro (ŝtuparo)"
     },
     "rct2.footpath_surface.tarmac_green": {
         "reference-name": "Dark Green Tarmac Footpath",
-        "name": "Malhela Verda Asfalta Trotuaro"
+        "name": "Malhela verda asfalta trotuaro"
     },
     "rct2.footpath_surface.tarmac_red": {
         "reference-name": "Red Tarmac Footpath (Stairs)",
-        "name": "Ruĝa Asfalta Trotuaro (Ŝtuparo)"
+        "name": "Ruĝa asfalta trotuaro (ŝtuparo)"
     },
     "rct2.music.candy": {
         "reference-name": "Candy style",
@@ -1873,7 +1873,7 @@
     },
     "rct2.music.dodgems": {
         "reference-name": "Dodgems beat style",
-        "name": "Muzikstilo de Doĝemoj-trako"
+        "name": "Muzikstilo de kunfrapemaj aŭtetoj"
     },
     "rct2.music.egyptian": {
         "reference-name": "Egyptian style",
@@ -1973,7 +1973,7 @@
     },
     "rct2.music.toyland": {
         "reference-name": "Toyland style",
-        "name": "Ludilejo-stilo"
+        "name": "Ludlanda stilo"
     },
     "rct2.music.urban": {
         "reference-name": "Urban style",
@@ -1989,15 +1989,15 @@
     },
     "rct2.park_entrance.pkemm": {
         "reference-name": "Park Entrance Gates",
-        "name": "Pasejo de Parkenirejo"
+        "name": "Pasejo de parkenirejo"
     },
     "rct2.park_entrance.pkent1": {
         "reference-name": "Traditional Park Entrance",
-        "name": "Tradicia Parkenirejo"
+        "name": "Tradicia parkenirejo"
     },
     "rct2.park_entrance.pkesfh": {
         "reference-name": "Park Entrance Building",
-        "name": "Konstruaĵo de Parkenirejo"
+        "name": "Konstruaĵo de parkenirejo"
     },
     "rct2.peep_animations.entertainer_astronaut": {
         "reference-name": "Astronaut costume",
@@ -2061,11 +2061,11 @@
     },
     "rct2.peep_names.original": {
         "reference-name": "Original peep names",
-        "name": "Original peep names"
+        "name": "Originalaj nomoj de homoj"
     },
     "rct2.ride.4x4": {
         "reference-name": "Monster Trucks",
-        "name": "Monstro-Kamionoj",
+        "name": "Monstro-kamionoj",
         "reference-description": "Powered giant 4 x 4 trucks which can climb steep slopes",
         "description": "Ŝaltitaj gigantaj 4 × 4 kamionoj, kiuj povas grimpi krutajn montetojn",
         "reference-capacity": "2 passengers per truck",
@@ -2073,7 +2073,7 @@
     },
     "rct2.ride.aml1": {
         "reference-name": "American Style Steam Trains",
-        "name": "Amerikaj Lokomotivoj",
+        "name": "Amerikaj lokomotivoj",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
         "description": "Miniaturaj lokomotivoj, kiuj konsistas el replikaĵo de lokomotivo kaj tendro, kaj tiras lignajn kaleŝojn kun fabrikaj tegmentoj",
         "reference-capacity": "6 passengers per carriage",
@@ -2089,7 +2089,7 @@
     },
     "rct2.ride.arrsw1": {
         "reference-name": "Suspended Swinging Cars",
-        "name": "Penditaj Svingiĝantaj Ĉaroj",
+        "name": "Penditaj svingiĝantaj ĉaroj",
         "reference-description": "Suspended roller coaster trains consisting of cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "4 passengers per car",
@@ -2097,7 +2097,7 @@
     },
     "rct2.ride.arrsw2": {
         "reference-name": "Suspended Swinging Aeroplane Cars",
-        "name": "Penditaj Svingiĝantaj Aeroplano-Ĉaroj",
+        "name": "Penditaj svingiĝantaj aeroplano-ĉaroj",
         "reference-description": "Suspended roller coaster trains consisting of aeroplane-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el aeroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "4 passengers per car",
@@ -2105,7 +2105,7 @@
     },
     "rct2.ride.arrt1": {
         "reference-name": "Corkscrew Roller Coaster Trains",
-        "name": "Trajnoj de Korktirila Onda Fervojo",
+        "name": "Trajnoj de korktirila onda fervojo",
         "reference-description": "Roller coaster trains with shoulder restraints",
         "description": "Trajnoj de onda fervojo kun ŝultrobridoj",
         "reference-capacity": "4 passengers per car",
@@ -2113,7 +2113,7 @@
     },
     "rct2.ride.arrt2": {
         "reference-name": "Hypercoaster Trains",
-        "name": "Trajnoj de Hipergiganta Onda Fervojo",
+        "name": "Trajnoj de hipergiganta onda fervojo",
         "reference-description": "Comfortable trains with only lap bar restraints",
         "description": "Komfortaj trajnoj kun nur sinobridoj",
         "reference-capacity": "6 passengers per car",
@@ -2121,7 +2121,7 @@
     },
     "rct2.ride.arrx": {
         "reference-name": "Multi-Dimension Coaster Trains",
-        "name": "Multidimensionaj Trajnoj de Onda Fervojo",
+        "name": "Multidimensionaj trajnoj de onda fervojo",
         "reference-description": "Cars with seats capable of pitching the riders head-over-heels",
         "description": "Ĉaroj kun seĝoj, kiuj kapablas renversigi la rajdantojn",
         "reference-capacity": "4 passengers per car",
@@ -2141,7 +2141,7 @@
     },
     "rct2.ride.batfl": {
         "reference-name": "Swinging Cars",
-        "name": "Svingiĝantaj Ĉaroj",
+        "name": "Svingiĝantaj ĉaroj",
         "reference-description": "Small cars which swing from the rail above",
         "description": "Malgrandaj ĉaroj, kiuj svingiĝas sub la relo supere",
         "reference-capacity": "2 passengers per car",
@@ -2149,7 +2149,7 @@
     },
     "rct2.ride.bboat": {
         "reference-name": "Bumper Boats",
-        "name": "Doĝemo-Boatoj",
+        "name": "Kunfrapemaj boatoj",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Malgrandaj rondaj boatetoj ŝaltitaj per centra motoro, kiun la pasaĝeroj funkciigas",
         "reference-capacity": "2 passengers per boat",
@@ -2157,7 +2157,7 @@
     },
     "rct2.ride.bmair": {
         "reference-name": "Flying Roller Coaster Trains",
-        "name": "Trajnoj de Fluganta Onda Fervojo",
+        "name": "Trajnoj de fluganta onda fervojo",
         "reference-description": "Riders are held in comfortable seats below the track to give the ultimate flying experience",
         "description": "Rajdantoj estas tenitaj en komfortaj seĝoj sub la trako por havi la plej bonan sperton de flugado",
         "reference-capacity": "4 passengers per car",
@@ -2165,7 +2165,7 @@
     },
     "rct2.ride.bmfl": {
         "reference-name": "Floorless Twister Trains",
-        "name": "Senplankaj Tvisto-Trajnoj",
+        "name": "Senplankaj tvisto-trajnoj",
         "reference-description": "A spacious train with shoulder restraints and no floor, making for a more exciting ride",
         "description": "Grandspaca trajno kun ŝultrobridoj kaj neniu planko, por fariĝi pli ekscita atrakcio",
         "reference-capacity": "4 passengers per car",
@@ -2173,7 +2173,7 @@
     },
     "rct2.ride.bmrb": {
         "reference-name": "Hyper-Twister Trains (wide cars)",
-        "name": "Trajnoj de Hiper-Tvisto (larĝaj ĉaroj)",
+        "name": "Trajnoj de hiper-tvisto (larĝaj ĉaroj)",
         "reference-description": "Wide 4-across cars with raised seating and simple lap restraints",
         "description": "Larĝaj ĉaroj kun po 4 seĝoj por vico, pli altaj seĝoj, kaj simplaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -2181,7 +2181,7 @@
     },
     "rct2.ride.bmsd": {
         "reference-name": "Twister Trains",
-        "name": "Tvisto-Trajnoj",
+        "name": "Tvisto-trajnoj",
         "reference-description": "Spacious trains with shoulder restraints",
         "description": "Grandspacaj trajnoj kun ŝultrobridoj",
         "reference-capacity": "4 passengers per car",
@@ -2189,7 +2189,7 @@
     },
     "rct2.ride.bmsu": {
         "reference-name": "Stand-up Twister Trains",
-        "name": "Stariĝantaj Tvisto-Trajnoj",
+        "name": "Stariĝantaj tvisto-trajnoj",
         "reference-description": "A train with shoulder restraints, in which the riders stand up",
         "description": "Trajno kun ŝultrobridoj, en kiuj la rajdantoj stariĝas",
         "reference-capacity": "4 passengers per car",
@@ -2197,7 +2197,7 @@
     },
     "rct2.ride.bmvd": {
         "reference-name": "Six-seater Twister Trains",
-        "name": "Tvisto-Trajnoj kun Ses Seĝoj",
+        "name": "Tvisto-trajnoj kun ses seĝoj",
         "reference-description": "Roller coaster trains with extra-wide cars, built for vertical drops",
         "description": "Trajnoj de onda fervojo kun ekstra-larĝaj ĉaroj, konstruitaj por vertikalaj faloj",
         "reference-capacity": "6 passengers per car",
@@ -2205,13 +2205,13 @@
     },
     "rct2.ride.bnoodles": {
         "reference-name": "Beef Noodles Stall",
-        "name": "Bovaĵaj-Nudeloj-Budo",
+        "name": "Bovaĵnudela budo",
         "reference-description": "A stall selling Chinese style beef noodles",
         "description": "Budo vendanta Ĉina-stilajn bovaĵajn nudelojn"
     },
     "rct2.ride.bob1": {
         "reference-name": "Bobsleigh Trains",
-        "name": "Bobsledo-Trajnoj",
+        "name": "Bobsledaj trajnoj",
         "reference-description": "Trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Trajnoj, konsistaj de ĉaroj kun 2 seĝoj, kie la rajdantoj estas malantaŭ unu la alian",
         "reference-capacity": "2 passengers per car",
@@ -2225,9 +2225,9 @@
     },
     "rct2.ride.c3d": {
         "reference-name": "3D Cinema",
-        "name": "3D Kinejo",
+        "name": "3D-kinejo",
         "reference-description": "Cinema showing 3D films inside a geodesic sphere shaped building",
-        "description": "Kinejo, kiu montras 3D-ajn filmojn en geodezikoforma konstruaĵo",
+        "description": "Kinejo, kiu montras tridimensiajn filmojn en geodezikoforma konstruaĵo",
         "reference-capacity": "20 guests",
         "capacity": "20 gastoj"
     },
@@ -2241,7 +2241,7 @@
     },
     "rct2.ride.chbuild": {
         "reference-name": "Crooked House",
-        "name": "Malrekta Domo",
+        "name": "Malrekta domo",
         "reference-description": "Building containing warped rooms and angled corridors to disorientate people walking through it",
         "description": "Konstruaĵo, kiu enhavas ĉambrojn torditajn kaj koridorojn angulajn por malorienti homojn tie",
         "reference-capacity": "5 guests",
@@ -2249,13 +2249,13 @@
     },
     "rct2.ride.chcks": {
         "reference-name": "Fried Chicken Stall",
-        "name": "Fritita-Kokaĵo-Budo",
+        "name": "Budo de fritita kokaĵo",
         "reference-description": "A stall selling tubs of fried chicken",
         "description": "Budo vendanta ujojn da fritita kokaĵo"
     },
     "rct2.ride.chknug": {
         "reference-name": "Chicken Nuggets Stall",
-        "name": "Nugetoj-el-Kokaĵo-Budo",
+        "name": "Budo de kokaĵaj nugetoj",
         "reference-description": "A stall selling fried chicken nuggets",
         "description": "Budo vendanta frititajn nugetojn el kokaĵo"
     },
@@ -2267,7 +2267,7 @@
     },
     "rct2.ride.chpsh2": {
         "reference-name": "Chips Stall",
-        "name": "Fritoj-Budo",
+        "name": "Fritobudo",
         "reference-description": "A stall selling chips",
         "description": "Budo vendanta fritojn"
     },
@@ -2287,7 +2287,7 @@
     },
     "rct2.ride.clift1": {
         "reference-name": "Chairlift Cars",
-        "name": "Ĉaroj de Seĝlifto",
+        "name": "Ĉaroj de seĝlifto",
         "reference-description": "Open cars for chairlift",
         "description": "Subĉielaj ĉaroj de seĝlifto",
         "reference-capacity": "2 passengers per car",
@@ -2295,7 +2295,7 @@
     },
     "rct2.ride.clift2": {
         "reference-name": "Ski-lift Chairs",
-        "name": "Skilifto-Seĝoj",
+        "name": "Skilifto-seĝoj",
         "reference-description": "Open cars for chairlift",
         "description": "Subĉielaj ĉaroj de seĝlifto",
         "reference-capacity": "2 passengers per car",
@@ -2321,7 +2321,7 @@
     },
     "rct2.ride.cstboat": {
         "reference-name": "Coaster Boats",
-        "name": "Boato-Ĉaroj",
+        "name": "Boato-ĉaroj",
         "reference-description": "Boat-shaped roller coaster cars",
         "description": "Boatoformaj ĉaroj de onda fervojo",
         "reference-capacity": "6 passengers per boat",
@@ -2329,7 +2329,7 @@
     },
     "rct2.ride.ctcar": {
         "reference-name": "Cheshire Cats",
-        "name": "Ĉeŝiraj Katoj",
+        "name": "Ĉeŝiraj katoj",
         "reference-description": "Powered cat-shaped vehicles",
         "description": "Ŝaltitaj katformaj veturiloj",
         "reference-capacity": "2 passengers per cat",
@@ -2345,9 +2345,9 @@
     },
     "rct2.ride.dodg1": {
         "reference-name": "Dodgems",
-        "name": "Doĝemoj",
+        "name": "Kunfrapemaj aŭtetoj",
         "reference-description": "Riders bump into each other in self-drive electric dodgems",
-        "description": "Rajdantoj albatiĝas al unu la alian per elektraj doĝemoj",
+        "description": "Rajdantoj albatiĝas al unu la alian per elektraj aŭtetoj",
         "reference-capacity": "1 person per car",
         "capacity": "Po 1 ulo por ĉaro"
     },
@@ -2359,7 +2359,7 @@
     },
     "rct2.ride.drnks": {
         "reference-name": "Drinks Stall",
-        "name": "Trinkaĵoj-Budo",
+        "name": "Trinkaĵobudo",
         "reference-description": "A can-shaped stall selling fizzy drinks",
         "description": "Ladskatolo-forma budo vendanta refreŝigaĵojn"
     },
@@ -2379,7 +2379,7 @@
     },
     "rct2.ride.frnood": {
         "reference-name": "Fried Rice Noodles Stall",
-        "name": "Frititaj-Riznudeloj-Budo",
+        "name": "Budo de frititaj riznudeloj",
         "reference-description": "A stall selling Chinese style fried rice noodles",
         "description": "Budo vendanta Ĉina-stilajn frititajn riznudelojn"
     },
@@ -2393,7 +2393,7 @@
     },
     "rct2.ride.funcake": {
         "reference-name": "Funnel Cake Shop",
-        "name": "Funelkuko-Butiko",
+        "name": "Funelkuko-butiko",
         "reference-description": "A stall selling funnel cakes",
         "description": "Budo vendanta funelkukojn"
     },
@@ -2407,7 +2407,7 @@
     },
     "rct2.ride.gdrop1": {
         "reference-name": "Roto-Drop",
-        "name": "Turno-Falo",
+        "name": "Turno-falo",
         "reference-description": "A ring of seats is pulled to the top of a tall tower while gently rotating, then allowed to free-fall down, stopping gently at the bottom using magnetic brakes",
         "description": "Ringo da seĝoj, milde turniĝante, estas tirata al la supro de alta turo. Tiam, la ringo falas libere, kaj haltas milde al la malsupro per magnetaj bremsoj.",
         "reference-capacity": "16 passengers",
@@ -2415,7 +2415,7 @@
     },
     "rct2.ride.golf1": {
         "reference-name": "Mini Golf",
-        "name": "Miniatura Golfo",
+        "name": "Miniatura golfo",
         "reference-description": "A gentle game of miniature golf",
         "description": "Milda ludo de miniatura golfo",
         "reference-capacity": "",
@@ -2423,7 +2423,7 @@
     },
     "rct2.ride.goltr": {
         "reference-name": "Hyper-Twister Trains",
-        "name": "Trajnoj de Hiper-Tvisto",
+        "name": "Trajnoj de hiper-tvisto",
         "reference-description": "Spacious trains with simple lap restraints",
         "description": "Grandspacaj trajnoj kun simplaj sinobridoj",
         "reference-capacity": "6 passengers per car",
@@ -2431,7 +2431,7 @@
     },
     "rct2.ride.gtc": {
         "reference-name": "Ghost Train Cars",
-        "name": "Ĉaroj de Fantomo-Trajno",
+        "name": "Ĉaroj de fantomo-trajno",
         "reference-description": "Powered monster-shaped cars that run on a ghost train track",
         "description": "Ŝaltitaj monstroformaj ĉaroj, kiuj veturas sur trako de fantomo-trajno",
         "reference-capacity": "2 passengers per car",
@@ -2445,13 +2445,13 @@
     },
     "rct2.ride.hchoc": {
         "reference-name": "Hot Chocolate Stall",
-        "name": "Varma-Ĉokolado-Budo",
+        "name": "Budo de varma ĉokolado",
         "reference-description": "A stall selling hot chocolate drinks",
         "description": "Budo vendanta varmĉokolado-trinkaĵojn"
     },
     "rct2.ride.helicar": {
         "reference-name": "Mini Helicopters",
-        "name": "Miniaturaj Helikopteroj",
+        "name": "Miniaturaj helikopteroj",
         "reference-description": "Powered helicopter-shaped cars, controlled by the pedalling of the riders",
         "description": "Ŝaltitaj helikopteroformaj ĉaroj, kiujn la pedalado de la rajdantoj funkciigas",
         "reference-capacity": "2 passengers per car",
@@ -2459,7 +2459,7 @@
     },
     "rct2.ride.hhbuild": {
         "reference-name": "Haunted House",
-        "name": "Fantomita Domo",
+        "name": "Fantomita domo",
         "reference-description": "Large themed building containing scary corridors and spooky rooms",
         "description": "Granda temita konstruaĵo, kiu enhavas timigajn koridorojn, kaj timigetajn ĉambrojn",
         "reference-capacity": "15 guests",
@@ -2473,7 +2473,7 @@
     },
     "rct2.ride.hmcar": {
         "reference-name": "Haunted Mansion Cars",
-        "name": "Ĉaroj de Fantomita Dormego",
+        "name": "Ĉaroj de fantomita dormego",
         "reference-description": "Small powered cars that run on a ghost train track",
         "description": "Malgrandaj ŝaltitaj ĉaroj, kiuj veturas sur trako de fantomita trajno",
         "reference-capacity": "2 passengers per car",
@@ -2481,13 +2481,13 @@
     },
     "rct2.ride.hotds": {
         "reference-name": "Hot Dog Stall",
-        "name": "Kolbasobulko-Budo",
+        "name": "Kolbasobulko-budo",
         "reference-description": "A stall selling hot dogs in rolls",
         "description": "Budo vendanta kolbasojn en bulkoj"
     },
     "rct2.ride.hskelt": {
         "reference-name": "Spiral Slide",
-        "name": "Spirala Glitejo",
+        "name": "Spirala glitejo",
         "reference-description": "Wooden building with an internal staircase and an external spiral slide for use with slide mats",
         "description": "Ligna konstruaĵo kun interna ŝtuparo kaj ekstera spirala glitejo por uzi kun glitmatoj",
         "reference-capacity": "1 person at a time",
@@ -2495,19 +2495,19 @@
     },
     "rct2.ride.icecr1": {
         "reference-name": "Fruity Ices Stall",
-        "name": "Frukto-Glaciaĵobudo",
+        "name": "Frukto-glaciaĵobudo",
         "reference-description": "A themed stall selling fruity ice creams",
         "description": "Temita budo vendanta frukto-glaciaĵojn"
     },
     "rct2.ride.icecr2": {
         "reference-name": "Ice Cream Cone Stall",
-        "name": "Glaciaĵo-Konuso-Budo",
+        "name": "Glaciaĵo-konuso-budo",
         "reference-description": "A stall selling ice cream cones",
         "description": "Budo vendanta glaciaĵo-konusojn"
     },
     "rct2.ride.icetst": {
         "reference-name": "Iced Tea Stall",
-        "name": "Glacia-Teo-Budo",
+        "name": "Glacia-teo-budo",
         "reference-description": "A stall selling iced tea drinks",
         "description": "Budo vendanta glacia-teo-trinkaĵojn"
     },
@@ -2519,7 +2519,7 @@
     },
     "rct2.ride.intbob": {
         "reference-name": "6-seater Bobsleighs",
-        "name": "Bobsledoj kun 6 seĝoj",
+        "name": "6-seĝaj bobsledoj",
         "reference-description": "Bobsleighs with three seating rows, with room for two people on each",
         "description": "Bobsledoj kun tri vicoj, kie ĉiu vico havas spacon por du uloj",
         "reference-capacity": "6 passengers per car",
@@ -2527,23 +2527,23 @@
     },
     "rct2.ride.intinv": {
         "reference-name": "Impulse Trains",
-        "name": "Lanĉitaj Trajnoj",
+        "name": "Lanĉitaj trajnoj",
         "reference-description": "Inverted roller coaster trains for the Inverted Impulse Coaster",
-        "description": "Inversigitaj trajnoj de onda fervojo por la Inversigita Lanĉita Onda Fervojo",
+        "description": "Inversigitaj trajnoj de onda fervojo por la inversigita lanĉita onda fervojo",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2.ride.intst": {
         "reference-name": "Giga Coaster Trains",
-        "name": "Trajnoj de Altega Onda Fervojo",
+        "name": "Trajnoj de altega onda fervojo",
         "reference-description": "Roller coaster trains for the Giga Coaster, capable of smooth drops",
-        "description": "Trajnoj de onda fervojo por la Altega Onda Fervojo, kapabla je glataj malleviĝoj",
+        "description": "Trajnoj de onda fervojo por la altega onda fervojo, kapabla je glataj malleviĝoj",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2.ride.ivmc1": {
         "reference-name": "Four-seater Cars",
-        "name": "Ĉaroj kun Kvar Seĝoj",
+        "name": "Kvar-seĝaj ĉaroj",
         "reference-description": "Individual roller coaster cars built for tracks with hairpin turns and sharp drops",
         "description": "Individuaj ĉaroj de onda fervojo, konstruitaj por trakoj kun harpingloformaj kurboj kaj krutaj malleviĝoj",
         "reference-capacity": "4 passengers per car",
@@ -2551,7 +2551,7 @@
     },
     "rct2.ride.jski": {
         "reference-name": "Jet Skis",
-        "name": "Akvo-Motorsledoj",
+        "name": "Akvo-motorsledoj",
         "reference-description": "Single-seater jet skis which riders can drive themselves",
         "description": "Akvo-motorsledoj, kiujn rajdantoj povas stiri per si mem",
         "reference-capacity": "1 rider per vehicle",
@@ -2559,7 +2559,7 @@
     },
     "rct2.ride.jstar1": {
         "reference-name": "Toboggan Cars",
-        "name": "Sledo-Ĉaroj",
+        "name": "Sledo-ĉaroj",
         "reference-description": "Toboggan-shaped roller coaster cars with in-line seating",
         "description": "Sledformaj ĉaroj de onda fervojo kun kolono da seĝoj",
         "reference-capacity": "4 passengers per car",
@@ -2567,9 +2567,9 @@
     },
     "rct2.ride.kart1": {
         "reference-name": "Go-Karts",
-        "name": "Gokartoj",
+        "name": "Vetkuraj aŭtetoj",
         "reference-description": "Self-drive petrol-engined go-karts",
-        "description": "Gokartoj kun benzinmotoroj, kiujn pasaĝeroj stiras per si mem",
+        "description": "Aŭtetoj kun benzinmotoroj, kiujn pasaĝeroj stiras per si mem",
         "reference-capacity": "single-seater",
         "capacity": "Po 1 pasaĝero por aŭto"
     },
@@ -2597,13 +2597,13 @@
     },
     "rct2.ride.mbsoup": {
         "reference-name": "Meatball Soup Stall",
-        "name": "Knela-Supobudo",
+        "name": "Knela-supobudo",
         "reference-description": "A stall selling Chinese style meatball soup",
         "description": "Budo vendanta Ĉina-stilan knela-supon"
     },
     "rct2.ride.mcarpet1": {
         "reference-name": "Magic Carpet",
-        "name": "Magia Tapiŝo",
+        "name": "Magia tapiŝo",
         "reference-description": "A large flying-carpet themed car which moves up and down cyclically on the ends of 4 arms",
         "description": "Granda ĉaro kun temo de fluganta tapiŝo, kiu movas cikle supren kaj malsupren al la finoj de 4 brakoj",
         "reference-capacity": "12 passengers",
@@ -2611,7 +2611,7 @@
     },
     "rct2.ride.mft": {
         "reference-name": "Articulated Roller Coaster Trains",
-        "name": "Artikaj Trajnoj de Onda Fervojo",
+        "name": "Artikaj trajnoj de onda fervojo",
         "reference-description": "Roller coaster trains with short single-row cars and open fronts",
         "description": "Trajnoj de onda fervojo, kiuj havas kaj mallongajn ĉarojn kun unu vico kaj subĉielajn frontojn",
         "reference-capacity": "2 passengers per car",
@@ -2635,7 +2635,7 @@
     },
     "rct2.ride.mono1": {
         "reference-name": "Streamlined Monorail Trains",
-        "name": "Aerodinamikaj Monorelaj Trajnoj",
+        "name": "Aerodinamikaj monorelaj trajnoj",
         "reference-description": "Large capacity monorail trains with streamlined front and rear cars",
         "description": "Grandspacaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
         "reference-capacity": "5 or 10 passengers per car",
@@ -2643,7 +2643,7 @@
     },
     "rct2.ride.mono2": {
         "reference-name": "Small Monorail Cars",
-        "name": "Malgrandaj Monorelaj Ĉaroj",
+        "name": "Malgrandaj monorelaj ĉaroj",
         "reference-description": "Small monorail cars with open sides",
         "description": "Malgrandaj monorelaj ĉaroj kun subĉielaj flankoj",
         "reference-capacity": "4 passengers per car",
@@ -2659,7 +2659,7 @@
     },
     "rct2.ride.nemt": {
         "reference-name": "4-across Inverted Roller Coaster Trains",
-        "name": "4-horizontalaj Trajnoj de Inversigita Onda Fervojo",
+        "name": "4-horizontalaj trajnoj de inversigita onda fervojo",
         "reference-description": "Suspended trains in which riders sit in rows",
         "description": "Penditaj trajnoj, en kiuj rajdantoj sidas en vicoj",
         "reference-capacity": "4 passengers per car",
@@ -2675,7 +2675,7 @@
     },
     "rct2.ride.nrl2": {
         "reference-name": "Steam Trains with Covered Cars",
-        "name": "Vaporlokomotivoj kun Kovritaj Ĉaroj",
+        "name": "Vaporlokomotivoj kun kovritaj ĉaroj",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling wooden carriages with fabric roofs",
         "description": "Miniaturaj lokomotivoj, kiuj konsistas el replikaĵo de lokomotivo kaj tendro, kaj tiras lignajn kaleŝojn kun fabrikaj tegmentoj",
         "reference-capacity": "6 passengers per carriage",
@@ -2683,17 +2683,17 @@
     },
     "rct2.ride.obs1": {
         "reference-name": "Single-deck Cabin",
-        "name": "Unuetaĝa Kajuto",
+        "name": "Unuetaĝa kajuto",
         "reference-description": "Single-deck rotating observation cabin",
-        "description": "Unuetaĝa turniĝanta kajuto por observadi",
+        "description": "Unuetaĝa turniĝanta kajuto por observa turo",
         "reference-capacity": "20 passengers",
         "capacity": "20 pasaĝeroj"
     },
     "rct2.ride.obs2": {
         "reference-name": "Double-deck Cabin",
-        "name": "Duetaĝa Kajuto",
+        "name": "Duetaĝa kajuto",
         "reference-description": "Twin-deck rotating observation cabin",
-        "description": "Duetaĝa turniĝanta kajuto por observi",
+        "description": "Duetaĝa turniĝanta kajuto por observa turo",
         "reference-capacity": "32 passengers",
         "capacity": "32 pasaĝeroj"
     },
@@ -2705,7 +2705,7 @@
     },
     "rct2.ride.pmt1": {
         "reference-name": "Powered Mine Trains",
-        "name": "Ŝaltitaj Mino-Trajnoj",
+        "name": "Elektraj mino-trajnoj",
         "reference-description": "Mine train-themed roller coaster trains that propel themselves",
         "description": "Minotrajno-temitaj trajnoj de onda fervojo, kiuj iras per si mem",
         "reference-capacity": "2 or 4 passengers per car",
@@ -2719,7 +2719,7 @@
     },
     "rct2.ride.premt1": {
         "reference-name": "LIM Launched Roller Coaster Trains",
-        "name": "Trajnoj de Onda Fervojo Lanĉitaj per LIM-oj",
+        "name": "LIM-lanĉitaj trajnoj de onda fervojo",
         "reference-description": "Roller coaster trains that are accelerated by linear induction motors",
         "description": "Trajnoj de onda fervojo, kiujn linearaj induktaj motoroj plirapidigas",
         "reference-capacity": "4 passengers per car",
@@ -2733,7 +2733,7 @@
     },
     "rct2.ride.ptct1": {
         "reference-name": "Wooden Roller Coaster Trains",
-        "name": "Trajnoj de Ligna Onda Fervojo",
+        "name": "Trajnoj de ligna onda fervojo",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
         "description": "Trajnoj de ligna onda fervojo kun komfortaj seĝoj kaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -2741,7 +2741,7 @@
     },
     "rct2.ride.ptct2": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater)",
-        "name": "Trajnoj de Ligna Onda Fervojo (6 seĝoj)",
+        "name": "Trajnoj de ligna onda fervojo (6 seĝoj)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
         "description": "Trajnoj de ligna onda fervojo kun komfortaj seĝoj kaj sinobridoj",
         "reference-capacity": "6 passengers per car",
@@ -2749,7 +2749,7 @@
     },
     "rct2.ride.ptct2r": {
         "reference-name": "Wooden Roller Coaster Trains (6 seater, Reversed)",
-        "name": "Trajnoj de Ligna Onda Fervojo (6 seĝoj, Inversigita)",
+        "name": "Trajnoj de ligna onda fervojo (6 seĝoj, inversigita)",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints, running with the seats facing backwards",
         "description": "Lignaj trajnoj de onda fervojo, kun komfortaj seĝoj kaj sinobridoj, kiuj havas inversigitajn seĝojn",
         "reference-capacity": "6 passengers per car",
@@ -2757,7 +2757,7 @@
     },
     "rct2.ride.rapboat": {
         "reference-name": "River Rapids Boats",
-        "name": "Boatoj de Rapidfluorajdo",
+        "name": "Boatoj de rapidfluorajdo",
         "reference-description": "Circular boats that turn and splash around as they meander along the river rapids",
         "description": "Rondaj boatoj, kiuj turniĝas kaj plaŭdas vagante laŭ la rapidfluoj",
         "reference-capacity": "8 passengers per boat",
@@ -2765,7 +2765,7 @@
     },
     "rct2.ride.rboat": {
         "reference-name": "Rowing Boats",
-        "name": "Remado-Boatoj",
+        "name": "Remado-boatoj",
         "reference-description": "Rowing boats which passengers row themselves",
         "description": "Remado-boatoj, kiujn pasaĝeroj remas per si mem",
         "reference-capacity": "2 passengers per boat",
@@ -2773,7 +2773,7 @@
     },
     "rct2.ride.rckc": {
         "reference-name": "Rocket Cars",
-        "name": "Raketo-Ĉaroj",
+        "name": "Raketo-ĉaroj",
         "reference-description": "Roller coaster cars themed to look like rockets",
         "description": "Ĉaroj de onda fervojo, temitaj por aspekti kiel raketoj",
         "reference-capacity": "4 passengers per car",
@@ -2789,7 +2789,7 @@
     },
     "rct2.ride.revcar": {
         "reference-name": "Reverser Cars",
-        "name": "Inversiĝantaj Ĉaroj",
+        "name": "Inversiĝantaj ĉaroj",
         "reference-description": "Bogied cars capable of turning around on special reversing sections",
         "description": "Boĝiĉaroj kapablas je turniĝi ĉirkaŭ specialaj inversigantaj partoj",
         "reference-capacity": "6 passengers per car",
@@ -2797,7 +2797,7 @@
     },
     "rct2.ride.revf1": {
         "reference-name": "Reverse Freefall Car",
-        "name": "Ĉaro de Onda Fervojo kun Dorsantaŭa Libera Falo",
+        "name": "Ĉaro de onda fervojo kun dorsantaŭa libera falo",
         "reference-description": "Large coaster car for the Reverse Freefall Coaster",
         "description": "Granda ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
         "reference-capacity": "8 passengers",
@@ -2813,7 +2813,7 @@
     },
     "rct2.ride.rsaus": {
         "reference-name": "Roast Sausage Stall",
-        "name": "Rostita-Kolbaso-Budo",
+        "name": "Rostita-kolbaso-budo",
         "reference-description": "A stall selling Chinese style roast sausage",
         "description": "Budo vendanta Ĉina-stilajn rostitajn kolbasojn"
     },
@@ -2827,7 +2827,7 @@
     },
     "rct2.ride.scht1": {
         "reference-name": "Looping Roller Coaster Trains",
-        "name": "Trajnoj de Lopanta Onda Fervojo",
+        "name": "Trajnoj de lopanta onda fervojo",
         "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops",
         "description": "Trajnoj de onda fervojo kun sinobridoj, kiuj kapablas veturi tra vertikalaj lopoj",
         "reference-capacity": "4 passengers per car",
@@ -2835,15 +2835,15 @@
     },
     "rct2.ride.sfric1": {
         "reference-name": "Wooden Side-Friction Cars",
-        "name": "Ĉaroj de Ligna Onda Fervojo kun Flanka Froto",
+        "name": "Ĉaroj de ligna onda fervojo kun flanka froto",
         "reference-description": "Basic cars for the Side-Friction Roller Coaster",
-        "description": "Bazaj ĉaroj por la Ligna Onda Fervojo kun Flanka Froto",
+        "description": "Bazaj ĉaroj por la ligna onda fervojo kun flanka froto",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2.ride.simpod": {
         "reference-name": "Motion Simulator",
-        "name": "Moviĝado-Simulilo",
+        "name": "Moviĝado-simulilo",
         "reference-description": "Riders view a film inside the motion simulator pod while it is twisted and moved around by a hydraulic arm",
         "description": "Rajdantoj vidas filmon en la moviĝado-simulilo, kiun hidraŭlika brako turnas kaj movas",
         "reference-capacity": "8 passengers",
@@ -2851,7 +2851,7 @@
     },
     "rct2.ride.skytr": {
         "reference-name": "Lay-down Cars",
-        "name": "Kuŝiĝantaj Ĉaroj",
+        "name": "Kuŝiĝantaj ĉaroj",
         "reference-description": "Small suspended cars in which the passengers ride face-down in a lying position, swinging freely from side to side",
         "description": "Malgrandaj penditaj ĉaroj, en kiuj la pasaĝeroj rajdas kuŝiĝante, frontas al la tero, kaj svingiĝas libere de unu flanko al la alia",
         "reference-capacity": "1 passenger per car",
@@ -2859,7 +2859,7 @@
     },
     "rct2.ride.slcfo": {
         "reference-name": "Face-off Cars",
-        "name": "Alfrontantaj Aŭtoj",
+        "name": "Alfrontantaj aŭtoj",
         "reference-description": "Riders sit in pairs facing either forwards or backwards as they loop and twist through tight inversions",
         "description": "Rapidirante tra krutaj inversigoj, rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
         "reference-capacity": "4 passengers per car",
@@ -2867,7 +2867,7 @@
     },
     "rct2.ride.slct": {
         "reference-name": "Compact Inverted Coaster Trains",
-        "name": "Trajnoj de Kompakta Inversigita Onda Fervojo",
+        "name": "Trajnoj de kompakta inversigita onda fervojo",
         "reference-description": "Riders sit in pairs of seats suspended beneath the track",
         "description": "Rajdantoj sidas en paroj da seĝoj penditaj sub la trako",
         "reference-capacity": "2 passengers per car",
@@ -2891,7 +2891,7 @@
     },
     "rct2.ride.smono": {
         "reference-name": "Suspended Monorail Trains",
-        "name": "Penditaj Monorelaj Trajnoj",
+        "name": "Penditaj monorelaj trajnoj",
         "reference-description": "Large capacity monorail train cars",
         "description": "Grandspacaj monorelaj trajnoĉaroj",
         "reference-capacity": "8 passengers per car",
@@ -2905,13 +2905,13 @@
     },
     "rct2.ride.soybean": {
         "reference-name": "Soybean Milk Stall",
-        "name": "Sojlaktobudo",
+        "name": "Sojolaktobudo",
         "reference-description": "A stall selling cartons of soybean milk",
         "description": "Budo vendanta kartonojn da sojlakto"
     },
     "rct2.ride.spboat": {
         "reference-name": "Splash Boats",
-        "name": "Plaŭdantaj Boatoj",
+        "name": "Plaŭdantaj boatoj",
         "reference-description": "Large capacity boats, built for water tracks with very steep drops",
         "description": "Grandspacaj boatoj, konstruitaj por akvotrakoj kun tre krutaj faloj",
         "reference-capacity": "16 passengers per boat",
@@ -2927,7 +2927,7 @@
     },
     "rct2.ride.spdrcr": {
         "reference-name": "Spiral Roller Coaster Trains",
-        "name": "Spiralaj Trajnoj de Onda Fervojo",
+        "name": "Spiralaj trajnoj de onda fervojo",
         "reference-description": "Compact roller coaster trains with cars with in-line seating",
         "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj",
         "reference-capacity": "6 passengers per car",
@@ -2941,7 +2941,7 @@
     },
     "rct2.ride.srings": {
         "reference-name": "Space Rings",
-        "name": "Kosmaj Ringoj",
+        "name": "Kosmaj ringoj",
         "reference-description": "Concentric pivoting rings allowing the riders free rotation in all directions",
         "description": "Koncentraj pivotantaj ringoj, kiuj donas al la rajdantoj liberan rotacion en ĉiuj direktoj",
         "reference-capacity": "1 guest per ring",
@@ -2949,7 +2949,7 @@
     },
     "rct2.ride.ssc1": {
         "reference-name": "Launched Freefall Car",
-        "name": "Lanĉita Libera-Falo-Ĉaro",
+        "name": "Lanĉita libera-falo-ĉaro",
         "reference-description": "Freefall car is pneumatically launched up a tall steel tower and then allowed to freefall down",
         "description": "Ĉaro estas lanĉita pneŭmatike, kaj unue supreniras je alta ŝtala turo, kaj tiam falas libere malsupren",
         "reference-capacity": "8 passengers",
@@ -2957,7 +2957,7 @@
     },
     "rct2.ride.starfrdr": {
         "reference-name": "Star Fruit Drink Stall",
-        "name": "Stelfrukto-Trinkaĵbudo",
+        "name": "Stelfrukto-trinkaĵbudo",
         "reference-description": "A stall selling star fruit drinks",
         "description": "Budo vendanta stelfrukto-trinkaĵojn"
     },
@@ -2993,13 +2993,13 @@
     },
     "rct2.ride.sungst": {
         "reference-name": "Sunglasses Stall",
-        "name": "Sunokulvitroj-Budo",
+        "name": "Sunokulvitroj-budo",
         "reference-description": "A stall selling all kinds of sunglasses",
         "description": "Budo vendanta ĉiaspecajn sunokulvitrojn"
     },
     "rct2.ride.swans": {
         "reference-name": "Swans",
-        "name": "Cigno-Boatoj",
+        "name": "Cigno-boatoj",
         "reference-description": "Swan-shaped boats, propelled by the pedalling front seat passengers",
         "description": "Cignoformaj boatoj, kiujn la pedalado de la frontaj pasaĝeroj antaŭenigas",
         "reference-capacity": "4 passengers per boat",
@@ -3007,7 +3007,7 @@
     },
     "rct2.ride.swsh1": {
         "reference-name": "Pirate Ship",
-        "name": "Pirato-Ŝipo",
+        "name": "Pirato-ŝipo",
         "reference-description": "Large swinging pirate ship",
         "description": "Granda svingiĝanta pirato-ŝipo",
         "reference-capacity": "16 passengers",
@@ -3015,7 +3015,7 @@
     },
     "rct2.ride.swsh2": {
         "reference-name": "Swinging Inverter Ship",
-        "name": "Svingiĝanta Inversigilo-Ŝipo",
+        "name": "Svingiĝanta inversigilo-ŝipo",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
         "description": "La ŝipo estas fiksita al brako, kiu havas kontraŭpezon al la kontraŭa flanko, kaj svingiĝas tra plenaj 360 gradoj",
         "reference-capacity": "12 passengers",
@@ -3023,7 +3023,7 @@
     },
     "rct2.ride.thcar": {
         "reference-name": "Air Powered Vertical Coaster Trains",
-        "name": "Trajnoj de Aerofunkciigita Vertikala Onda Fervojo",
+        "name": "Trajnoj de aerofunkciigita vertikala onda fervojo",
         "reference-description": "Air-powered launched roller coaster trains",
         "description": "Trajnoj de onda fervojo lanĉitaj per aero",
         "reference-capacity": "2 passengers per car",
@@ -3049,7 +3049,7 @@
     },
     "rct2.ride.togst": {
         "reference-name": "Stand-up Roller Coaster Trains",
-        "name": "Stariĝantaj Trajnoj de Onda Fervojo",
+        "name": "Stariĝantaj trajnoj de onda fervojo",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position",
         "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio",
         "reference-capacity": "4 passengers per car",
@@ -3057,7 +3057,7 @@
     },
     "rct2.ride.topsp1": {
         "reference-name": "Top Spin",
-        "name": "Tuniĝanta Gondolo",
+        "name": "Turniĝanta gondolo",
         "reference-description": "Passengers ride in a gondola suspended by large rotating arms, rotating forwards and backwards head-over-heels",
         "description": "Pasaĝeroj rajdas en gondolo, pendita per grandaj turniĝantaj brakoj, kaj turniĝas antaŭen kaj malantaŭen renversite",
         "reference-capacity": "8 passengers",
@@ -3067,13 +3067,13 @@
         "reference-name": "Trams",
         "name": "Tramoj",
         "reference-description": "Old-timer replica trams",
-        "description": "Eksmodaj replikaĵoj de tramoj",
+        "description": "Replikaĵoj de eksmodaj tramoj",
         "reference-capacity": "10 passengers per car",
         "capacity": "Po 10 pasaĝeroj por ĉaro"
     },
     "rct2.ride.trike": {
         "reference-name": "Water Tricycles",
-        "name": "Akvo-Tricikloj",
+        "name": "Akvo-tricikloj",
         "reference-description": "Pedal-tricycle with large buoyant wheels",
         "description": "Pedal-tricikloj kun grandaj naĝemaj radoj",
         "reference-capacity": "2 passengers per tricycle",
@@ -3089,7 +3089,7 @@
     },
     "rct2.ride.tshrt": {
         "reference-name": "T-Shirt Stall",
-        "name": "T-Ĉemizbudo",
+        "name": "T-ĉemizbudo",
         "reference-description": "A stall selling souvenir T-Shirts",
         "description": "Budo vendanta memoraĵecajn T-Ĉemizojn"
     },
@@ -3103,7 +3103,7 @@
     },
     "rct2.ride.twist2": {
         "reference-name": "Snow Cups",
-        "name": "Neĝo-Tasoj",
+        "name": "Neĝo-tasoj",
         "reference-description": "Riders ride in pairs of seats rotating around a central snowman",
         "description": "Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ centra neĝhomo",
         "reference-capacity": "18 passengers",
@@ -3111,7 +3111,7 @@
     },
     "rct2.ride.utcar": {
         "reference-name": "Twister Cars",
-        "name": "Tvisto-Ĉaroj",
+        "name": "Tvisto-ĉaroj",
         "reference-description": "Roller coaster cars capable of heartline twists",
         "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn",
         "reference-capacity": "4 passengers per car",
@@ -3119,7 +3119,7 @@
     },
     "rct2.ride.utcarr": {
         "reference-name": "Twister Cars (starting reversed)",
-        "name": "Tvisto-Ĉaroj (startantaj dorsantaŭe)",
+        "name": "Tvisto-ĉaroj (startantaj dorsantaŭe)",
         "reference-description": "Roller coaster cars capable of heartline twists, starting reversed",
         "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, startantaj dorsantaŭe",
         "reference-capacity": "4 passengers per car",
@@ -3127,7 +3127,7 @@
     },
     "rct2.ride.vcr": {
         "reference-name": "Vintage Cars",
-        "name": "Malnovaj Aŭtoj",
+        "name": "Malnovaj aŭtoj",
         "reference-description": "Powered vehicles in the shape of vintage cars",
         "description": "Ŝaltitaj veturiloj en la formo de malnovaj aŭtoj",
         "reference-capacity": "2 passengers per car",
@@ -3135,7 +3135,7 @@
     },
     "rct2.ride.vekdv": {
         "reference-name": "Vertical Shuttle Cars",
-        "name": "Vertikalaj Navedo-Ĉaroj",
+        "name": "Vertikalaj navedo-ĉaroj",
         "reference-description": "Large roller coaster cars in which riders sit in seats suspended beneath the track",
         "description": "Grandaj ĉaroj de onda fervojo, en kiu rajdantoj sidas en seĝoj penditaj sub la trako",
         "reference-capacity": "4 passengers per car",
@@ -3143,7 +3143,7 @@
     },
     "rct2.ride.vekst": {
         "reference-name": "Lay-down Roller Coaster Trains",
-        "name": "Trajnoj de Kuŝiĝanta Onda Fervojo",
+        "name": "Trajnoj de kuŝiĝanta onda fervojo",
         "reference-description": "Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
         "description": "Rajdantoj kuŝiĝantaj estas tenitaj en specialaj jungaĵoj, kaj veturas aŭ fronte al la ĉielo aŭ fronte al la tero",
         "reference-capacity": "4 passengers per car",
@@ -3151,7 +3151,7 @@
     },
     "rct2.ride.vekvamp": {
         "reference-name": "Swinging Floorless Cars",
-        "name": "Svingiĝantaj Senplankaj Aŭtoj",
+        "name": "Svingiĝantaj senplankaj aŭtoj",
         "reference-description": "Suspended roller coaster trains consisting of chairlift-style seats able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "2 passengers per car",
@@ -3167,7 +3167,7 @@
     },
     "rct2.ride.wcatc": {
         "reference-name": "Automobile Cars",
-        "name": "Aŭto-Ĉaroj",
+        "name": "Aŭto-ĉaroj",
         "reference-description": "Roller coaster cars in the shape of automobiles",
         "description": "Ĉaroj de onda fervojo formitaj kiel aŭtoj",
         "reference-capacity": "4 passengers per car",
@@ -3199,13 +3199,13 @@
     },
     "rct2.ride.wonton": {
         "reference-name": "Wonton Soup Stall",
-        "name": "Huntuna-Supobudo",
+        "name": "Huntuna-supo-budo",
         "reference-description": "A stall selling Wonton Soup",
         "description": "Budo vendanta Huntunan Supon"
     },
     "rct2.ride.zldb": {
         "reference-name": "Ladybird Trains",
-        "name": "Kokcineloj-Trajnoj",
+        "name": "Kokcinelo-trajnoj",
         "reference-description": "Roller coaster trains with small ladybird-shaped cars",
         "description": "Trajnoj de onda fervojo kun malgrandaj kokcineloformaj ĉaroj",
         "reference-capacity": "2 passengers per car",
@@ -3213,7 +3213,7 @@
     },
     "rct2.ride.zlog": {
         "reference-name": "Log Trains",
-        "name": "Ŝtipo-Trajnoj",
+        "name": "Ŝtipo-trajnoj",
         "reference-description": "Roller coaster trains with small log-shaped cars",
         "description": "Trajnoj de onda fervojo kun malgrandaj ŝtipoformaj ĉaroj",
         "reference-capacity": "2 passengers per car",
@@ -3229,9 +3229,9 @@
     },
     "rct2.scenario_meta.amity_airfield": {
         "reference-name": "Amity Airfield",
-        "name": "Amikeco-Aerodromo",
+        "name": "Amikeca Aerodromo",
         "reference-park_name": "Amity Airfield",
-        "park_name": "Amikeco-Aerodromo",
+        "park_name": "Amikeca Aerodromo",
         "reference-details": "Build a flying-themed amusement park in this abandoned airport",
         "details": "Konstruu amuzparkon kun flugado-temo en ĉi tiu forlasita flughaveno"
     },
@@ -3245,7 +3245,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_belgium": {
         "reference-name": "Build your own Six Flags Belgium",
-        "name": "Konstrui je via propra Six Flags Belgium",
+        "name": "Konstruu vian propran parkon Six Flags Belgium",
         "reference-park_name": "Six Flags Belgium",
         "park_name": "Six Flags Belgium",
         "reference-details": "Build your own version of this European Six Flags park",
@@ -3253,7 +3253,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_great_adventure": {
         "reference-name": "Build your own Six Flags Great Adventure",
-        "name": "Konstrui je via propra Six Flags Great Adventure",
+        "name": "Konstruu vian propran parkon Six Flags Great Adventure",
         "reference-park_name": "Six Flags Great Adventure",
         "park_name": "Six Flags Great Adventure",
         "reference-details": "Use your design skills to recreate this Six Flags park",
@@ -3261,7 +3261,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_holland": {
         "reference-name": "Build your own Six Flags Holland",
-        "name": "Konstrui je via propra Six Flags Holland",
+        "name": "Konstruu vian propran parkon Six Flags Holland",
         "reference-park_name": "Six Flags Holland",
         "park_name": "Six Flags Holland",
         "reference-details": "Build this European Six Flags park the way you want to",
@@ -3269,7 +3269,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_magic_mountain": {
         "reference-name": "Build your own Six Flags Magic Mountain",
-        "name": "Konstrui je via propra Six Flags Magic Mountain",
+        "name": "Konstruu vian propran parkon Six Flags Magic Mountain",
         "reference-park_name": "Six Flags Magic Mountain",
         "park_name": "Six Flags Magic Mountain",
         "reference-details": "Create your own version of this massive Six Flags park",
@@ -3277,7 +3277,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_over_texas": {
         "reference-name": "Build your own Six Flags over Texas",
-        "name": "Konstrui je via propra Six Flags over Texas",
+        "name": "Konstruu vian propran parkon Six Flags over Texas",
         "reference-park_name": "Six Flags over Texas",
         "park_name": "Six Flags over Texas",
         "reference-details": "Starting from scratch, build the rides in this Six Flags park",
@@ -3285,7 +3285,7 @@
     },
     "rct2.scenario_meta.build_your_own_six_flags_park": {
         "reference-name": "Build your own Six Flags Park",
-        "name": "Konstrui vian propran parkon de Six Flags",
+        "name": "Konstruu vian propran parkon de Six Flags",
         "reference-park_name": "Six Flags",
         "park_name": "Six Flags",
         "reference-details": "Build your own design of Six Flags park - either build rides from other Six Flags parks or design and build your own rides",
@@ -3293,9 +3293,9 @@
     },
     "rct2.scenario_meta.bumbly_bazaar": {
         "reference-name": "Bumbly Bazaar",
-        "name": "Burda Bazaro",
+        "name": "Plumpa Bazaro",
         "reference-park_name": "Bumbly Bazaar",
-        "park_name": "Burda Bazaro",
+        "park_name": "Plumpa Bazaro",
         "reference-details": "Starting with a small market bazaar, your challenge is to increase the profit from shops and stalls by building rides and roller coasters to attract more customers",
         "details": "Komencante kun malgranda bazaro, via defio estas pliigi la profitan de vendejoj kaj budoj per konstrui atrakciojn kaj ondajn fervojojn por allogi pli da klientoj"
     },
@@ -3333,9 +3333,9 @@
     },
     "rct2.scenario_meta.factory_capers": {
         "reference-name": "Factory Capers",
-        "name": "Fabriko-Kaprioloj",
+        "name": "Fabrikaj Kaprioloj",
         "reference-park_name": "Factory Capers",
-        "park_name": "Fabriko-Kaprioloj",
+        "park_name": "Fabrikaj Kaprioloj",
         "reference-details": "An abandoned factory complex is an opportunity to build a mechanical-themed amusement park",
         "details": "Ĉi tiu forlasita fabriko-konstruaĵaro estas okazo por konstrui amuzparkon kun mekanika temo"
     },
@@ -3381,9 +3381,9 @@
     },
     "rct2.scenario_meta.rainbow_summit": {
         "reference-name": "Rainbow Summit",
-        "name": "Ĉielarko-Supraĵo",
+        "name": "Ĉielarka Supraĵo",
         "reference-park_name": "Rainbow Summit",
-        "park_name": "Ĉielarko-Supraĵo",
+        "park_name": "Ĉielarka Supraĵo",
         "reference-details": "Built on a hillside, this park is forbidden from building anything tall. Can you expand the park and make it successful?",
         "details": "Konstruita ĉe montetoflanko, la aŭtoritato malpermesas altajn konstruaĵojn. Ĉu vi povas ellabori la parkon kaj farigi ĝin sukcesa?"
     },
@@ -3437,23 +3437,23 @@
     },
     "rct2.scenery_group.scgabstr": {
         "reference-name": "Abstract Theming",
-        "name": "Abstrakta Temo"
+        "name": "Abstrakta temo"
     },
     "rct2.scenery_group.scgcandy": {
         "reference-name": "Giant Candy Theming",
-        "name": "Temo de Giganta Dolĉaĵo"
+        "name": "Temo de giganta dolĉaĵo"
     },
     "rct2.scenery_group.scgclass": {
         "reference-name": "Classical/Roman Theming",
-        "name": "Klasika / Roma Temo"
+        "name": "Klasika / romia temo"
     },
     "rct2.scenery_group.scgegypt": {
         "reference-name": "Egyptian Theming",
-        "name": "Egipta Temo"
+        "name": "Egipta temo"
     },
     "rct2.scenery_group.scgfence": {
         "reference-name": "Fences and Walls",
-        "name": "Bariloj kaj Muroj"
+        "name": "Bariloj kaj muroj"
     },
     "rct2.scenery_group.scggardn": {
         "reference-name": "Gardens",
@@ -3461,31 +3461,31 @@
     },
     "rct2.scenery_group.scggiant": {
         "reference-name": "Giant Garden Theming",
-        "name": "Temo de Giganta Ĝardeno"
+        "name": "Temo de giganta ĝardeno"
     },
     "rct2.scenery_group.scghallo": {
         "reference-name": "Creepy Theming",
-        "name": "Timigeta Temo"
+        "name": "Timigeta temo"
     },
     "rct2.scenery_group.scgindus": {
         "reference-name": "Mechanical Theming",
-        "name": "Mekanika Temo"
+        "name": "Mekanika temo"
     },
     "rct2.scenery_group.scgjungl": {
         "reference-name": "Jungle Theming",
-        "name": "Ĝangalo-Temo"
+        "name": "Ĝangalo-temo"
     },
     "rct2.scenery_group.scgjuras": {
         "reference-name": "Jurassic Theming",
-        "name": "Ĵurasa Temo"
+        "name": "Ĵurasa temo"
     },
     "rct2.scenery_group.scgmart": {
         "reference-name": "Martian Theming",
-        "name": "Marsa Temo"
+        "name": "Marsa temo"
     },
     "rct2.scenery_group.scgmedie": {
         "reference-name": "Medieval Theming",
-        "name": "Mezepoka Temo"
+        "name": "Mezepoka temo"
     },
     "rct2.scenery_group.scgmine": {
         "reference-name": "Mine Theming",
@@ -3493,19 +3493,19 @@
     },
     "rct2.scenery_group.scgorien": {
         "reference-name": "Pagoda Theming",
-        "name": "Pagodo-Temo"
+        "name": "Pagodo-temo"
     },
     "rct2.scenery_group.scgpathx": {
         "reference-name": "Signs and Items for Footpaths",
-        "name": "Afiŝoj kaj Diversaĵoj por Trotuaroj"
+        "name": "Afiŝoj kaj diversaĵoj por trotuaroj"
     },
     "rct2.scenery_group.scgpirat": {
         "reference-name": "Pirates Theming",
-        "name": "Pirato-Temo"
+        "name": "Pirato-temo"
     },
     "rct2.scenery_group.scgshrub": {
         "reference-name": "Shrubs and Ornaments",
-        "name": "Arbetoj kaj Ornamaĵoj"
+        "name": "Arbetoj kaj ornamaĵoj"
     },
     "rct2.scenery_group.scgsixfl": {
         "reference-name": "Six Flags Theming",
@@ -3513,19 +3513,19 @@
     },
     "rct2.scenery_group.scgsnow": {
         "reference-name": "Snow and Ice Theming",
-        "name": "Temo de Neĝo kaj Glacio"
+        "name": "Temo de neĝo kaj glacio"
     },
     "rct2.scenery_group.scgspace": {
         "reference-name": "Space Theming",
-        "name": "Kosma Temo"
+        "name": "Kosma temo"
     },
     "rct2.scenery_group.scgspook": {
         "reference-name": "Spooky Theming",
-        "name": "Timigeta Temo"
+        "name": "Timigeta temo"
     },
     "rct2.scenery_group.scgsport": {
         "reference-name": "Sports Theming",
-        "name": "Temo de Sportoj"
+        "name": "Temo de sportoj"
     },
     "rct2.scenery_group.scgtrees": {
         "reference-name": "Trees",
@@ -3533,11 +3533,11 @@
     },
     "rct2.scenery_group.scgurban": {
         "reference-name": "Urban Theming",
-        "name": "Urba Temo"
+        "name": "Urba temo"
     },
     "rct2.scenery_group.scgwalls": {
         "reference-name": "Walls and Roofs",
-        "name": "Muroj kaj Tegmentoj"
+        "name": "Muroj kaj tegmentoj"
     },
     "rct2.scenery_group.scgwater": {
         "reference-name": "Water Feature Theming",
@@ -3545,11 +3545,11 @@
     },
     "rct2.scenery_group.scgwond": {
         "reference-name": "Wonderland Theming",
-        "name": "Mirlando-Temo"
+        "name": "Mirlando-temo"
     },
     "rct2.scenery_group.scgwwest": {
         "reference-name": "Wild West Theming",
-        "name": "Sovaĝa-Okcidento-Temo"
+        "name": "Sovaĝa-okcidento-temo"
     },
     "rct2.scenery_large.badrack": {
         "reference-name": "Badminton Racket",
@@ -3557,23 +3557,23 @@
     },
     "rct2.scenery_large.genstore": {
         "reference-name": "General Store",
-        "name": "Vilaĝo-Vendejo"
+        "name": "Vilaĝo-vendejo"
     },
     "rct2.scenery_large.glthent": {
         "reference-name": "‘Goliath’ Sign",
-        "name": "‘Goliato’ Afiŝo"
+        "name": "Afiŝo ‘Goliato’"
     },
     "rct2.scenery_large.mdsaent": {
         "reference-name": "‘Medusa’ Sign",
-        "name": "‘Meduzo’ Afiŝo"
+        "name": "Afiŝo ‘Meduzo’"
     },
     "rct2.scenery_large.nitroent": {
         "reference-name": "‘Nitro’ Sign",
-        "name": "‘Nitro’ Afiŝo"
+        "name": "Afiŝo ‘Nitro’"
     },
     "rct2.scenery_large.prship": {
         "reference-name": "Pirate Ship",
-        "name": "Pirato-Ŝipo"
+        "name": "Pirato-ŝipo"
     },
     "rct2.scenery_large.sah": {
         "reference-name": "House",
@@ -3597,7 +3597,7 @@
     },
     "rct2.scenery_large.scol": {
         "reference-name": "Roman Colosseum",
-        "name": "Roma Koloseo"
+        "name": "Romia koloseo"
     },
     "rct2.scenery_large.sct": {
         "reference-name": "Tent",
@@ -3617,7 +3617,7 @@
     },
     "rct2.scenery_large.sgp": {
         "reference-name": "Giant Pumpkin",
-        "name": "Giganta Kukurbo"
+        "name": "Giganta kukurbo"
     },
     "rct2.scenery_large.shs1": {
         "reference-name": "Terraced House",
@@ -3629,11 +3629,11 @@
     },
     "rct2.scenery_large.sip": {
         "reference-name": "Ice Palace",
-        "name": "Palaco el Glacio"
+        "name": "Palaco el glacio"
     },
     "rct2.scenery_large.smb": {
         "reference-name": "Martian Building",
-        "name": "Marsa Konstruaĵo"
+        "name": "Marsa konstruaĵo"
     },
     "rct2.scenery_large.smh1": {
         "reference-name": "Mine Hut",
@@ -3649,7 +3649,7 @@
     },
     "rct2.scenery_large.sob": {
         "reference-name": "Office Block",
-        "name": "Oficejo-Bloko"
+        "name": "Oficejo-bloko"
     },
     "rct2.scenery_large.soh1": {
         "reference-name": "House",
@@ -3677,23 +3677,23 @@
     },
     "rct2.scenery_large.ssh": {
         "reference-name": "Space Capsule",
-        "name": "Kosma Kapsulo"
+        "name": "Kosma kapsulo"
     },
     "rct2.scenery_large.ssig1": {
         "reference-name": "Scrolling Sign",
-        "name": "Rulumanta Afiŝo"
+        "name": "Rulumanta afiŝo"
     },
     "rct2.scenery_large.ssig2": {
         "reference-name": "3D Sign",
-        "name": "3D Afiŝo"
+        "name": "3D-afiŝo"
     },
     "rct2.scenery_large.ssig3": {
         "reference-name": "Vertical 3D Sign",
-        "name": "Vertikala 3D Afiŝo"
+        "name": "Vertikala 3D-afiŝo"
     },
     "rct2.scenery_large.ssig4": {
         "reference-name": "3D Sign",
-        "name": "3D Afiŝo"
+        "name": "3D-afiŝo"
     },
     "rct2.scenery_large.ssk1": {
         "reference-name": "Skeleton",
@@ -3705,7 +3705,7 @@
     },
     "rct2.scenery_large.ssr": {
         "reference-name": "Space Rocket",
-        "name": "Kosma Raketo"
+        "name": "Kosma raketo"
     },
     "rct2.scenery_large.sst": {
         "reference-name": "Satellite",
@@ -3713,23 +3713,23 @@
     },
     "rct2.scenery_large.stb1": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_large.stb2": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_large.stg1": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_large.stg2": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_large.sth": {
         "reference-name": "Town Hall",
-        "name": "Urbdomo"
+        "name": "Urbodomo"
     },
     "rct2.scenery_large.svlc": {
         "reference-name": "Volcano",
@@ -3753,19 +3753,19 @@
     },
     "rct2.scenery_small.badshut": {
         "reference-name": "Shuttlecock",
-        "name": "Volanoj"
+        "name": "Volano"
     },
     "rct2.scenery_small.badshut2": {
         "reference-name": "Shuttlecock",
-        "name": "Volanoj"
+        "name": "Volano"
     },
     "rct2.scenery_small.ball1": {
         "reference-name": "American Football",
-        "name": "Amerika Piedpilko"
+        "name": "Amerika piedpilko"
     },
     "rct2.scenery_small.ball2": {
         "reference-name": "American Football",
-        "name": "Amerika Piedpilko"
+        "name": "Amerika piedpilko"
     },
     "rct2.scenery_small.ball3": {
         "reference-name": "Football",
@@ -3777,11 +3777,11 @@
     },
     "rct2.scenery_small.beanst1": {
         "reference-name": "Giant Beanstalk",
-        "name": "Giganta Fabotrunko"
+        "name": "Giganta fabotrunko"
     },
     "rct2.scenery_small.beanst2": {
         "reference-name": "Giant Beanstalk",
-        "name": "Giganta Fabotrunko"
+        "name": "Giganta fabotrunko"
     },
     "rct2.scenery_small.brbase": {
         "reference-name": "Base Block",
@@ -3797,11 +3797,11 @@
     },
     "rct2.scenery_small.brcrrf1": {
         "reference-name": "Curved Roof",
-        "name": "Kurba Tegmento"
+        "name": "Kurba tegmento"
     },
     "rct2.scenery_small.brcrrf2": {
         "reference-name": "Curved Roof",
-        "name": "Kurba Tegmento"
+        "name": "Kurba tegmento"
     },
     "rct2.scenery_small.buttfly": {
         "reference-name": "Butterfly",
@@ -3809,11 +3809,11 @@
     },
     "rct2.scenery_small.carrot": {
         "reference-name": "Giant Carrot",
-        "name": "Giganta Karoto"
+        "name": "Giganta karoto"
     },
     "rct2.scenery_small.chbbase": {
         "reference-name": "Checkerboard Block",
-        "name": "Bloko de Damludo-Tablo"
+        "name": "Bloko de damludo-tablo"
     },
     "rct2.scenery_small.chest1": {
         "reference-name": "Treasure Chest",
@@ -3825,7 +3825,7 @@
     },
     "rct2.scenery_small.chocroof": {
         "reference-name": "Chocolate Bar",
-        "name": "Ĉokolado-Briketo"
+        "name": "Ĉokolado-briketo"
     },
     "rct2.scenery_small.cnballs": {
         "reference-name": "Cannon Balls",
@@ -3853,19 +3853,19 @@
     },
     "rct2.scenery_small.cog2": {
         "reference-name": "Small Cogwheel",
-        "name": "Malgranda Dentrado"
+        "name": "Malgranda dentrado"
     },
     "rct2.scenery_small.cog2r": {
         "reference-name": "Small Cogwheel",
-        "name": "Malgranda Dentrado"
+        "name": "Malgranda dentrado"
     },
     "rct2.scenery_small.cog2u": {
         "reference-name": "Small Cogwheel",
-        "name": "Malgranda Dentrado"
+        "name": "Malgranda dentrado"
     },
     "rct2.scenery_small.cog2ur": {
         "reference-name": "Small Cogwheel",
-        "name": "Malgranda Dentrado"
+        "name": "Malgranda dentrado"
     },
     "rct2.scenery_small.colagum": {
         "reference-name": "Cola Candy",
@@ -3873,11 +3873,11 @@
     },
     "rct2.scenery_small.corroof": {
         "reference-name": "Corrugated Steel Roof",
-        "name": "Onda Ŝtala Tegmento"
+        "name": "Onda ŝtala tegmento"
     },
     "rct2.scenery_small.corroof2": {
         "reference-name": "Corrugated Steel Base",
-        "name": "Onda Ŝtala Bazo"
+        "name": "Onda ŝtala bazo"
     },
     "rct2.scenery_small.cwbcrv32": {
         "reference-name": "Curved Wall",
@@ -3905,15 +3905,15 @@
     },
     "rct2.scenery_small.georoof1": {
         "reference-name": "Glass Roof",
-        "name": "Vitra Tegmento"
+        "name": "Vitra tegmento"
     },
     "rct2.scenery_small.georoof2": {
         "reference-name": "Glass Roof",
-        "name": "Vitra Tegmento"
+        "name": "Vitra tegmento"
     },
     "rct2.scenery_small.ggrs1": {
         "reference-name": "Giant Grass",
-        "name": "Giganta Herbo"
+        "name": "Giganta herbo"
     },
     "rct2.scenery_small.hang1": {
         "reference-name": "Gallows",
@@ -3921,7 +3921,7 @@
     },
     "rct2.scenery_small.helmet1": {
         "reference-name": "American Football Helmet",
-        "name": "Amerika Piedpilko-Kasko"
+        "name": "Amerika piedpilko-kasko"
     },
     "rct2.scenery_small.icecube": {
         "reference-name": "Ice Cube",
@@ -3929,23 +3929,23 @@
     },
     "rct2.scenery_small.igroof": {
         "reference-name": "Igloo Roof",
-        "name": "Tegmento de Iglo"
+        "name": "Tegmento de iglo"
     },
     "rct2.scenery_small.jbean1": {
         "reference-name": "Jellybean",
-        "name": "Ĝelateno-Fabo"
+        "name": "Ĝelateno-fabo"
     },
     "rct2.scenery_small.jelbab1": {
         "reference-name": "Jelly Baby",
-        "name": "Ĝelateno-Bebo"
+        "name": "Ĝelateno-bebo"
     },
     "rct2.scenery_small.jeldrop1": {
         "reference-name": "Fruit Drop",
-        "name": "Frukto-Dolĉaĵo"
+        "name": "Frukto-dolĉaĵo"
     },
     "rct2.scenery_small.jeldrop2": {
         "reference-name": "Fruit Drop",
-        "name": "Frukto-Dolĉaĵo"
+        "name": "Frukto-dolĉaĵo"
     },
     "rct2.scenery_small.jngroof1": {
         "reference-name": "Roof",
@@ -3973,15 +3973,15 @@
     },
     "rct2.scenery_small.mment1": {
         "reference-name": "Ornamental Structure",
-        "name": "Ornama Konstruaĵo"
+        "name": "Ornama konstruaĵo"
     },
     "rct2.scenery_small.mment2": {
         "reference-name": "Ornamental Structure",
-        "name": "Ornama Konstruaĵo"
+        "name": "Ornama konstruaĵo"
     },
     "rct2.scenery_small.mment3": {
         "reference-name": "Ornamental Structure",
-        "name": "Ornama Konstruaĵo"
+        "name": "Ornama konstruaĵo"
     },
     "rct2.scenery_small.pagroof1": {
         "reference-name": "Roof",
@@ -4001,7 +4001,7 @@
     },
     "rct2.scenery_small.pirflag": {
         "reference-name": "Pirate Flag",
-        "name": "Pirato-Flago"
+        "name": "Pirato-flago"
     },
     "rct2.scenery_small.pirroof1": {
         "reference-name": "Roof",
@@ -4113,19 +4113,19 @@
     },
     "rct2.scenery_small.stbase": {
         "reference-name": "Steel Block",
-        "name": "Ŝtala Bloko"
+        "name": "Ŝtala bloko"
     },
     "rct2.scenery_small.stlbaset": {
         "reference-name": "Steel Block",
-        "name": "Ŝtala Bloko"
+        "name": "Ŝtala bloko"
     },
     "rct2.scenery_small.stldw": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_small.stldw2": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_small.sumrf": {
         "reference-name": "Roof",
@@ -4141,27 +4141,27 @@
     },
     "rct2.scenery_small.suppw1": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "rct2.scenery_small.suppw2": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "rct2.scenery_small.suppw3": {
         "reference-name": "Support Structure",
-        "name": "Subtena Konstruaĵo"
+        "name": "Subtena konstruaĵo"
     },
     "rct2.scenery_small.tac": {
         "reference-name": "Arizona Cypress Tree",
-        "name": "Arizona Cipresarbo"
+        "name": "Arizona cipresarbo"
     },
     "rct2.scenery_small.tal": {
         "reference-name": "Alligator Shaped Tree",
-        "name": "Aligatorforma Arbo"
+        "name": "Aligatorforma arbo"
     },
     "rct2.scenery_small.tap": {
         "reference-name": "Aleppo Pine Tree",
-        "name": "Alepo-Pinoarbo"
+        "name": "Alepo-pinoarbo"
     },
     "rct2.scenery_small.tas": {
         "reference-name": "Aspen Tree",
@@ -4169,15 +4169,15 @@
     },
     "rct2.scenery_small.tas1": {
         "reference-name": "Candy Tree",
-        "name": "Dolĉaĵo-Arbo"
+        "name": "Dolĉaĵo-arbo"
     },
     "rct2.scenery_small.tas2": {
         "reference-name": "Candy Tree",
-        "name": "Dolĉaĵo-Arbo"
+        "name": "Dolĉaĵo-arbo"
     },
     "rct2.scenery_small.tas3": {
         "reference-name": "Candy Tree",
-        "name": "Dolĉaĵo-Arbo"
+        "name": "Dolĉaĵo-arbo"
     },
     "rct2.scenery_small.tas4": {
         "reference-name": "Candy",
@@ -4185,11 +4185,11 @@
     },
     "rct2.scenery_small.tb1": {
         "reference-name": "White Bishop",
-        "name": "Blanka Kuriero"
+        "name": "Blanka kuriero"
     },
     "rct2.scenery_small.tb2": {
         "reference-name": "Black Bishop",
-        "name": "Nigra Kuriero"
+        "name": "Nigra kuriero"
     },
     "rct2.scenery_small.tbc": {
         "reference-name": "Cactus",
@@ -4205,7 +4205,7 @@
     },
     "rct2.scenery_small.tbp": {
         "reference-name": "Black Poplar Tree",
-        "name": "Nigra Poploarbo"
+        "name": "Nigra poploarbo"
     },
     "rct2.scenery_small.tbr": {
         "reference-name": "Bulrushes",
@@ -4229,15 +4229,15 @@
     },
     "rct2.scenery_small.tbw": {
         "reference-name": "Broken Wheel",
-        "name": "Rompita Rado"
+        "name": "Rompita rado"
     },
     "rct2.scenery_small.tcb": {
         "reference-name": "Club Shaped Tree",
-        "name": "Klabforma Arbo"
+        "name": "Trefoforma arbo"
     },
     "rct2.scenery_small.tcc": {
         "reference-name": "Chinese Cedar Tree",
-        "name": "Ĉina Cedroarbo"
+        "name": "Ĉina cedroarbo"
     },
     "rct2.scenery_small.tcd": {
         "reference-name": "Cauldron",
@@ -4245,19 +4245,19 @@
     },
     "rct2.scenery_small.tce": {
         "reference-name": "Camperdown Elm Tree",
-        "name": "Arbo de Ulmus Glabra"
+        "name": "Malglata ulmoarbo"
     },
     "rct2.scenery_small.tcf": {
         "reference-name": "Caucasian Fir Tree",
-        "name": "Kaŭkaza Abioarbo"
+        "name": "Kaŭkaza abioarbo"
     },
     "rct2.scenery_small.tcfs": {
         "reference-name": "Snow-covered Caucasian Fir Tree",
-        "name": "Neĝkovrita Kaŭkaza Abioarbo"
+        "name": "Neĝkovrita kaŭkaza abioarbo"
     },
     "rct2.scenery_small.tcj": {
         "reference-name": "Common Juniper Tree",
-        "name": "Ordinara Juniperoarbo"
+        "name": "Ordinara juniperoarbo"
     },
     "rct2.scenery_small.tck": {
         "reference-name": "Clock",
@@ -4265,7 +4265,7 @@
     },
     "rct2.scenery_small.tcl": {
         "reference-name": "Cedar of Lebanon Tree",
-        "name": "Lebanona Cedroarbo"
+        "name": "Lebanona cedroarbo"
     },
     "rct2.scenery_small.tcn": {
         "reference-name": "Cannon",
@@ -4273,35 +4273,35 @@
     },
     "rct2.scenery_small.tco": {
         "reference-name": "Common Oak Tree",
-        "name": "Tigfrukta Kverkoarbo"
+        "name": "Tigfrukta kverkoarbo"
     },
     "rct2.scenery_small.tcrp": {
         "reference-name": "Corsican Pine Tree",
-        "name": "Nigra Pinoarbo"
+        "name": "Nigra pinoarbo"
     },
     "rct2.scenery_small.tct": {
         "reference-name": "Cabbage Tree",
-        "name": "Arbo de Andira Inermis"
+        "name": "Arbo de Andira inermis"
     },
     "rct2.scenery_small.tct1": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_small.tct2": {
         "reference-name": "Castle Tower",
-        "name": "Turo de Kastelo"
+        "name": "Turo de kastelo"
     },
     "rct2.scenery_small.tcy": {
         "reference-name": "Common Yew Tree",
-        "name": "Eŭropa Taksusoarbo"
+        "name": "Eŭropa taksusoarbo"
     },
     "rct2.scenery_small.tdf": {
         "reference-name": "Dolphin Fountain",
-        "name": "Delfeno-Fontano"
+        "name": "Delfeno-fontano"
     },
     "rct2.scenery_small.tdm": {
         "reference-name": "Diamond Shaped Tree",
-        "name": "Diamantoforma Arbo"
+        "name": "Diamantoforma arbo"
     },
     "rct2.scenery_small.tdn4": {
         "reference-name": "Dinosaur",
@@ -4313,15 +4313,15 @@
     },
     "rct2.scenery_small.tdt1": {
         "reference-name": "Dead Tree",
-        "name": "Morta Arbo"
+        "name": "Morta arbo"
     },
     "rct2.scenery_small.tdt2": {
         "reference-name": "Dead Tree",
-        "name": "Morta Arbo"
+        "name": "Senviva arbo"
     },
     "rct2.scenery_small.tdt3": {
         "reference-name": "Dead Tree",
-        "name": "Morta Arbo"
+        "name": "Senviva arbo"
     },
     "rct2.scenery_small.teepee1": {
         "reference-name": "Tepee",
@@ -4329,11 +4329,11 @@
     },
     "rct2.scenery_small.tef": {
         "reference-name": "Elephant Fountain",
-        "name": "Elefanto-Fontano"
+        "name": "Elefanto-fontano"
     },
     "rct2.scenery_small.tel": {
         "reference-name": "European Larch Tree",
-        "name": "Eŭropa Larikoarbo"
+        "name": "Eŭropa larikoarbo"
     },
     "rct2.scenery_small.ten": {
         "reference-name": "Cleopatra’s Needle",
@@ -4341,19 +4341,19 @@
     },
     "rct2.scenery_small.tep": {
         "reference-name": "Egyptian Column",
-        "name": "Egipta Kolono"
+        "name": "Egipta kolono"
     },
     "rct2.scenery_small.terb": {
         "reference-name": "Stone Block",
-        "name": "Ŝtona Bloko"
+        "name": "Ŝtona bloko"
     },
     "rct2.scenery_small.ters": {
         "reference-name": "Ruined Statue",
-        "name": "Rompita Statuo"
+        "name": "Rompita statuo"
     },
     "rct2.scenery_small.tes1": {
         "reference-name": "Egyptian Statue",
-        "name": "Egipta Statuo"
+        "name": "Egipta statuo"
     },
     "rct2.scenery_small.tf1": {
         "reference-name": "Fruit Tree",
@@ -4457,23 +4457,23 @@
     },
     "rct2.scenery_small.tge1": {
         "reference-name": "Geometric Sculpture",
-        "name": "Geometria Skulptaĵo"
+        "name": "Geometria skulptaĵo"
     },
     "rct2.scenery_small.tge2": {
         "reference-name": "Geometric Sculpture",
-        "name": "Geometria Skulptaĵo"
+        "name": "Geometria skulptaĵo"
     },
     "rct2.scenery_small.tge3": {
         "reference-name": "Geometric Sculpture",
-        "name": "Geometria Skulptaĵo"
+        "name": "Geometria skulptaĵo"
     },
     "rct2.scenery_small.tge4": {
         "reference-name": "Geometric Sculpture",
-        "name": "Geometria Skulptaĵo"
+        "name": "Geometria skulptaĵo"
     },
     "rct2.scenery_small.tge5": {
         "reference-name": "Geometric Sculpture",
-        "name": "Geometria Skulptaĵo"
+        "name": "Geometria skulptaĵo"
     },
     "rct2.scenery_small.tgg": {
         "reference-name": "Gong",
@@ -4489,15 +4489,15 @@
     },
     "rct2.scenery_small.tghc": {
         "reference-name": "Golden Hinoki Cypress Tree",
-        "name": "Ora Japana Cipresarbo"
+        "name": "Ora japana cipresarbo"
     },
     "rct2.scenery_small.tghc2": {
         "reference-name": "Hiba Tree",
-        "name": "Arbo de Thujopsis Dolabrata"
+        "name": "Tujopsarbo"
     },
     "rct2.scenery_small.tgs": {
         "reference-name": "Giraffe Statue",
-        "name": "Statuo de Ĝirafo"
+        "name": "Statuo de ĝirafo"
     },
     "rct2.scenery_small.tgs1": {
         "reference-name": "Grave Stone",
@@ -4517,7 +4517,7 @@
     },
     "rct2.scenery_small.th1": {
         "reference-name": "Canary Palm Tree",
-        "name": "Kanaria Palmarbo"
+        "name": "Kanaria palmarbo"
     },
     "rct2.scenery_small.th2": {
         "reference-name": "Palm Tree",
@@ -4525,19 +4525,19 @@
     },
     "rct2.scenery_small.thl": {
         "reference-name": "Honey Locust Tree",
-        "name": "Kristodorna Glediĉioarbo"
+        "name": "Kristodorna glediĉioarbo"
     },
     "rct2.scenery_small.thrs": {
         "reference-name": "Horseman Statue",
-        "name": "Statuo de Ĉevalrajdanto"
+        "name": "Statuo de ĉevalrajdanto"
     },
     "rct2.scenery_small.tht": {
         "reference-name": "Heart Shaped Tree",
-        "name": "Korforma Arbo"
+        "name": "Kerforma arbo"
     },
     "rct2.scenery_small.tic": {
         "reference-name": "Incense Cedar Tree",
-        "name": "Bonodorfumo-Cedroarbo"
+        "name": "Bonodorfumo-cedroarbo"
     },
     "rct2.scenery_small.tig": {
         "reference-name": "Igloo",
@@ -4545,7 +4545,7 @@
     },
     "rct2.scenery_small.titc": {
         "reference-name": "Italian Cypress Tree",
-        "name": "Mediteranea Cipresoarbo"
+        "name": "Mediteranea cipresoarbo"
     },
     "rct2.scenery_small.tjb1": {
         "reference-name": "Bush",
@@ -4601,19 +4601,19 @@
     },
     "rct2.scenery_small.tk1": {
         "reference-name": "White Knight",
-        "name": "Blanka Kavaliro"
+        "name": "Blanka kavaliro"
     },
     "rct2.scenery_small.tk2": {
         "reference-name": "Black Knight",
-        "name": "Nigra Kavaliro"
+        "name": "Nigra kavaliro"
     },
     "rct2.scenery_small.tk3": {
         "reference-name": "White King",
-        "name": "Blanka Reĝo"
+        "name": "Blanka reĝo"
     },
     "rct2.scenery_small.tk4": {
         "reference-name": "Black King",
-        "name": "Nigra Reĝo"
+        "name": "Nigra reĝo"
     },
     "rct2.scenery_small.tl0": {
         "reference-name": "Tree",
@@ -4633,11 +4633,11 @@
     },
     "rct2.scenery_small.tlc": {
         "reference-name": "Lawson Cypress Tree",
-        "name": "Lawson-Cipresoarbo"
+        "name": "Lawson-cipresoarbo"
     },
     "rct2.scenery_small.tlp": {
         "reference-name": "Lombardy Poplar Tree",
-        "name": "Lombardy Poploarbo"
+        "name": "Tabriza poploarbo"
     },
     "rct2.scenery_small.tly": {
         "reference-name": "Lily",
@@ -4661,7 +4661,7 @@
     },
     "rct2.scenery_small.tmbj": {
         "reference-name": "Meyer’s Blue Juniper Tree",
-        "name": "Blua Juniperoarbo de Meyer"
+        "name": "Blua juniperoarbo de Meyer"
     },
     "rct2.scenery_small.tmc": {
         "reference-name": "Monterey Cypress Tree",
@@ -4681,15 +4681,15 @@
     },
     "rct2.scenery_small.tmm1": {
         "reference-name": "Graveyard Monument",
-        "name": "Momumento de Tombejo"
+        "name": "Momumento de tombejo"
     },
     "rct2.scenery_small.tmm2": {
         "reference-name": "Graveyard Monument",
-        "name": "Momumento de Tombejo"
+        "name": "Momumento de tombejo"
     },
     "rct2.scenery_small.tmm3": {
         "reference-name": "Graveyard Monument",
-        "name": "Momumento de Tombejo"
+        "name": "Momumento de tombejo"
     },
     "rct2.scenery_small.tmo1": {
         "reference-name": "Martian Object",
@@ -4713,7 +4713,7 @@
     },
     "rct2.scenery_small.tmp": {
         "reference-name": "Monkey-Puzzle Tree",
-        "name": "Ĉilia Araŭkarioarbo"
+        "name": "Ĉilia araŭkarioarbo"
     },
     "rct2.scenery_small.tms1": {
         "reference-name": "Toadstool",
@@ -4733,7 +4733,7 @@
     },
     "rct2.scenery_small.tnss": {
         "reference-name": "Snow-covered Norway Spruce Tree",
-        "name": "Neĝkovrita Abipiceoarbo"
+        "name": "Neĝkovrita abipiceoarbo"
     },
     "rct2.scenery_small.tntroof1": {
         "reference-name": "Canvas Roof",
@@ -4753,11 +4753,11 @@
     },
     "rct2.scenery_small.torn1": {
         "reference-name": "Ornamental Tree",
-        "name": "Ornama Arbo"
+        "name": "Ornama arbo"
     },
     "rct2.scenery_small.torn2": {
         "reference-name": "Ornamental Tree",
-        "name": "Ornama Arbo"
+        "name": "Ornama arbo"
     },
     "rct2.scenery_small.tos": {
         "reference-name": "Statue",
@@ -4781,15 +4781,15 @@
     },
     "rct2.scenery_small.totem1": {
         "reference-name": "Totem Pole",
-        "name": "Totema Paliso"
+        "name": "Totema paliso"
     },
     "rct2.scenery_small.tp1": {
         "reference-name": "White Pawn",
-        "name": "Blanka Peono"
+        "name": "Blanka peono"
     },
     "rct2.scenery_small.tp2": {
         "reference-name": "Black Pawn",
-        "name": "Nigra Peono"
+        "name": "Nigra peono"
     },
     "rct2.scenery_small.tpm": {
         "reference-name": "Palm Tree",
@@ -4797,47 +4797,47 @@
     },
     "rct2.scenery_small.tq1": {
         "reference-name": "White Queen",
-        "name": "Blanka Reĝino"
+        "name": "Blanka reĝino"
     },
     "rct2.scenery_small.tq2": {
         "reference-name": "Black Queen",
-        "name": "Nigra Reĝino"
+        "name": "Nigra reĝino"
     },
     "rct2.scenery_small.tqf": {
         "reference-name": "Cupid Fountains",
-        "name": "Kupido-Fontanoj"
+        "name": "Kupido-fontanoj"
     },
     "rct2.scenery_small.tr1": {
         "reference-name": "White Rook",
-        "name": "Blanka Turo"
+        "name": "Blanka turo"
     },
     "rct2.scenery_small.tr2": {
         "reference-name": "Black Rook",
-        "name": "Nigra Turo"
+        "name": "Nigra turo"
     },
     "rct2.scenery_small.trc": {
         "reference-name": "Roman Column",
-        "name": "Roma Kolono"
+        "name": "Romia kolono"
     },
     "rct2.scenery_small.trf": {
         "reference-name": "Red Fir Tree",
-        "name": "Ruĝa Abioarbo"
+        "name": "Ruĝa abioarbo"
     },
     "rct2.scenery_small.trf2": {
         "reference-name": "Red Fir Tree",
-        "name": "Ruĝa Abioarbo"
+        "name": "Ruĝa abioarbo"
     },
     "rct2.scenery_small.trf3": {
         "reference-name": "Snow-covered Red Fir Tree",
-        "name": "Neĝkovrita Ruĝa Abioarbo"
+        "name": "Neĝkovrita ruĝa abioarbo"
     },
     "rct2.scenery_small.trfs": {
         "reference-name": "Snow-covered Red Fir Tree",
-        "name": "Neĝkovrita Ruĝa Abioarbo"
+        "name": "Neĝkovrita ruĝa abioarbo"
     },
     "rct2.scenery_small.trms": {
         "reference-name": "Roman Statue",
-        "name": "Roma Statuo"
+        "name": "Romia statuo"
     },
     "rct2.scenery_small.tropt1": {
         "reference-name": "Tree",
@@ -4845,7 +4845,7 @@
     },
     "rct2.scenery_small.trws": {
         "reference-name": "Roman Statue",
-        "name": "Roma Statuo"
+        "name": "Romia statuo"
     },
     "rct2.scenery_small.ts0": {
         "reference-name": "Tree",
@@ -4865,19 +4865,19 @@
     },
     "rct2.scenery_small.ts4": {
         "reference-name": "Ornamental Tree",
-        "name": "Ornama Arbo"
+        "name": "Ornama arbo"
     },
     "rct2.scenery_small.ts5": {
         "reference-name": "Ornamental Tree",
-        "name": "Ornama Arbo"
+        "name": "Ornama arbo"
     },
     "rct2.scenery_small.ts6": {
         "reference-name": "Ornamental Tree",
-        "name": "Ornama Arbo"
+        "name": "Ornama arbo"
     },
     "rct2.scenery_small.tsb": {
         "reference-name": "Silver Birch Tree",
-        "name": "Penda Betuloarbo"
+        "name": "Penda betuloarbo"
     },
     "rct2.scenery_small.tsc": {
         "reference-name": "Cactus",
@@ -4889,23 +4889,23 @@
     },
     "rct2.scenery_small.tscp": {
         "reference-name": "Space Capsule",
-        "name": "Kosma Kapsulo"
+        "name": "Kosma kapsulo"
     },
     "rct2.scenery_small.tsd": {
         "reference-name": "Spade Shaped Tree",
-        "name": "Pikforma Arbo"
+        "name": "Pikforma arbo"
     },
     "rct2.scenery_small.tsf1": {
         "reference-name": "Giant Snowflake",
-        "name": "Giganta Neĝero"
+        "name": "Giganta neĝero"
     },
     "rct2.scenery_small.tsf2": {
         "reference-name": "Giant Snowflake",
-        "name": "Giganta Neĝero"
+        "name": "Giganta neĝero"
     },
     "rct2.scenery_small.tsf3": {
         "reference-name": "Giant Snowflake",
-        "name": "Giganta Neĝero"
+        "name": "Giganta neĝero"
     },
     "rct2.scenery_small.tsg": {
         "reference-name": "Swamp Goo",
@@ -4913,7 +4913,7 @@
     },
     "rct2.scenery_small.tsh": {
         "reference-name": "Horse Statue",
-        "name": "Statuo de Ĉevalo"
+        "name": "Statuo de ĉevalo"
     },
     "rct2.scenery_small.tsh0": {
         "reference-name": "Bush",
@@ -4961,7 +4961,7 @@
     },
     "rct2.scenery_small.tsp": {
         "reference-name": "Scots Pine Tree",
-        "name": "Arbara Pinoarbo"
+        "name": "Arbara pinoarbo"
     },
     "rct2.scenery_small.tsp1": {
         "reference-name": "Tree",
@@ -4977,7 +4977,7 @@
     },
     "rct2.scenery_small.tsq": {
         "reference-name": "Squirrel Shaped Tree",
-        "name": "Sciurforma Arbo"
+        "name": "Sciurforma arbo"
     },
     "rct2.scenery_small.tst1": {
         "reference-name": "Toadstool",
@@ -5001,11 +5001,11 @@
     },
     "rct2.scenery_small.tstd": {
         "reference-name": "Dolphins Statue",
-        "name": "Statuo de Delfenoj"
+        "name": "Statuo de delfenoj"
     },
     "rct2.scenery_small.tt1": {
         "reference-name": "Roman Temple",
-        "name": "Roma Templo"
+        "name": "Romia templo"
     },
     "rct2.scenery_small.ttf": {
         "reference-name": "Fountain",
@@ -5017,15 +5017,15 @@
     },
     "rct2.scenery_small.tus": {
         "reference-name": "Unicorn Statue",
-        "name": "Statuo de Unikorno"
+        "name": "Statuo de unikorno"
     },
     "rct2.scenery_small.tvl": {
         "reference-name": "Voss’s Laburnam Tree",
-        "name": "Arbo de Laburnam de Voss"
+        "name": "Orpluvarbo"
     },
     "rct2.scenery_small.twf": {
         "reference-name": "Geometric Fountain",
-        "name": "Geometria Fontano"
+        "name": "Geometria fontano"
     },
     "rct2.scenery_small.twh1": {
         "reference-name": "House",
@@ -5033,7 +5033,7 @@
     },
     "rct2.scenery_small.twh2": {
         "reference-name": "Pumpkin House",
-        "name": "Kukurbo-Domo"
+        "name": "Kukurbo-domo"
     },
     "rct2.scenery_small.twn": {
         "reference-name": "Walnut Tree",
@@ -5041,7 +5041,7 @@
     },
     "rct2.scenery_small.twp": {
         "reference-name": "White Poplar Tree",
-        "name": "Blanka Poploarbo"
+        "name": "Blanka poploarbo"
     },
     "rct2.scenery_small.tww": {
         "reference-name": "Weeping Willow Tree",
@@ -5069,7 +5069,7 @@
     },
     "rct2.scenery_small.whoriz": {
         "reference-name": "Water Jet",
-        "name": "Akvo-Ajuto"
+        "name": "Akvo-ajuto"
     },
     "rct2.scenery_small.wspout": {
         "reference-name": "Water Spout",
@@ -5093,7 +5093,7 @@
     },
     "rct2.scenery_wall.wallbb34": {
         "reference-name": "Stone Wall",
-        "name": "Ŝtona Muro"
+        "name": "Ŝtona muro"
     },
     "rct2.scenery_wall.wallbb8": {
         "reference-name": "Wall",
@@ -5173,7 +5173,7 @@
     },
     "rct2.scenery_wall.wallco16": {
         "reference-name": "Corrugated Steel Wall",
-        "name": "Onda Ŝtala Muro"
+        "name": "Onda ŝtala muro"
     },
     "rct2.scenery_wall.wallcw32": {
         "reference-name": "Wall",
@@ -5193,27 +5193,27 @@
     },
     "rct2.scenery_wall.wallgl16": {
         "reference-name": "Glass Wall",
-        "name": "Vitra Muro"
+        "name": "Vitra muro"
     },
     "rct2.scenery_wall.wallgl32": {
         "reference-name": "Glass Wall",
-        "name": "Vitra Muro"
+        "name": "Vitra muro"
     },
     "rct2.scenery_wall.wallgl8": {
         "reference-name": "Glass Wall",
-        "name": "Vitra Muro"
+        "name": "Vitra muro"
     },
     "rct2.scenery_wall.wallig16": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2.scenery_wall.wallig24": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2.scenery_wall.walljb16": {
         "reference-name": "Jellybean Wall",
-        "name": "Muro el Ĝelateno-Faboj"
+        "name": "Muro el ĝelateno-faboj"
     },
     "rct2.scenery_wall.walljn32": {
         "reference-name": "Wall",
@@ -5221,7 +5221,7 @@
     },
     "rct2.scenery_wall.walllt32": {
         "reference-name": "Steel Latticework",
-        "name": "Ŝtala Kradaĵo"
+        "name": "Ŝtala kradaĵo"
     },
     "rct2.scenery_wall.wallmm16": {
         "reference-name": "Railings",
@@ -5237,11 +5237,11 @@
     },
     "rct2.scenery_wall.wallnt32": {
         "reference-name": "Tennis Net Wall",
-        "name": "Retmuro de Teniso"
+        "name": "Tenisa retmuro"
     },
     "rct2.scenery_wall.wallnt33": {
         "reference-name": "Tennis Net Wall",
-        "name": "Retmuro de Teniso"
+        "name": "Tenisa retmuro"
     },
     "rct2.scenery_wall.wallpg32": {
         "reference-name": "Wall",
@@ -5293,7 +5293,7 @@
     },
     "rct2.scenery_wall.wallsign": {
         "reference-name": "Scrolling Sign",
-        "name": "Rulumanta Afiŝo"
+        "name": "Rulumanta afiŝo"
     },
     "rct2.scenery_wall.wallsk16": {
         "reference-name": "Wall",
@@ -5309,23 +5309,23 @@
     },
     "rct2.scenery_wall.wallst16": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_wall.wallst32": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_wall.wallst8": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_wall.wallstfn": {
         "reference-name": "Steel Fence",
-        "name": "Ŝtala Barilo"
+        "name": "Ŝtala barilo"
     },
     "rct2.scenery_wall.wallstwn": {
         "reference-name": "Steel Wall",
-        "name": "Ŝtala Muro"
+        "name": "Ŝtala muro"
     },
     "rct2.scenery_wall.walltn32": {
         "reference-name": "Poles",
@@ -5333,7 +5333,7 @@
     },
     "rct2.scenery_wall.walltxgt": {
         "reference-name": "‘Texas Giant’ Sign",
-        "name": "‘Texas Giant’ Afiŝo"
+        "name": "Afiŝo ‘Texas Giant’"
     },
     "rct2.scenery_wall.wallu132": {
         "reference-name": "Wall",
@@ -5345,11 +5345,11 @@
     },
     "rct2.scenery_wall.wallwd16": {
         "reference-name": "Wooden Wall",
-        "name": "Ligna Muro"
+        "name": "Ligna muro"
     },
     "rct2.scenery_wall.wallwd32": {
         "reference-name": "Wooden Wall",
-        "name": "Ligna Muro"
+        "name": "Ligna muro"
     },
     "rct2.scenery_wall.wallwd33": {
         "reference-name": "Wooden Wall",
@@ -5357,11 +5357,11 @@
     },
     "rct2.scenery_wall.wallwd8": {
         "reference-name": "Wooden Wall",
-        "name": "Ligna Muro"
+        "name": "Ligna muro"
     },
     "rct2.scenery_wall.wallwdps": {
         "reference-name": "Wooden Post Fence",
-        "name": "Barilo el Lignaj Fostoj"
+        "name": "Barilo el lignaj fostoj"
     },
     "rct2.scenery_wall.wallwf32": {
         "reference-name": "Waterfall",
@@ -5369,51 +5369,51 @@
     },
     "rct2.scenery_wall.wbr1": {
         "reference-name": "Brick Wall",
-        "name": "Brika Muro"
+        "name": "Brika muro"
     },
     "rct2.scenery_wall.wbr1a": {
         "reference-name": "Brick Wall",
-        "name": "Brika Muro"
+        "name": "Brika muro"
     },
     "rct2.scenery_wall.wbr2": {
         "reference-name": "Stone Wall",
-        "name": "Ŝtona Muro"
+        "name": "Ŝtona muro"
     },
     "rct2.scenery_wall.wbr2a": {
         "reference-name": "Stone Wall",
-        "name": "Ŝtona Muro"
+        "name": "Ŝtona muro"
     },
     "rct2.scenery_wall.wbr3": {
         "reference-name": "Stone Wall",
-        "name": "Ŝtona Muro"
+        "name": "Ŝtona muro"
     },
     "rct2.scenery_wall.wbrg": {
         "reference-name": "Brick Wall",
-        "name": "Brika Muro"
+        "name": "Brika muro"
     },
     "rct2.scenery_wall.wbw": {
         "reference-name": "Bone Fence",
-        "name": "Barilo de Ostoj"
+        "name": "Barilo de ostoj"
     },
     "rct2.scenery_wall.wc1": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc10": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc11": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc12": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc13": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc14": {
         "reference-name": "Wall",
@@ -5429,75 +5429,75 @@
     },
     "rct2.scenery_wall.wc17": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct2.scenery_wall.wc18": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "rct2.scenery_wall.wc2": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc3": {
         "reference-name": "Roman Column Wall",
-        "name": "Muro de Roma Kolono"
+        "name": "Muro de romia kolono"
     },
     "rct2.scenery_wall.wc4": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc5": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc6": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc7": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc8": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wc9": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2.scenery_wall.wch": {
         "reference-name": "Conifer Hedge",
-        "name": "Konifera Heĝo"
+        "name": "Konifera heĝo"
     },
     "rct2.scenery_wall.wchg": {
         "reference-name": "Conifer Hedge",
-        "name": "Konifera Heĝo"
+        "name": "Konifera heĝo"
     },
     "rct2.scenery_wall.wcw1": {
         "reference-name": "Playing Card Wall",
-        "name": "Muro el Ludkartoj"
+        "name": "Muro el ludkartoj"
     },
     "rct2.scenery_wall.wcw2": {
         "reference-name": "Playing Card Wall",
-        "name": "Muro el Ludkartoj"
+        "name": "Muro el ludkartoj"
     },
     "rct2.scenery_wall.wew": {
         "reference-name": "Egyptian Wall",
-        "name": "Egipta Muro"
+        "name": "Egipta muro"
     },
     "rct2.scenery_wall.wfw1": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct2.scenery_wall.wfwg": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct2.scenery_wall.wgw2": {
         "reference-name": "Glass Wall",
-        "name": "Vitra Muro"
+        "name": "Vitra muro"
     },
     "rct2.scenery_wall.whg": {
         "reference-name": "Hedge",
@@ -5509,23 +5509,23 @@
     },
     "rct2.scenery_wall.wjf": {
         "reference-name": "Jungle Fence",
-        "name": "Ĝangalo-Barilo"
+        "name": "Ĝangalo-barilo"
     },
     "rct2.scenery_wall.wmf": {
         "reference-name": "Mesh Fence",
-        "name": "Maŝa Barilo"
+        "name": "Maŝa barilo"
     },
     "rct2.scenery_wall.wmfg": {
         "reference-name": "Mesh Fence",
-        "name": "Maŝa Barilo"
+        "name": "Maŝa barilo"
     },
     "rct2.scenery_wall.wmw": {
         "reference-name": "Martian Wall",
-        "name": "Marsa Muro"
+        "name": "Marsa muro"
     },
     "rct2.scenery_wall.wmww": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct2.scenery_wall.wpf": {
         "reference-name": "Fence",
@@ -5537,23 +5537,23 @@
     },
     "rct2.scenery_wall.wpw1": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "rct2.scenery_wall.wpw2": {
         "reference-name": "Wooden Post Wall",
-        "name": "Muro el Lignaj Fostoj"
+        "name": "Muro el lignaj fostoj"
     },
     "rct2.scenery_wall.wpw3": {
         "reference-name": "Wooden Fence",
-        "name": "Ligna Barilo"
+        "name": "Ligna barilo"
     },
     "rct2.scenery_wall.wrw": {
         "reference-name": "Roman Wall",
-        "name": "Roma Muro"
+        "name": "Romia muro"
     },
     "rct2.scenery_wall.wrwa": {
         "reference-name": "Roman Wall",
-        "name": "Roma Muro"
+        "name": "Romia muro"
     },
     "rct2.scenery_wall.wsw": {
         "reference-name": "Railings",
@@ -5573,11 +5573,11 @@
     },
     "rct2.scenery_wall.wwtw": {
         "reference-name": "Tall Wooden Fence",
-        "name": "Alta Ligna Barilo"
+        "name": "Alta ligna barilo"
     },
     "rct2.scenery_wall.wwtwa": {
         "reference-name": "Wooden Fence Wall",
-        "name": "Ligna Barilo-Muro"
+        "name": "Ligna barilo-muro"
     },
     "rct2.station.abstract": {
         "reference-name": "Abstract",
@@ -5585,23 +5585,23 @@
     },
     "rct2.station.canvas_tent": {
         "reference-name": "Canvas Tent",
-        "name": "Kanvasa Tendo"
+        "name": "Kanvasa tendo"
     },
     "rct2.station.castle_brown": {
         "reference-name": "Castle (Brown)",
-        "name": "Kastelo (Bruna)"
+        "name": "Kastelo (bruna)"
     },
     "rct2.station.castle_grey": {
         "reference-name": "Castle (Grey)",
-        "name": "Kastelo (Griza)"
+        "name": "Kastelo (griza)"
     },
     "rct2.station.classical": {
         "reference-name": "Classical / Roman",
-        "name": "Klasika / Roma"
+        "name": "Klasika / Romia"
     },
     "rct2.station.jungle": {
         "reference-name": "Jungle",
-        "name": "Ĝangalo"
+        "name": "Ĝangala"
     },
     "rct2.station.log": {
         "reference-name": "Log Cabin",
@@ -5617,11 +5617,11 @@
     },
     "rct2.station.snow": {
         "reference-name": "Snow / Ice",
-        "name": "Neĝo / Glacio"
+        "name": "Neĝa / Glacia"
     },
     "rct2.station.space": {
         "reference-name": "Space",
-        "name": "Kosmo"
+        "name": "Kosma"
     },
     "rct2.station.wooden": {
         "reference-name": "Wooden",
@@ -5629,23 +5629,23 @@
     },
     "rct2.terrain_edge.ice": {
         "reference-name": "Ice",
-        "name": "Glacio"
+        "name": "Glacia"
     },
     "rct2.terrain_edge.rock": {
         "reference-name": "Rock",
-        "name": "Ŝtono"
+        "name": "Ŝtona"
     },
     "rct2.terrain_edge.wood_black": {
         "reference-name": "Wood (black)",
-        "name": "Ligno (nigra)"
+        "name": "Ligna (nigra)"
     },
     "rct2.terrain_edge.wood_red": {
         "reference-name": "Wood (red)",
-        "name": "Ligno (ruĝa)"
+        "name": "Ligna (ruĝa)"
     },
     "rct2.terrain_surface.chequerboard": {
         "reference-name": "Chequerboard",
-        "name": "Damludo-Tablo"
+        "name": "Damludo-tablo"
     },
     "rct2.terrain_surface.dirt": {
         "reference-name": "Dirt",
@@ -5657,23 +5657,23 @@
     },
     "rct2.terrain_surface.grass_clumps": {
         "reference-name": "Grass Clumps",
-        "name": "Tufoj da Herbo"
+        "name": "Tufoj da herbo"
     },
     "rct2.terrain_surface.grid_green": {
         "reference-name": "Grid (Green)",
-        "name": "Krado (Verda)"
+        "name": "Krado (verda)"
     },
     "rct2.terrain_surface.grid_purple": {
         "reference-name": "Grid (Purple)",
-        "name": "Krado (Purpura)"
+        "name": "Krado (purpura)"
     },
     "rct2.terrain_surface.grid_red": {
         "reference-name": "Grid (Red)",
-        "name": "Krado (Ruĝa)"
+        "name": "Krado (ruĝa)"
     },
     "rct2.terrain_surface.grid_yellow": {
         "reference-name": "Grid (Yellow)",
-        "name": "Krado (Flava)"
+        "name": "Krado (flava)"
     },
     "rct2.terrain_surface.ice": {
         "reference-name": "Ice",
@@ -5693,35 +5693,35 @@
     },
     "rct2.terrain_surface.sand_brown": {
         "reference-name": "Sand (Brown)",
-        "name": "Sablo (Bruna)"
+        "name": "Sablo (bruna)"
     },
     "rct2.terrain_surface.sand_red": {
         "reference-name": "Sand (Red)",
-        "name": "Sablo (Ruĝa)"
+        "name": "Sablo (ruĝa)"
     },
     "rct2.water.wtrcyan": {
         "reference-name": "Natural Water",
-        "name": "Natura Akvo"
+        "name": "Natura akvo"
     },
     "rct2.water.wtrgreen": {
         "reference-name": "Acid Green Water",
-        "name": "Acidverda Akvo"
+        "name": "Acidverda akvo"
     },
     "rct2.water.wtrgrn": {
         "reference-name": "Green Water",
-        "name": "Verda Akvo"
+        "name": "Verda akvo"
     },
     "rct2.water.wtrorng": {
         "reference-name": "Orange Water",
-        "name": "Oranĝkolora Akvo"
+        "name": "Oranĝkolora akvo"
     },
     "rct2dlc.footpath_item.litterpa": {
         "reference-name": "Panda Litter Bin",
-        "name": "Pando-Rubujo"
+        "name": "Pando-rubujo"
     },
     "rct2dlc.ride.zpanda": {
         "reference-name": "Panda Trains",
-        "name": "Pando-Trajnoj",
+        "name": "Pando-trajnoj",
         "reference-description": "Roller coaster trains with cuddly panda cars",
         "description": "Trajnoj de onda fervojo kun karesigaj pando-ĉaroj",
         "reference-capacity": "1 passenger per car",
@@ -5737,11 +5737,11 @@
     },
     "rct2dlc.scenery_group.scgpanda": {
         "reference-name": "Panda Theming",
-        "name": "Pando-Temo"
+        "name": "Panda temo"
     },
     "rct2dlc.scenery_small.bigpanda": {
         "reference-name": "Giant Panda",
-        "name": "Giganta Pando"
+        "name": "Giganta pando"
     },
     "rct2dlc.scenery_small.pandagr": {
         "reference-name": "Bamboo Shoots",
@@ -5749,11 +5749,11 @@
     },
     "rct2dlc.water.wtrpink": {
         "reference-name": "Pink Water",
-        "name": "Rozkolora Akvo"
+        "name": "Rozkolora akvo"
     },
     "rct2tt.footpath_item.firhydrt": {
         "reference-name": "Fire Hydrant",
-        "name": "Fajro-Hidranto"
+        "name": "Fajro-hidranto"
     },
     "rct2tt.footpath_item.medbench": {
         "reference-name": "Benches",
@@ -5761,43 +5761,43 @@
     },
     "rct2tt.footpath_railings.balustrade": {
         "reference-name": "Balustrade",
-        "name": "Balustrade"
+        "name": "Balustrado"
     },
     "rct2tt.footpath_railings.circuitboard": {
         "reference-name": "Circuit Board Railings",
-        "name": "Cirkvitkartaj Balustradoj"
+        "name": "Cirkvitkartaj balustradoj"
     },
     "rct2tt.footpath_railings.circuitboard_invisible": {
         "reference-name": "Sky Walk",
-        "name": "Ĉiela Vojo"
+        "name": "Ĉiela vojo"
     },
     "rct2tt.footpath_railings.medieval": {
         "reference-name": "Medieval Railings",
-        "name": "Mezepokaj Balustradoj"
+        "name": "Mezepokaj balustradoj"
     },
     "rct2tt.footpath_railings.pavement": {
         "reference-name": "Iron Railings",
-        "name": "Feraj Balustradoj"
+        "name": "Feraj balustradoj"
     },
     "rct2tt.footpath_railings.rainbow": {
         "reference-name": "Rainbow Railings",
-        "name": "Ĉielarkaj Balustradoj"
+        "name": "Ĉielarkaj balustradoj"
     },
     "rct2tt.footpath_railings.rocky": {
         "reference-name": "Jungle Railings",
-        "name": "Ĝangalaj Balustradoj"
+        "name": "Ĝangalaj balustradoj"
     },
     "rct2tt.footpath_surface.circuitboard": {
         "reference-name": "Circuit Footpath",
-        "name": "Cirkvitkarta Trotuaro"
+        "name": "Elektrocirkvita trotuaro"
     },
     "rct2tt.footpath_surface.medieval": {
         "reference-name": "Wooden Footpath",
-        "name": "Ligna Trotuaro"
+        "name": "Ligna trotuaro"
     },
     "rct2tt.footpath_surface.mosaic": {
         "reference-name": "Mosaic Footpath",
-        "name": "Mozaiko-Trotuaro"
+        "name": "Mozaika trotuaro"
     },
     "rct2tt.footpath_surface.pavement": {
         "reference-name": "Pavement",
@@ -5805,23 +5805,23 @@
     },
     "rct2tt.footpath_surface.queue_circuitboard": {
         "reference-name": "Circuit Queue",
-        "name": "Cirkvitkarta Atendovico"
+        "name": "Elektrocirkvita atendovico"
     },
     "rct2tt.footpath_surface.queue_pavement": {
         "reference-name": "Pavement Queue",
-        "name": "Pavima Atendovico"
+        "name": "Pavima atendovico"
     },
     "rct2tt.footpath_surface.queue_rainbow": {
         "reference-name": "Rainbow Queue",
-        "name": "Ĉielarka Atendovico"
+        "name": "Ĉielarka atendovico"
     },
     "rct2tt.footpath_surface.rainbow": {
         "reference-name": "Rainbow Footpath",
-        "name": "Ĉielarka Trotuaro"
+        "name": "Ĉielarka trotuaro"
     },
     "rct2tt.footpath_surface.rocky": {
         "reference-name": "Rocky Footpath",
-        "name": "Roka Trotuaro"
+        "name": "Roka trotuaro"
     },
     "rct2tt.park_entrance.1920sent": {
         "reference-name": "Roaring Twenties Park Entrance",
@@ -5829,27 +5829,27 @@
     },
     "rct2tt.park_entrance.futurent": {
         "reference-name": "Futuristic Park Entrance",
-        "name": "Estonteca Parkenirejo"
+        "name": "Estonteca parkenirejo"
     },
     "rct2tt.park_entrance.gldyrent": {
         "reference-name": "Rock ’n’ Roll Park Entrance",
-        "name": "Parkenirejo de Rokenrolo"
+        "name": "Rokenrola parkenirejo"
     },
     "rct2tt.park_entrance.jurasent": {
         "reference-name": "Prehistoric Entrance",
-        "name": "Praa Enirejo"
+        "name": "Praa enirejo"
     },
     "rct2tt.park_entrance.medientr": {
         "reference-name": "Dark Age Entrance",
-        "name": "Malluma Epoko-Enirejo"
+        "name": "Mallum-epoka enirejo"
     },
     "rct2tt.park_entrance.mythentr": {
         "reference-name": "Mythological Entrance",
-        "name": "Mitologia Enirejo"
+        "name": "Mitologia enirejo"
     },
     "rct2tt.ride.1920racr": {
         "reference-name": "1920s Racing Cars",
-        "name": "Vetkuraŭtoj de la 1920-aj",
+        "name": "Vetkuraŭtoj de la 1920-aj jaroj",
         "reference-description": "1920s race car themed go-karts",
         "description": "Gokartoj kun temo de 1920-aj vetkuraŭtoj",
         "reference-capacity": "Single-seater",
@@ -5857,13 +5857,13 @@
     },
     "rct2tt.ride.1920sand": {
         "reference-name": "Art Deco Food Stall",
-        "name": "Artdekora Manĝaĵbudo",
+        "name": "Artdekora manĝaĵbudo",
         "reference-description": "A stall selling noodles and fresh Lemonade",
         "description": "Budo vendanta nudelojn kaj freŝan Limonadon"
     },
     "rct2tt.ride.1960tsrt": {
         "reference-name": "Flower Power T-Shirts",
-        "name": "Florpotencaj T-Ĉemizoj",
+        "name": "Florpotencaj T-ĉemizoj",
         "reference-description": "Stall selling T-shirts with a flower motif",
         "description": "Budo vendanta T-ĉemizojn kun motivo de floro"
     },
@@ -5877,7 +5877,7 @@
     },
     "rct2tt.ride.battrram": {
         "reference-name": "Battering Ram Trains",
-        "name": "Ramilego-Trajnoj",
+        "name": "Ramilego-trajnoj",
         "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like battering rams from the Dark Age",
         "description": "Kompaktaj trajnoj de onda fervojo kun ĉaroj kun kolono da seĝoj, temitaj por aspekti kiel ramilegoj de la Malluma Epoko",
         "reference-capacity": "6 passengers per car",
@@ -5893,7 +5893,7 @@
     },
     "rct2tt.ride.bmvoctps": {
         "reference-name": "Blob from Outer Space",
-        "name": "Aĵo de Kosmospaco",
+        "name": "Aĵo de kosmospaco",
         "reference-description": "A themed rotating observation cabin shaped like a blob from a sci-fi B-film",
         "description": "Temita turniĝanta kajuto formita kiel iu aĵo de sciencofiksia B-filmo",
         "reference-capacity": "32 passengers",
@@ -5901,15 +5901,15 @@
     },
     "rct2tt.ride.cavmncar": {
         "reference-name": "Caveman Cars",
-        "name": "Kavernhomo-Aŭtoj",
+        "name": "Kavernhomo-aŭtoj",
         "reference-description": "Self-drive go-karts in Stone Age style",
-        "description": "Gokartoj kun Ŝtonepoka stilo",
+        "description": "Gokartoj kun ŝtonepoka stilo",
         "reference-capacity": "Single-seater",
         "capacity": "Po 1 pasaĝero por aŭto"
     },
     "rct2tt.ride.cerberus": {
         "reference-name": "Cerberus Trains",
-        "name": "Cerbero-Trajnoj",
+        "name": "Cerbero-trajnoj",
         "reference-description": "Spacious trains with simple lap restraints with cars shaped like the multi-headed dog from the Underworld",
         "description": "Grandspacoj trajnoj kun simplaj sinobridoj, kaj ĉaroj, kiuj aspektas kiel la hundo de la infero kun multaj kapoj",
         "reference-capacity": "4 passengers per car",
@@ -5917,7 +5917,7 @@
     },
     "rct2tt.ride.cyclopsx": {
         "reference-name": "Cyclops Dodgems",
-        "name": "Ciklopaj Doĝemoj",
+        "name": "Ciklopaj kunfrapemaj aŭtetoj",
         "reference-description": "Riders drive the Eye of a Giant Cyclops",
         "description": "Rajdantoj stiras la Okulon de Giganta Ciklopo",
         "reference-capacity": "1 person per car",
@@ -5925,7 +5925,7 @@
     },
     "rct2tt.ride.dinoeggs": {
         "reference-name": "Dinosaur Egg Ride",
-        "name": "Dinosaŭro-Ovo-Atrakcio",
+        "name": "Dinosaŭro-ovo-atrakcio",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated mother dinosaur",
         "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ animita patrino-dinosaŭro",
         "reference-capacity": "18 passengers",
@@ -5933,7 +5933,7 @@
     },
     "rct2tt.ride.dragnfly": {
         "reference-name": "Dragonfly Cars",
-        "name": "Libelo-Ĉaroj",
+        "name": "Libelo-ĉaroj",
         "reference-description": "Dragonfly-shaped cars which swing from the rail above",
         "description": "Libeloformaj ĉaroj, kiuj svingiĝas sub la relo supere",
         "reference-capacity": "2 passengers per car",
@@ -5941,9 +5941,9 @@
     },
     "rct2tt.ride.figtknit": {
         "reference-name": "Fighting Knights Dodgems",
-        "name": "Doĝemoj de Batantaj Kavaliroj",
+        "name": "Aŭtetoj de Batantaj Kavaliroj",
         "reference-description": "Riders joust on horse-themed dodgems",
-        "description": "Rajdantoj batalas sur ĉevalo-temitaj doĝemoj",
+        "description": "Rajdantoj batalas sur ĉevalo-temitaj kunfrapantaj aŭtetoj",
         "reference-capacity": "1 person per car",
         "capacity": "Po 1 ulo por ĉaro"
     },
@@ -5957,7 +5957,7 @@
     },
     "rct2tt.ride.flwrpowr": {
         "reference-name": "Flower Power Dodgems",
-        "name": "Florpotencaj Doĝemoj",
+        "name": "Florpotencaj kunfrapemaj aŭtetoj",
         "reference-description": "Riders ride in flower-shaped hovercraft vehicles that they freely control",
         "description": "Rajdantoj rajdas en floroformaj kusenveturiloj, kiujn ili stiras libere",
         "reference-capacity": "1 passenger per car",
@@ -5965,7 +5965,7 @@
     },
     "rct2tt.ride.flygboat": {
         "reference-name": "Flying Boats",
-        "name": "Flugantaj Boatoj",
+        "name": "Flugantaj boatoj",
         "reference-description": "Roller coaster cars shaped like flying boats",
         "description": "Ĉaroj de onda fervojo formitaj kiel flugantaj boatoj",
         "reference-capacity": "6 passengers per boat",
@@ -5973,7 +5973,7 @@
     },
     "rct2tt.ride.funhouse": {
         "reference-name": "Fun House",
-        "name": "Konstruaĵo de Amuzo",
+        "name": "Konstruaĵo de amuzo",
         "reference-description": "Building containing moving walls and floors to disorientate people walking through it",
         "description": "Konstruaĵo, kiu enhavas movantajn murojn kaj plankojn por malorienti homojn irante tra tie",
         "reference-capacity": "5 guests",
@@ -5981,23 +5981,23 @@
     },
     "rct2tt.ride.ganstrcr": {
         "reference-name": "Gangster Cars",
-        "name": "Gangstero-Aŭtoj",
+        "name": "Gangstero-aŭtoj",
         "reference-description": "1920s-themed gangster cars are accelerated out of the station by linear induction motors to speed through twisting inversions",
-        "description": "Linearaj induktaj motoroj plirapidigas gangstero-aŭtojn, kiuj havas 1920-ajn temon, el la stacio por rapidiri tra kurboplenaj inversigoj",
+        "description": "Linearaj induktaj motoroj plirapidigas gangstero-aŭtojn, temitaj de la 1920-aj jaroj, el la stacio por rapidiri tra kurboplenaj inversigoj",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2tt.ride.gintspdr": {
         "reference-name": "B-Movie Giant Spider Ride",
-        "name": "Atrakcio de B-Filmo Giganta Araneo",
+        "name": "B-filmo-stila rajdo sur giganta araneo",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a giant B-Movie spider",
-        "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ giganta B-Filmo araneo",
+        "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ giganta B-filma araneo",
         "reference-capacity": "18 passengers",
         "capacity": "18 pasaĝeroj"
     },
     "rct2tt.ride.halofmrs": {
         "reference-name": "Hall of Mirrors",
-        "name": "Koridoro da Speguloj",
+        "name": "Koridoro da speguloj",
         "reference-description": "Building containing warped mirrors which distort the reflection of the viewer",
         "description": "Konstruaĵo, kiu enhavas torditajn spegulojn, kiuj tordas la rebrilon de la vidanto",
         "reference-capacity": "5 guests",
@@ -6005,7 +6005,7 @@
     },
     "rct2tt.ride.harpiesx": {
         "reference-name": "Harpies Trains",
-        "name": "Harpio-Trajnoj",
+        "name": "Harpio-trajnoj",
         "reference-description": "Roller coaster trains in the shape of mythological bird-like creatures. Riders are held in special harnesses in a lying-down position, travelling either on their backs or facing the ground",
         "description": "Trajnoj de onda fervojo, kiuj havas la formon de mitologiaj birdecaj bestoj. Rajdantoj estas tenitaj en specialaj jungaĵoj, kaj veturas aŭ fronte al la ĉielo, aŭ fronte al la tero.",
         "reference-capacity": "4 passengers per car",
@@ -6013,15 +6013,15 @@
     },
     "rct2tt.ride.hotrodxx": {
         "reference-name": "Hot Rod Trains",
-        "name": "Hot-Rod Trajnoj",
+        "name": "Hot-rod-stilaj trajnoj",
         "reference-description": "Air-powered launched roller coaster trains in the shape of hot rod cars",
-        "description": "Trajnoj de onda fervojo, lanĉitaj per aero kaj formitaj kiel hot-rod-aj aŭtoj",
+        "description": "Trajnoj de onda fervojo, lanĉitaj per aero, kaj formitaj kiel stratvetkur-modifitaj aŭtoj de frua 20a jarcento",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct2tt.ride.hoverbke": {
         "reference-name": "Hover Bikes",
-        "name": "Flugpendantaj Bicikloj",
+        "name": "Flugpendantaj bicikloj",
         "reference-description": "Futuristic bike-shaped single vehicles",
         "description": "Estontecaj bicikloformaj individuaj veturiloj",
         "reference-capacity": "2 riders per vehicle",
@@ -6029,7 +6029,7 @@
     },
     "rct2tt.ride.hovercar": {
         "reference-name": "Hover Cars",
-        "name": "Flugpendantaj Aŭtoj",
+        "name": "Flugpendantaj aŭtoj",
         "reference-description": "Maglev technology has been implemented to create the illusion of futuristic hover cars",
         "description": "Teknologio de magneta levitacio estis realigita por krei la iluzion de estontecaj flugpendantaj aŭtoj",
         "reference-capacity": "1 passenger per car",
@@ -6037,7 +6037,7 @@
     },
     "rct2tt.ride.hovrbord": {
         "reference-name": "Hoverboards",
-        "name": "Flugpendantaj Platoj",
+        "name": "Flugpendantaj platoj",
         "reference-description": "Guests ride on a futuristic hoverboard, swinging freely from side to side around corners",
         "description": "Gastoj rajdas sur estonteca flugpendanta plato, kaj svingiĝas libere ĉirkaŭ anguloj",
         "reference-capacity": "2 passengers per car",
@@ -6045,7 +6045,7 @@
     },
     "rct2tt.ride.jetpackx": {
         "reference-name": "Jet Pack Booster",
-        "name": "Plifortigilo de Rakettornistro",
+        "name": "Plifortigilo de rakettornistro",
         "reference-description": "Large jetpack-shaped coaster car for the Reverse Freefall Coaster",
         "description": "Granda rakettornistro-forma ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
         "reference-capacity": "8 passengers per car",
@@ -6053,7 +6053,7 @@
     },
     "rct2tt.ride.jetplane": {
         "reference-name": "Jet Plane Cars",
-        "name": "Aeroplano-Ĉaroj",
+        "name": "Aeroplano-ĉaroj",
         "reference-description": "Roller coaster cars in the shape of jet planes",
         "description": "Ĉaroj de onda fervojo formitaj kiel aeroplanoj",
         "reference-capacity": "4 passengers per car",
@@ -6061,7 +6061,7 @@
     },
     "rct2tt.ride.jousting": {
         "reference-name": "Jousting Knights",
-        "name": "Kavaliroj kun Lancoj",
+        "name": "Kavaliroj kun lancoj",
         "reference-description": "Separate horse-shaped vehicles with a jousting knight on the front",
         "description": "Apartaj ĉevaloformaj veturiloj, kun kavaliro kun lanco ĉe la fronto",
         "reference-capacity": "2 riders per vehicle",
@@ -6069,13 +6069,13 @@
     },
     "rct2tt.ride.medisoup": {
         "reference-name": "Witches Brew Soup",
-        "name": "Supo de Sorĉistinoj",
+        "name": "Supo de sorĉistinoj",
         "reference-description": "A stall selling a thick broth-style soup",
         "description": "Budo vendanta densan brogaĵecan supon"
     },
     "rct2tt.ride.mgr2": {
         "reference-name": "Double Deck Carousel",
-        "name": "Duetaĝa Karuselo",
+        "name": "Duetaĝa karuselo",
         "reference-description": "Traditional enclosed double-deck carousel with carved wooden horses",
         "description": "Tradicia nesubĉiela duetaĝa karuselo kun skulptitaj lignaj ĉevaloj",
         "reference-capacity": "32 passengers",
@@ -6083,7 +6083,7 @@
     },
     "rct2tt.ride.microbus": {
         "reference-name": "MicroBus Ride",
-        "name": "Mikrobuso-Atrakcio",
+        "name": "Mikrobuso-atrakcio",
         "reference-description": "Riders view a film inside the Flower Power-themed motion simulator pod while it is twisted and moved around by a hydraulic arm",
         "description": "Rajdantoj vidas filmon en la moviĝado-simulilo, kiu kaj havas temon de la Potenco de Floroj, kaj estas movita kaj turnigita per hidraŭlika brako",
         "reference-capacity": "8 passengers",
@@ -6091,13 +6091,13 @@
     },
     "rct2tt.ride.mktstal1": {
         "reference-name": "Toffee Apple Market Stall",
-        "name": "Sukerpomo-Bazarbudo",
+        "name": "Sukerpomo-bazarbudo",
         "reference-description": "A themed stall selling sticky toffee apples",
         "description": "Temita budo vendanta gluecajn sukerpomojn"
     },
     "rct2tt.ride.mktstal2": {
         "reference-name": "Lemonade Market Stall",
-        "name": "Limonado-Bazarbudo",
+        "name": "Limonado-bazarbudo",
         "reference-description": "A themed stall selling old style, fresh lemonade.",
         "description": "Temita budo vendanta malnovstilan freŝan limonadon"
     },
@@ -6115,7 +6115,7 @@
     },
     "rct2tt.ride.neptunex": {
         "reference-name": "Neptune Ride",
-        "name": "Neptuno-Atrackio",
+        "name": "Neptuno-atrackio",
         "reference-description": "Riders ride in pairs, in themed seats rotating around an animated statue of Neptune",
         "description": "Rajdantoj rajdas pare, en temitaj seĝoj, kiuj turniĝas ĉirkaŭ animita statuo de Neptuno",
         "reference-capacity": "18 passengers",
@@ -6123,7 +6123,7 @@
     },
     "rct2tt.ride.oakbarel": {
         "reference-name": "Oak Barrels",
-        "name": "Kverkaj Bareloj",
+        "name": "Kverkaj bareloj",
         "reference-description": "Oak barrels that turn and splash around as they meander along the river rapids",
         "description": "Kverkaj bareloj, kiuj turniĝas kaj plaŭdas ĉirkaŭe dum ili serpentumas laŭ la rapidfluo",
         "reference-capacity": "8 passengers per boat",
@@ -6131,7 +6131,7 @@
     },
     "rct2tt.ride.pegasusx": {
         "reference-name": "Pegasus Cars",
-        "name": "Pegaso-Ĉaroj",
+        "name": "Pegaso-ĉaroj",
         "reference-description": "Powered vehicles in the shape of Pegasus drawing a cart",
         "description": "Ŝaltitaj veturiloj formitaj kiel Pegaso tiranta ĉaron",
         "reference-capacity": "2 passengers per car",
@@ -6139,7 +6139,7 @@
     },
     "rct2tt.ride.polchase": {
         "reference-name": "Police Car Trains",
-        "name": "Policaj-Aŭtoj-Trajnoj",
+        "name": "Policaj-aŭtoj-trajnoj",
         "reference-description": "Roller coaster trains with lap bars capable of travelling through vertical loops, themed to look like police cars",
         "description": "Trajnoj de onda fervojo kun sinobridoj, kiuj kapablas veturi tra vertikalaj lopoj, kaj estas temitaj por aspeki kiel policajn aŭtojn",
         "reference-capacity": "4 passengers per car",
@@ -6147,7 +6147,7 @@
     },
     "rct2tt.ride.policecr": {
         "reference-name": "Police Cars",
-        "name": "Policaj Aŭtoj",
+        "name": "Policaj aŭtoj",
         "reference-description": "1920s-themed police cars run on wooden tracks, turning around on special reversing sections",
         "description": "1920-aj-temitaj policaj aŭtoj veturas sur lignaj trakoj, kiuj turniĝas sur specialaj inversigantaj partoj",
         "reference-capacity": "6 passengers per car",
@@ -6155,7 +6155,7 @@
     },
     "rct2tt.ride.pterodac": {
         "reference-name": "Pterodactyl Trains",
-        "name": "Pterodaktilo-Trajnoj",
+        "name": "Pterodaktilo-trajnoj",
         "reference-description": "Riders are held in comfortable seats below the track to give the ultimate prehistoric flying experience",
         "description": "Rajdantoj estas tenitaj en komfortaj seĝoj sub la trako por havi la plejan praan sperton de flugado",
         "reference-capacity": "4 passengers per car",
@@ -6163,7 +6163,7 @@
     },
     "rct2tt.ride.raptorxx": {
         "reference-name": "Racing Raptors",
-        "name": "Vetkurantaj Raptoroj",
+        "name": "Vetkurantaj raptoroj",
         "reference-description": "Separate raptor-shaped vehicles",
         "description": "Individuaj raptorformaj veturiloj",
         "reference-capacity": "2 riders per vehicle",
@@ -6179,7 +6179,7 @@
     },
     "rct2tt.ride.schoolbs": {
         "reference-name": "School Bus Trams",
-        "name": "Lernejo-Buso-Tramoj",
+        "name": "Lernejo-buso-tramoj",
         "reference-description": "Miniature trams themed to look like North American school buses",
         "description": "Miniaturaj tramoj temitaj por aspekti kiel nordamerikaj lernejo-busoj",
         "reference-capacity": "6 passengers per car",
@@ -6187,7 +6187,7 @@
     },
     "rct2tt.ride.seaplane": {
         "reference-name": "Suspended Seaplane Cars",
-        "name": "Penditaj Hidroplano-Ĉaroj",
+        "name": "Penditaj hidroplano-ĉaroj",
         "reference-description": "Suspended roller coaster trains consisting of seaplane-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el hidroplanoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkau anguloj",
         "reference-capacity": "4 passengers per car",
@@ -6195,13 +6195,13 @@
     },
     "rct2tt.ride.softoyst": {
         "reference-name": "Soft Toy Stall",
-        "name": "Mola-Ludilo-Budo",
+        "name": "Mola-ludilo-budo",
         "reference-description": "A stall selling a cute soft toy dinosaur",
         "description": "Budo vendanta ĉarmajn molajn dinosaŭro-ludilojn"
     },
     "rct2tt.ride.spokprsn": {
         "reference-name": "Haunted Jail House",
-        "name": "Fantomita Prizono",
+        "name": "Fantomita prizono",
         "reference-description": "Building containing dungeons and mannequins of incarcerated figures, to scare people walking through it",
         "description": "Konstruaĵo, kiu enhavas malliberejojn kaj manekenojn de enprizonigitaj uloj, por timigi homojn irante tra tie",
         "reference-capacity": "16 guests",
@@ -6209,7 +6209,7 @@
     },
     "rct2tt.ride.stamphrd": {
         "reference-name": "Stampeding Herd Trains",
-        "name": "Kureganta-Grego-Trajnoj",
+        "name": "Kureganta-grego-trajnoj",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position, themed to look like a stampeding dinosaur herd",
         "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio, temitaj por aspekti kiel kureganta dinosaŭro-grego",
         "reference-capacity": "4 passengers per car",
@@ -6217,7 +6217,7 @@
     },
     "rct2tt.ride.telepter": {
         "reference-name": "Teleporter Cabin",
-        "name": "Teleportila Lifto",
+        "name": "Teleportila lifto",
         "reference-description": "Futuristic lift cabin that gives guests the illusion of teleportation",
         "description": "Futurisma lifto, kiu donas al gastoj la iluzion de teleportado",
         "reference-capacity": "16 passengers",
@@ -6233,7 +6233,7 @@
     },
     "rct2tt.ride.tommygun": {
         "reference-name": "Tommy Gun Ride",
-        "name": "Tommy-Pafilo-Atrakcio",
+        "name": "Tommy-Pafilo-atrakcio",
         "reference-description": "Riders ride in pairs of themed seats which rotate around a large replica Tommy Gun",
         "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda replikaĵo de Tommy-Pafilo",
         "reference-capacity": "18 passengers",
@@ -6241,7 +6241,7 @@
     },
     "rct2tt.ride.trebucht": {
         "reference-name": "Trebuchet Ride",
-        "name": "Ĵetmaŝino-Atrakcio",
+        "name": "Ĵetmaŝino-atrakcio",
         "reference-description": "Passengers ride in a carriage suspended by two large arms, based on a Dark Age siege weapon",
         "description": "Rajdantoj rajdas en vagono pendita per du grandaj brakoj, surbaze de Mezepoka sieĝarmilo",
         "reference-capacity": "8 passengers",
@@ -6249,15 +6249,15 @@
     },
     "rct2tt.ride.tricatop": {
         "reference-name": "Triceratops Dodgems",
-        "name": "Triceratopaj Aŭtetoj",
+        "name": "Triceratopaj aŭtetoj",
         "reference-description": "Riders lock horns with each other in triceratops dodgems",
-        "description": "Rajdantoj ŝlosas kornojn kun unu la alian en triceratopo-doĝemoj",
+        "description": "Rajdantoj ŝlosas kornojn kun unu la alian en triceratopo-stilaj kunfrapemaj aŭtetoj",
         "reference-capacity": "1 person per car",
         "capacity": "Po 1 ulo por ĉaro"
     },
     "rct2tt.ride.trilobte": {
         "reference-name": "Trilobite Boats",
-        "name": "Trilobita-Boatoj",
+        "name": "Trilobita-boatoj",
         "reference-description": "Trilobite-shaped roller coaster cars",
         "description": "Trilobitformaj ĉaroj de onda fervojo",
         "reference-capacity": "6 passengers per boat",
@@ -6265,7 +6265,7 @@
     },
     "rct2tt.ride.valkyrie": {
         "reference-name": "Valkyries Trains",
-        "name": "Valkiroj-Trajnoj",
+        "name": "Valkiraj trajnoj",
         "reference-description": "Valkyries-themed roller coaster trains with extra-wide cars, built for vertical drops",
         "description": "Trajnoj de onda fervojo kun temo de valkiroj kaj ekstra-larĝaj ĉaroj, konstruitaj por vertikalaj faloj",
         "reference-capacity": "6 passengers per car",
@@ -6273,7 +6273,7 @@
     },
     "rct2tt.ride.zeplelin": {
         "reference-name": "Airship Themed Monorail Trains",
-        "name": "Monorelaj Trajnoj kun Aeroŝipo-Temo",
+        "name": "Monorelaj aeroŝipo-temaj trajnoj",
         "reference-description": "Large capacity themed monorail trains with streamlined front and rear cars",
         "description": "Grandaj temitaj monorelaj trajnoj kun aerodinamikaj frontaj kaj postaj ĉaroj",
         "reference-capacity": "8 passengers per car",
@@ -6297,11 +6297,11 @@
     },
     "rct2tt.scenario_meta.cliffside_castle": {
         "reference-name": "Cliffside Castle",
-        "name": "Klifoflanko-Kastelo",
+        "name": "Klifoflanka Kastelo",
         "reference-park_name": "Cliffside Castle",
-        "park_name": "Klifoflanko-Kastelo",
+        "park_name": "Klifoflanka Kastelo",
         "reference-details": "Local members of the battle re-enactment society are rather serious about their hobby. They’ve entrusted you with the job of constructing a Dark Age theme park on the grounds of Cliffside Castle.",
-        "details": "Lokaj anoj de la socio de batalo-rekonstruoj estas sufiĉe seriozaj pri ilia ŝatokupo. Ili konfidis al vi la laboron de konstrui amuzparkon kun temo de Malluma Epoko sur la tereno de Klifoflanko-Kastelo."
+        "details": "Lokaj anoj de la socio de batalo-rekonstruoj estas sufiĉe seriozaj pri ilia ŝatokupo. Ili konfidis al vi la laboron de konstrui amuzparkon kun temo de Malluma Epoko sur la tereno de Klifoflanka Kastelo."
     },
     "rct2tt.scenario_meta.coastersaurus": {
         "reference-name": "Coastersaurus",
@@ -6313,9 +6313,9 @@
     },
     "rct2tt.scenario_meta.crater_carnage": {
         "reference-name": "Crater Carnage",
-        "name": "Kratero-Buĉado",
+        "name": "Kratera Katastrofo",
         "reference-park_name": "Crater Carnage",
-        "park_name": "Kratero-Buĉado",
+        "park_name": "Kratera Katastrofo",
         "reference-details": "You own a dusty old meteor crater. In the true entrepreneurial spirit, you’ve decided to construct an asteroid theme park and convert your seemingly worthless land into a sizeable fortune.",
         "details": "Vi posedas polvan malnovan meteor-krateron. Per vera entreprenema vigleco, vi decidis konstrui asteroidan amuzparkon kaj konverti vian ŝajne senvaloran bienon en konsiderindan riĉaĵon."
     },
@@ -6401,15 +6401,15 @@
     },
     "rct2tt.scenery_group.scg1960s": {
         "reference-name": "Rock ’n’ Roll Theming",
-        "name": "Temo de Rokenrolo"
+        "name": "Temo de rokenrolo"
     },
     "rct2tt.scenery_group.scgfutur": {
         "reference-name": "Future Theming",
-        "name": "Estonteca Temo"
+        "name": "Estonteca temo"
     },
     "rct2tt.scenery_group.scgjurra": {
         "reference-name": "Prehistoric Theming",
-        "name": "Praa Temo"
+        "name": "Praa temo"
     },
     "rct2tt.scenery_group.scgmediv": {
         "reference-name": "Dark Age Theming",
@@ -6417,27 +6417,27 @@
     },
     "rct2tt.scenery_group.scgmytho": {
         "reference-name": "Mythological Theming",
-        "name": "Mitologia Temo"
+        "name": "Mitologia temo"
     },
     "rct2tt.scenery_large.1950scar": {
         "reference-name": "1950s Car",
-        "name": "Aŭto de la 1950-aj"
+        "name": "Aŭto de la 1950-aj jaroj"
     },
     "rct2tt.scenery_large.4x4diner": {
         "reference-name": "Period Diner",
-        "name": "Historia Manĝejo"
+        "name": "Historia manĝejo"
     },
     "rct2tt.scenery_large.4x4gmant": {
         "reference-name": "Giant Mangrove Tree",
-        "name": "Giganta Manglujo"
+        "name": "Giganta manglujo"
     },
     "rct2tt.scenery_large.4x4stnhn": {
         "reference-name": "Stone Age Temple",
-        "name": "Ŝtonepoka Templo"
+        "name": "Ŝtonepoka templo"
     },
     "rct2tt.scenery_large.4x4trpit": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_large.4x4volca": {
         "reference-name": "Volcano with small trees",
@@ -6449,71 +6449,71 @@
     },
     "rct2tt.scenery_large.alnstr08": {
         "reference-name": "Alien Structure Large",
-        "name": "Ekstertera Konstruaĵo Granda"
+        "name": "Ekstertera konstruaĵo granda"
     },
     "rct2tt.scenery_large.alnstr09": {
         "reference-name": "Alien Structure Large",
-        "name": "Ekstertera Konstruaĵo Granda"
+        "name": "Ekstertera konstruaĵo granda"
     },
     "rct2tt.scenery_large.alnstr10": {
         "reference-name": "Alien Structure Large",
-        "name": "Ekstertera Konstruaĵo Granda"
+        "name": "Ekstertera konstruaĵo granda"
     },
     "rct2tt.scenery_large.alnstr11": {
         "reference-name": "Alien Skylight Large",
-        "name": "Ekstertera Ĉiellumo Granda"
+        "name": "Ekstertera ĉiellumo granda"
     },
     "rct2tt.scenery_large.artdec25": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Artdekora Angulo kun Fenestroj"
+        "name": "Artdekora angulo kun fenestroj"
     },
     "rct2tt.scenery_large.artdec26": {
         "reference-name": "Art Deco Corner with Railings",
-        "name": "Artdekora Angulo kun Balustrado"
+        "name": "Artdekora angulo kun balustrado"
     },
     "rct2tt.scenery_large.artdec27": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Artdekora Supra Anguloparto"
+        "name": "Artdekora supra anguloparto"
     },
     "rct2tt.scenery_large.ashnymph": {
         "reference-name": "Ash Tree with Nymphs",
-        "name": "Fraksenoarbo kun Najadoj"
+        "name": "Fraksenoarbo kun najadoj"
     },
     "rct2tt.scenery_large.bandbusx": {
         "reference-name": "Rock Band Tour Bus",
-        "name": "Rondvojaĝo-Buso de Rokgrupo"
+        "name": "Rondvojaĝo-buso de rokgrupo"
     },
     "rct2tt.scenery_large.bigdrums": {
         "reference-name": "Giant Drum Kit",
-        "name": "Giganta Tamburaro"
+        "name": "Giganta tamburaro"
     },
     "rct2tt.scenery_large.caventra": {
         "reference-name": "Cave Entrance",
-        "name": "Enirejo de Kavo"
+        "name": "Enirejo de kavo"
     },
     "rct2tt.scenery_large.corns2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Anguloparto de Roma Palaco"
+        "name": "Anguloparto de romia palaco"
     },
     "rct2tt.scenery_large.corvs2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Anguloparto de Roma Palaco"
+        "name": "Anguloparto de romia palaco"
     },
     "rct2tt.scenery_large.cratr2x2": {
         "reference-name": "Small Meteor Crater",
-        "name": "Malgranda Bolido-Kratero"
+        "name": "Malgranda bolido-kratero"
     },
     "rct2tt.scenery_large.cratr4x4": {
         "reference-name": "Large Meteor Crater",
-        "name": "Granda Bolido-Kratero"
+        "name": "Granda bolido-kratero"
     },
     "rct2tt.scenery_large.crsss2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Sekco de Roma Palaco"
+        "name": "Sekco de romia palaco"
     },
     "rct2tt.scenery_large.crsvs2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Sekco de Roma Palaco"
+        "name": "Sekco de romia palaco"
     },
     "rct2tt.scenery_large.cyclopss": {
         "reference-name": "Cyclops Statue",
@@ -6521,11 +6521,11 @@
     },
     "rct2tt.scenery_large.feastabl": {
         "reference-name": "Feast Table",
-        "name": "Tablo por Bankedi"
+        "name": "Bankedo-tablo"
     },
     "rct2tt.scenery_large.footprnt": {
         "reference-name": "Giant Dinosaur Footprint",
-        "name": "Giganta Piedsigno de Dinosaŭro"
+        "name": "Giganta piedsigno de dinosaŭro"
     },
     "rct2tt.scenery_large.forbidft": {
         "reference-name": "Forbidden Fruit Tree",
@@ -6533,55 +6533,55 @@
     },
     "rct2tt.scenery_large.futsky20": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_large.futsky22": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_large.futsky24": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_large.futsky25": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_large.futsky26": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_large.futsky28": {
         "reference-name": "Sandstone Walkway T-Junction",
-        "name": "T-Kuniĝo de Sabloŝtona Vojo"
+        "name": "T-kuniĝo de sabloŝtona vojo"
     },
     "rct2tt.scenery_large.futsky30": {
         "reference-name": "Sandstone Walkway Corner",
-        "name": "Angulo de Sabloŝtona Vojo"
+        "name": "Angulo de sabloŝtona vojo"
     },
     "rct2tt.scenery_large.futsky31": {
         "reference-name": "Sandstone Walkway Cross Section",
-        "name": "Sekco de Sabloŝtona Vojo"
+        "name": "Sekco de sabloŝtona vojo"
     },
     "rct2tt.scenery_large.futsky32": {
         "reference-name": "Sandstone Walkway End Section",
-        "name": "Finoparto de Sabloŝtona Vojo"
+        "name": "Finoparto de sabloŝtona vojo"
     },
     "rct2tt.scenery_large.gbeetlex": {
         "reference-name": "1950s Car",
-        "name": "Aŭto de la 1950-aj"
+        "name": "Aŭto de la 1950-aj jaroj"
     },
     "rct2tt.scenery_large.ghotrod1": {
         "reference-name": "Hot Rod Car",
-        "name": "Hot-Rod Aŭto"
+        "name": "Hot-roda aŭto"
     },
     "rct2tt.scenery_large.ghotrod2": {
         "reference-name": "Hot Rod Car",
-        "name": "Hot-Rod Aŭto"
+        "name": "Hot-roda aŭto"
     },
     "rct2tt.scenery_large.gschlbus": {
         "reference-name": "School Bus",
-        "name": "Lernejo-Buso"
+        "name": "Lernejo-buso"
     },
     "rct2tt.scenery_large.hadesxxx": {
         "reference-name": "Hades Statue",
@@ -6589,11 +6589,11 @@
     },
     "rct2tt.scenery_large.histfix1": {
         "reference-name": "Alien Historical Structures",
-        "name": "Eksterteraj Historiaj Konstruaĵoj"
+        "name": "Eksterteraj historiaj konstruaĵoj"
     },
     "rct2tt.scenery_large.histfix2": {
         "reference-name": "Alien Historical Structures",
-        "name": "Eksterteraj Historiaj Konstruaĵoj"
+        "name": "Eksterteraj historiaj konstruaĵoj"
     },
     "rct2tt.scenery_large.hodshut1": {
         "reference-name": "Robin Hood’s Hut",
@@ -6605,15 +6605,15 @@
     },
     "rct2tt.scenery_large.hrbwal07": {
         "reference-name": "Harbour Wall Corner Piece",
-        "name": "Anguloparto de Muro de Haveno"
+        "name": "Anguloparto de muro de haveno"
     },
     "rct2tt.scenery_large.hrbwal08": {
         "reference-name": "Harbour Wall Corner Piece",
-        "name": "Anguloparto de Muro de Haveno"
+        "name": "Anguloparto de muro de haveno"
     },
     "rct2tt.scenery_large.hrbwal09": {
         "reference-name": "Harbour Wall with Dock",
-        "name": "Muro de Haveno kun Doko"
+        "name": "Muro de haveno kun doko"
     },
     "rct2tt.scenery_large.hrbwal11": {
         "reference-name": "Harbour Dock",
@@ -6621,11 +6621,11 @@
     },
     "rct2tt.scenery_large.jailxx17": {
         "reference-name": "Prison Door",
-        "name": "Pordo de Malliberejo"
+        "name": "Pordo de malliberejo"
     },
     "rct2tt.scenery_large.jailxx18": {
         "reference-name": "Prison Water Tower",
-        "name": "Akvoturo de Malliberejo"
+        "name": "Akvoturo de malliberejo"
     },
     "rct2tt.scenery_large.jetplan1": {
         "reference-name": "Jet Aeroplane",
@@ -6641,123 +6641,123 @@
     },
     "rct2tt.scenery_large.majoroak": {
         "reference-name": "Large Oak",
-        "name": "Granda Kverko"
+        "name": "Granda kverko"
     },
     "rct2tt.scenery_large.mcastl01": {
         "reference-name": "Castle Inverted Corner",
-        "name": "Inversigita Angulo de Kastelo"
+        "name": "Inversigita angulo de kastelo"
     },
     "rct2tt.scenery_large.mcastl11": {
         "reference-name": "Castle Portcullis",
-        "name": "Herso de Kastelo"
+        "name": "Herso de kastelo"
     },
     "rct2tt.scenery_large.mcastl12": {
         "reference-name": "Castle Entrance",
-        "name": "Enirejo de Kastelo"
+        "name": "Enirejo de kastelo"
     },
     "rct2tt.scenery_large.mcastl13": {
         "reference-name": "Castle Tower Corner Piece",
-        "name": "Anguloparto de Turo de Kastelo"
+        "name": "anguloparto de turo de kastelo"
     },
     "rct2tt.scenery_large.mcastl14": {
         "reference-name": "Castle Tower Corner Piece",
-        "name": "Anguloparto de Turo de Kastelo"
+        "name": "Anguloparto de turo de kastelo"
     },
     "rct2tt.scenery_large.mcastl15": {
         "reference-name": "Castle Tower Cross Piece",
-        "name": "Krucoparto de Turo de Kastelo"
+        "name": "Krucoparto de turo de kastelo"
     },
     "rct2tt.scenery_large.mcastl16": {
         "reference-name": "Castle Tower Straight Piece",
-        "name": "Rektaparto de Turo de Kastelo"
+        "name": "Rektaparto de turo de kastelo"
     },
     "rct2tt.scenery_large.mcastl17": {
         "reference-name": "Castle Tower T Piece",
-        "name": "T-Parto de Turo de Kastelo"
+        "name": "T-Parto de turo de kastelo"
     },
     "rct2tt.scenery_large.mcastl18": {
         "reference-name": "Castle Tower T Piece",
-        "name": "T-Parto de Turo de Kastelo"
+        "name": "T-Parto de turo de kastelo"
     },
     "rct2tt.scenery_large.melmtree": {
         "reference-name": "Large Elm Tree",
-        "name": "Granda Ulmoarbo"
+        "name": "Granda ulmoarbo"
     },
     "rct2tt.scenery_large.metoan01": {
         "reference-name": "Meteor Crater Corner",
-        "name": "Angulo de Bolido-Kratero"
+        "name": "Angulo de bolido-kratero"
     },
     "rct2tt.scenery_large.metoan02": {
         "reference-name": "Meteor Crater Inverted Corner",
-        "name": "Inversigita Angulo de Bolido-Kratero"
+        "name": "Inversigita angulo de bolido-kratero"
     },
     "rct2tt.scenery_large.oldnyk20": {
         "reference-name": "New York Roof Piece",
-        "name": "Novjorka Tegmentoparto"
+        "name": "Novjorka tegmentoparto"
     },
     "rct2tt.scenery_large.oldnyk21": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk22": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk23": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk24": {
         "reference-name": "New York Inverted Corner Roof",
-        "name": "Inversigita Novjorka Tegmentangulo"
+        "name": "Inversigita novjorka tegmentangulo"
     },
     "rct2tt.scenery_large.oldnyk25": {
         "reference-name": "New York Roof Piece",
-        "name": "Novjorka Tegmentoparto"
+        "name": "Novjorka tegmentoparto"
     },
     "rct2tt.scenery_large.oldnyk26": {
         "reference-name": "New York Entrance",
-        "name": "Novjorka Enirejo"
+        "name": "Novjorka enirejo"
     },
     "rct2tt.scenery_large.oldnyk27": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk28": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk29": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk30": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_large.oldnyk32": {
         "reference-name": "New York Roof Piece",
-        "name": "Novjorka Tegmentoparto"
+        "name": "Novjorka tegmentoparto"
     },
     "rct2tt.scenery_large.peasthut": {
         "reference-name": "Peasant Hut",
-        "name": "Budo de Vilaĝano"
+        "name": "Budo de vilaĝano"
     },
     "rct2tt.scenery_large.peramob1": {
         "reference-name": "Period Automobile",
-        "name": "Historia Aŭto"
+        "name": "Historia aŭto"
     },
     "rct2tt.scenery_large.peramob2": {
         "reference-name": "Period Automobile",
-        "name": "Historia Aŭto"
+        "name": "Historia aŭto"
     },
     "rct2tt.scenery_large.perdtk01": {
         "reference-name": "Period Truck",
-        "name": "Historia Kamiono"
+        "name": "Historia kamiono"
     },
     "rct2tt.scenery_large.perdtk02": {
         "reference-name": "Period Truck",
-        "name": "Historia Kamiono"
+        "name": "Historia kamiono"
     },
     "rct2tt.scenery_large.ploughxx": {
         "reference-name": "Plough",
@@ -6765,35 +6765,35 @@
     },
     "rct2tt.scenery_large.prdyacht": {
         "reference-name": "Period Sailing Yacht",
-        "name": "Historia Jaĥto por Veli"
+        "name": "Historia velo-jaĥto"
     },
     "rct2tt.scenery_large.psntwl26": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_large.psntwl27": {
         "reference-name": "Dark Age Village Corner Roof Piece",
-        "name": "Anguloparto de Tegmento de Vilaĝo de Malluma Epoko"
+        "name": "Anguloparto de tegmento de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_large.psntwl28": {
         "reference-name": "Dark Age Village Inverted Roof Piece",
-        "name": "Inversigita Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Inversigita tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_large.rdmet2x2": {
         "reference-name": "Small Red Meteor Crater",
-        "name": "Malgranda Ruĝa Bolido-Kratero"
+        "name": "Malgranda ruĝa bolido-kratero"
     },
     "rct2tt.scenery_large.rdmet4x4": {
         "reference-name": "Large Red Meteor Crater",
-        "name": "Granda Ruĝa Bolido-Kratero"
+        "name": "Granda ruĝa bolido-kratero"
     },
     "rct2tt.scenery_large.rdmeto01": {
         "reference-name": "Red Meteor Crater Corner",
-        "name": "Angulo de Ruĝa Bolido-Kratero"
+        "name": "Angulo de ruĝa bolido-kratero"
     },
     "rct2tt.scenery_large.rdmeto02": {
         "reference-name": "Red Meteor Crater Corner",
-        "name": "Angulo de Ruĝa Bolido-Kratero"
+        "name": "Angulo de ruĝa bolido-kratero"
     },
     "rct2tt.scenery_large.robncamp": {
         "reference-name": "Robin Hood’s Camp",
@@ -6801,43 +6801,43 @@
     },
     "rct2tt.scenery_large.romnc2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Anguloparto de Roma Palaco"
+        "name": "Anguloparto de romia palaco"
     },
     "rct2tt.scenery_large.romne2x1": {
         "reference-name": "Roman Palace End Piece",
-        "name": "Finoparto de Roma Palaco"
+        "name": "Finoparto de romia palaco"
     },
     "rct2tt.scenery_large.romnm2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Sekco de Roma Palaco"
+        "name": "Sekco de roma palaco"
     },
     "rct2tt.scenery_large.romns2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Rektaparto de Roma Palaco"
+        "name": "Rektaparto de romia palaco"
     },
     "rct2tt.scenery_large.romvc2x2": {
         "reference-name": "Roman Palace Corner Piece",
-        "name": "Anguloparto de Roma Palaco"
+        "name": "Anguloparto de romia palaco"
     },
     "rct2tt.scenery_large.romve2x1": {
         "reference-name": "Roman Palace End Piece",
-        "name": "Finoparto de Roma Palaco"
+        "name": "Finoparto de romia palaco"
     },
     "rct2tt.scenery_large.romvm2x2": {
         "reference-name": "Roman Palace Cross Section",
-        "name": "Sekco de Roma Palaco"
+        "name": "Sekco de romia palaco"
     },
     "rct2tt.scenery_large.romvs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Rektaparto de Roma Palaco"
+        "name": "Rektaparto de romia palaco"
     },
     "rct2tt.scenery_large.schnpit2": {
         "reference-name": "Seaplane Pits",
-        "name": "Aŭtejoj de Hidroaeroplanoj"
+        "name": "Aŭtejoj de hidroaeroplanoj"
     },
     "rct2tt.scenery_large.schnpits": {
         "reference-name": "Seaplane Pits",
-        "name": "Aŭtejoj de Hidroaeroplanoj"
+        "name": "Aŭtejoj de hidroaeroplanoj"
     },
     "rct2tt.scenery_large.schntent": {
         "reference-name": "Marquee",
@@ -6845,23 +6845,23 @@
     },
     "rct2tt.scenery_large.shipb4x4": {
         "reference-name": "Luxury Liner Bow",
-        "name": "Pruo de Krozŝipo"
+        "name": "Pruo de krozŝipo"
     },
     "rct2tt.scenery_large.shipm4x4": {
         "reference-name": "Luxury Liner Mid Section",
-        "name": "Mezparto de Krozŝipo"
+        "name": "Mezparto de krozŝipo"
     },
     "rct2tt.scenery_large.ships4x4": {
         "reference-name": "Luxury Liner Stern",
-        "name": "Pobo de Krozŝipo"
+        "name": "Pobo de krozŝipo"
     },
     "rct2tt.scenery_large.strgs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Rektaparto de Roma Palaco"
+        "name": "Rektaparto de romia palaco"
     },
     "rct2tt.scenery_large.strvs2x2": {
         "reference-name": "Roman Palace Straight Piece",
-        "name": "Rektaparto de Roma Palaco"
+        "name": "Rektaparto de romia palaco"
     },
     "rct2tt.scenery_large.tavernxx": {
         "reference-name": "Dark Ages Tavern",
@@ -6869,7 +6869,7 @@
     },
     "rct2tt.scenery_large.travlr01": {
         "reference-name": "Traveller Van",
-        "name": "Vojaĝanto-Kamioneto"
+        "name": "Vojaĝanta kamioneto"
     },
     "rct2tt.scenery_large.travlr02": {
         "reference-name": "Microbus",
@@ -6877,199 +6877,199 @@
     },
     "rct2tt.scenery_small.1920slmp": {
         "reference-name": "Period Street Lamps",
-        "name": "Historiaj Stratlumoj"
+        "name": "Historiaj stratlumoj"
     },
     "rct2tt.scenery_small.alenplt1": {
         "reference-name": "Alien Plant",
-        "name": "Ekstertera Kreskaĵo"
+        "name": "Ekstertera kreskaĵo"
     },
     "rct2tt.scenery_small.alenplt2": {
         "reference-name": "Alien Plant",
-        "name": "Ekstertera Kreskaĵo"
+        "name": "Ekstertera kreskaĵo"
     },
     "rct2tt.scenery_small.alentre1": {
         "reference-name": "Alien Tree",
-        "name": "Ekstertera Arbo"
+        "name": "Ekstertera arbo"
     },
     "rct2tt.scenery_small.alentre2": {
         "reference-name": "Alien Tree",
-        "name": "Ekstertera Arbo"
+        "name": "Ekstertera arbo"
     },
     "rct2tt.scenery_small.allseeye": {
         "reference-name": "Animatronic All Seeing Eye",
-        "name": "Animatronika Ĉionvida Okulo"
+        "name": "Animatronika ĉionvida okulo"
     },
     "rct2tt.scenery_small.alnstr01": {
         "reference-name": "Alien Structure Small",
-        "name": "Ekstertera Konstruaĵo Malgranda"
+        "name": "Ekstertera konstruaĵo malgranda"
     },
     "rct2tt.scenery_small.alnstr02": {
         "reference-name": "Alien Structure Small",
-        "name": "Ekstertera Konstruaĵo Malgranda"
+        "name": "Ekstertera konstruaĵo malgranda"
     },
     "rct2tt.scenery_small.alnstr03": {
         "reference-name": "Alien Structure Small",
-        "name": "Ekstertera Konstruaĵo Malgranda"
+        "name": "Ekstertera konstruaĵo malgranda"
     },
     "rct2tt.scenery_small.alnstr04": {
         "reference-name": "Alien Skylight Small",
-        "name": "Ekstertera Ĉiellumo Malgranda"
+        "name": "Ekstertera ĉiellumo malgranda"
     },
     "rct2tt.scenery_small.alnstr05": {
         "reference-name": "Alien Tower Bottom",
-        "name": "Bazo de Ekstertera Turo"
+        "name": "Bazo de ekstertera turo"
     },
     "rct2tt.scenery_small.alnstr06": {
         "reference-name": "Alien Tower Middle",
-        "name": "Mezoparto de Ekstertera Turo"
+        "name": "Mezoparto de ekstertera turo"
     },
     "rct2tt.scenery_small.alnstr07": {
         "reference-name": "Alien Tower Top",
-        "name": "Supro de Ekstertera Turo"
+        "name": "Supro de ekstertera turo"
     },
     "rct2tt.scenery_small.argonau1": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Animatronika Argonaŭto"
+        "name": "Animatronika argonaŭto"
     },
     "rct2tt.scenery_small.argonau2": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Animatronika Argonaŭto"
+        "name": "Animatronika argonaŭto"
     },
     "rct2tt.scenery_small.argonau3": {
         "reference-name": "Animatronic Argonaut",
-        "name": "Animatronika Argonaŭto"
+        "name": "Animatronika argonaŭto"
     },
     "rct2tt.scenery_small.armrbody": {
         "reference-name": "Magical Armour",
-        "name": "Magia Armaĵo"
+        "name": "Magia armaĵo"
     },
     "rct2tt.scenery_small.armrhelm": {
         "reference-name": "Magical Helmet",
-        "name": "Magia Kasko"
+        "name": "Magia kasko"
     },
     "rct2tt.scenery_small.armrshld": {
         "reference-name": "Magical Shield",
-        "name": "Magia Ŝildo"
+        "name": "Magia ŝildo"
     },
     "rct2tt.scenery_small.armrswrd": {
         "reference-name": "Magical Sword",
-        "name": "Magia Glavo"
+        "name": "Magia glavo"
     },
     "rct2tt.scenery_small.artdec01": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec02": {
         "reference-name": "Art Deco Inverted Corner Section",
-        "name": "Artdekora Inversigita Anguloparto"
+        "name": "Artdekora inversigita anguloparto"
     },
     "rct2tt.scenery_small.artdec03": {
         "reference-name": "Art Deco Wall with Door",
-        "name": "Artdekora Muro kun Pordo"
+        "name": "Artdekora muro kun pordo"
     },
     "rct2tt.scenery_small.artdec04": {
         "reference-name": "Art Deco Wall with Windows",
-        "name": "Artdekora Muro kun Fenestroj"
+        "name": "Artdekora muro kun fenestroj"
     },
     "rct2tt.scenery_small.artdec05": {
         "reference-name": "Art Deco Wall with Windows",
-        "name": "Artdekora Muro kun Fenestroj"
+        "name": "Artdekora muro kun fenestroj"
     },
     "rct2tt.scenery_small.artdec06": {
         "reference-name": "Art Deco Top Section",
-        "name": "Artdekora Supra Parto"
+        "name": "Artdekora supra parto"
     },
     "rct2tt.scenery_small.artdec07": {
         "reference-name": "Art Deco Corner Section",
-        "name": "Artdekora Anguloparto"
+        "name": "Artdekora anguloparto"
     },
     "rct2tt.scenery_small.artdec08": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Artdekora Supra Anguloparto"
+        "name": "Artdekora supra anguloparto"
     },
     "rct2tt.scenery_small.artdec09": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec10": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec11": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Artdekora Angulo kun Fenestroj"
+        "name": "Artdekora angulo kun fenestroj"
     },
     "rct2tt.scenery_small.artdec12": {
         "reference-name": "Art Deco Corner with Railings",
-        "name": "Artdekora Angulo kun Balustrado"
+        "name": "Artdekora angulo kun balustrado"
     },
     "rct2tt.scenery_small.artdec13": {
         "reference-name": "Art Deco Top Corner Section",
-        "name": "Artdekora Supra Anguloparto"
+        "name": "Artdekora supra anguloparto"
     },
     "rct2tt.scenery_small.artdec14": {
         "reference-name": "Art Deco Corner with Windows",
-        "name": "Artdekora Angulo kun Fenestroj"
+        "name": "Artdekora angulo kun fenestroj"
     },
     "rct2tt.scenery_small.artdec15": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec16": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec17": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec18": {
         "reference-name": "Art Deco Top Section",
-        "name": "Artdekora Supra Parto"
+        "name": "Artdekora supra parto"
     },
     "rct2tt.scenery_small.artdec19": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec20": {
         "reference-name": "Art Deco Wall Section",
-        "name": "Artdekora Muroparto"
+        "name": "Artdekora muroparto"
     },
     "rct2tt.scenery_small.artdec21": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Artdekora Muro kun Balustrado"
+        "name": "Artdekora muro kun balustrado"
     },
     "rct2tt.scenery_small.artdec22": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Artdekora Muro kun Balustrado"
+        "name": "Artdekora muro kun balustrado"
     },
     "rct2tt.scenery_small.artdec23": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Artdekora Muro kun Balustrado"
+        "name": "Artdekora muro kun balustrado"
     },
     "rct2tt.scenery_small.artdec24": {
         "reference-name": "Art Deco Wall with Railings",
-        "name": "Artdekora Muro kun Balustrado"
+        "name": "Artdekora muro kun balustrado"
     },
     "rct2tt.scenery_small.artdec28": {
         "reference-name": "Art Deco Roof Section",
-        "name": "Artdekora Tegmentoparto"
+        "name": "Artdekora tegmentoparto"
     },
     "rct2tt.scenery_small.artdec29": {
         "reference-name": "Art Deco Inverted Corner Section",
-        "name": "Artdekora Inversigita Anguloparto"
+        "name": "Artdekora inversigita anguloparto"
     },
     "rct2tt.scenery_small.astrongt": {
         "reference-name": "Animatronic Astronaut",
-        "name": "Animatronika Argonaŭto"
+        "name": "Animatronika argonaŭto"
     },
     "rct2tt.scenery_small.bigbassx": {
         "reference-name": "Giant Bass Guitar",
-        "name": "Giganta Basagitaro"
+        "name": "Giganta basagitaro"
     },
     "rct2tt.scenery_small.biggutar": {
         "reference-name": "Giant Guitar",
-        "name": "Giganta Gitaro"
+        "name": "Giganta gitaro"
     },
     "rct2tt.scenery_small.bkrgang1": {
         "reference-name": "Biker",
@@ -7081,15 +7081,15 @@
     },
     "rct2tt.scenery_small.cagdstat": {
         "reference-name": "Animatronic Eagle on Cage",
-        "name": "Animatronika Aglo sur Kaĝo"
+        "name": "Animatronika aglo sur kaĝo"
     },
     "rct2tt.scenery_small.cavemenx": {
         "reference-name": "Animatronic Caveman lighting Fire",
-        "name": "Animatronika Kavernhomo flamiganta Fajron"
+        "name": "Animatronika kavernhomo flamiganta fajron"
     },
     "rct2tt.scenery_small.chanmaid": {
         "reference-name": "Animatronic Chained Maiden",
-        "name": "Animatronika Ĉenita Fraŭlino"
+        "name": "Animatronika ĉenita fraŭlino"
     },
     "rct2tt.scenery_small.chprbke1": {
         "reference-name": "Motorcycle",
@@ -7101,95 +7101,95 @@
     },
     "rct2tt.scenery_small.clnsmen1": {
         "reference-name": "Animatronic Clansman",
-        "name": "Animatronika Gentulo"
+        "name": "Animatronika gentulo"
     },
     "rct2tt.scenery_small.compeyex": {
         "reference-name": "Super Computer Monitor",
-        "name": "Ekrano de Superkomputilo"
+        "name": "Ekrano de superkomputilo"
     },
     "rct2tt.scenery_small.cookspit": {
         "reference-name": "Animal cooking on Spit",
-        "name": "Besto Kuirata per Pikbastono"
+        "name": "Besto kuirata per pikbastono"
     },
     "rct2tt.scenery_small.dinsign1": {
         "reference-name": "Neon Diner Sign",
-        "name": "Neona Afiŝo de Tagmanĝejo"
+        "name": "Neona afiŝo de tagmanĝejo"
     },
     "rct2tt.scenery_small.dinsign2": {
         "reference-name": "Neon Diner Sign",
-        "name": "Neona Afiŝo de Tagmanĝejo"
+        "name": "Neona afiŝo de tagmanĝejo"
     },
     "rct2tt.scenery_small.dinsign3": {
         "reference-name": "Neon Diner Sign",
-        "name": "Neona Afiŝo de Tagmanĝejo"
+        "name": "Neona afiŝo de tagmanĝejo"
     },
     "rct2tt.scenery_small.dinsign4": {
         "reference-name": "Neon Diner Sign",
-        "name": "Neona Afiŝo de Tagmanĝejo"
+        "name": "Neona afiŝo de tagmanĝejo"
     },
     "rct2tt.scenery_small.dkfight1": {
         "reference-name": "Animatronic Knight",
-        "name": "Animatronika Kavaliro"
+        "name": "Animatronika kavaliro"
     },
     "rct2tt.scenery_small.dkfight2": {
         "reference-name": "Animatronic Knight",
-        "name": "Animatronika Kavaliro"
+        "name": "Animatronika kavaliro"
     },
     "rct2tt.scenery_small.drgnattk": {
         "reference-name": "Dragon Attacking",
-        "name": "Drako Atakanta"
+        "name": "Drako atakanta"
     },
     "rct2tt.scenery_small.elecfen1": {
         "reference-name": "Electric Fence Corner Piece",
-        "name": "Anguloparto de Elektra Barilo"
+        "name": "Anguloparto de elektra barilo"
     },
     "rct2tt.scenery_small.elecfen2": {
         "reference-name": "Electric Fence",
-        "name": "Elektra Barilo"
+        "name": "Elektra barilo"
     },
     "rct2tt.scenery_small.elecfen3": {
         "reference-name": "Electric Fence with Light",
-        "name": "Elektra Barilo kun Lumo"
+        "name": "Elektra barilo kun lumo"
     },
     "rct2tt.scenery_small.elecfen4": {
         "reference-name": "Electric Fence Broken",
-        "name": "Elektra Barilo Rompita"
+        "name": "Elektra barilo rompita"
     },
     "rct2tt.scenery_small.elecfen5": {
         "reference-name": "Electric Fence Inverted Corner Piece",
-        "name": "Inversigita Anguloparto de Elektra Barilo"
+        "name": "Inversigita anguloparto de elektra barilo"
     },
     "rct2tt.scenery_small.evalien1": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Animatronika Malbona Eksterterulo"
+        "name": "Animatronika malbona eksterterulo"
     },
     "rct2tt.scenery_small.evalien2": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Animatronika Malbona Eksterterulo"
+        "name": "Animatronika malbona eksterterulo"
     },
     "rct2tt.scenery_small.evalien3": {
         "reference-name": "Animatronic Evil Alien",
-        "name": "Animatronika Malbona Eksterterulo"
+        "name": "Animatronika malbona eksterterulo"
     },
     "rct2tt.scenery_small.fircanon": {
         "reference-name": "Animatronic Firing Cannon",
-        "name": "Animatronika Pafata Kanono"
+        "name": "Animatronika pafata kanono"
     },
     "rct2tt.scenery_small.firemanx": {
         "reference-name": "Animatronic Fireman",
-        "name": "Animatronika Fajrobrigado"
+        "name": "Animatronika fajrobrigado"
     },
     "rct2tt.scenery_small.fltsign1": {
         "reference-name": "Anti-Gravity LCD Billboard",
-        "name": "Anti-Gravita Likvokristala Afiŝtabulo"
+        "name": "Anti-gravita likvokristala afiŝtabulo"
     },
     "rct2tt.scenery_small.fltsign2": {
         "reference-name": "Anti-Gravity LCD Billboard",
-        "name": "Anti-Gravita Likvokristala Afiŝtabulo"
+        "name": "Anti-gravita likvokristala afiŝtabulo"
     },
     "rct2tt.scenery_small.frbeacon": {
         "reference-name": "Fiery Beacon",
-        "name": "Fajra Signalfajro"
+        "name": "Fajra signalfajro"
     },
     "rct2tt.scenery_small.furobot1": {
         "reference-name": "Robot",
@@ -7201,179 +7201,179 @@
     },
     "rct2tt.scenery_small.futsky01": {
         "reference-name": "Sandstone Skyscraper Walkway",
-        "name": "Vojo de Sabloŝtona Ĉielskrapanto"
+        "name": "Vojo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky02": {
         "reference-name": "Sandstone Skyscraper Filler",
-        "name": "Diversaĵo de Sabloŝtona Ĉielskrapanto"
+        "name": "Diversaĵo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky03": {
         "reference-name": "Sandstone Skyscraper Bottom Corner",
-        "name": "Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky04": {
         "reference-name": "Sandstone Skyscraper Curved Slope Top",
-        "name": "Supra Kurba Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Supra kurba deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky05": {
         "reference-name": "Sandstone Skyscraper Corner Top",
-        "name": "Supra Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Supra angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky06": {
         "reference-name": "Sandstone Skyscraper Mid Curved Slope",
-        "name": "Meza Kurba Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza kurba deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky07": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Meza Muroparto de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza muroparto de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky08": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Meza Muroparto de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza muroparto de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky09": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Meza Muroparto de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza muroparto de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky10": {
         "reference-name": "Sandstone Skyscraper Bottom Slope Base",
-        "name": "Suba Deklivobazo de Sabloŝtona Ĉielskrapanto"
+        "name": "Suba deklivobazo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky11": {
         "reference-name": "Sandstone Skyscraper Mid Corner",
-        "name": "Meza Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky12": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Meza Muroparto de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza muroparto de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky13": {
         "reference-name": "Sandstone Skyscraper Roof Spire",
-        "name": "Sonorilejo de Sabloŝtona Ĉielskrapanto"
+        "name": "Sonorilejo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky14": {
         "reference-name": "Sandstone Skyscraper Roof Spire",
-        "name": "Sonorilejo de Sabloŝtona Ĉielskrapanto"
+        "name": "Sonorilejo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky15": {
         "reference-name": "Sandstone Skyscraper Docking Bay",
-        "name": "Doko de Sabloŝtona Ĉielskrapanto"
+        "name": "Doko de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky16": {
         "reference-name": "Sandstone Skyscraper Mid Slope Corner",
-        "name": "Meza Angulo de Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza angulo de deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky17": {
         "reference-name": "Sandstone Skyscraper Filler",
-        "name": "Diversaĵo de Sabloŝtona Ĉielskrapanto"
+        "name": "Diversaĵo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky18": {
         "reference-name": "Sandstone Skyscraper Doorway",
-        "name": "Pordapeturo de Sabloŝtona Ĉielskrapanto"
+        "name": "Pordapeturo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky19": {
         "reference-name": "Sandstone Skyscraper Bottom Corner",
-        "name": "Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky21": {
         "reference-name": "Sandstone Skyscraper Mid Wall Section",
-        "name": "Meza Muroparto de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza muroparto de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky23": {
         "reference-name": "Sandstone Skyscraper Inverted Corner Top",
-        "name": "Inversigita Supra Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita supra angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky29": {
         "reference-name": "Sandstone Skyscraper Bottom Curved Slope",
-        "name": "Suba Kurba Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Suba kurba deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky33": {
         "reference-name": "Sandstone Skyscraper Walkway",
-        "name": "Vojo de Sabloŝtona Ĉielskrapanto"
+        "name": "Vojo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky34": {
         "reference-name": "Sandstone Skyscraper Roof",
-        "name": "Tegmento de Sabloŝtona Ĉielskrapanto"
+        "name": "Tegmento de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky35": {
         "reference-name": "Sandstone Skyscraper Mid Curved Slope",
-        "name": "Meza Kurba Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza kurba deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky36": {
         "reference-name": "Obsidian Skyscraper Door Piece",
-        "name": "Pordoparto de Obsidiana Ĉielskrapanto"
+        "name": "Pordoparto de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky37": {
         "reference-name": "Obsidian Skyscraper Shallow Slope Corner",
-        "name": "Malprofunda Deklivita Angulo de Obsidiana Ĉielskrapanto"
+        "name": "Malprofunda deklivita angulo de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky38": {
         "reference-name": "Obsidian Skyscraper Shallow Sloped Wall",
-        "name": "Malprofunda Deklivita Muro de Obsidiana Ĉielskrapanto"
+        "name": "Malprofunda deklivita muro de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky39": {
         "reference-name": "Obsidian Skyscraper Shallow Slope Corner",
-        "name": "Malprofunda Deklivita Angulo de Obsidiana Ĉielskrapanto"
+        "name": "Malprofunda deklivita angulo de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky40": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Kruta Deklivita Muro de Obsidiana Ĉielskrapanto"
+        "name": "kruta deklivita muro de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky41": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Kruta Deklivita Muro de Obsidiana Ĉielskrapanto"
+        "name": "Kruta deklivita muro de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky42": {
         "reference-name": "Sandstone Skyscraper Curved Slope Top",
-        "name": "Supra Kurba Deklivo de Sabloŝtona Ĉielskrapanto"
+        "name": "Supra kurba deklivo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky44": {
         "reference-name": "Obsidian Skyscraper Steep Sloped Wall",
-        "name": "Kruta Deklivita Muro de Obsidiana Ĉielskrapanto"
+        "name": "Kruta deklivita muro de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky46": {
         "reference-name": "Obsidian Skyscraper Steep Slope Corner",
-        "name": "Kruta Deklivita Angulo de Obsidiana Ĉielskrapanto"
+        "name": "Kruta deklivita angulo de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky47": {
         "reference-name": "Obsidian Skyscraper Wall",
-        "name": "Muro de Obsidiana Ĉielskrapanto"
+        "name": "Muro de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky48": {
         "reference-name": "Obsidian Skyscraper Wall with Window",
-        "name": "Muro de Obsidiana Ĉielskrapanto kun Fenestro "
+        "name": "Muro de obsidiana ĉielskrapanto kun fenestro"
     },
     "rct2tt.scenery_small.futsky52": {
         "reference-name": "Sandstone Skyscraper Bottom Inverted Corner",
-        "name": "Inversigita Suba Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Inversigita suba angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky53": {
         "reference-name": "Sandstone Skyscraper Mid Corner",
-        "name": "Meza Angulo de Sabloŝtona Ĉielskrapanto"
+        "name": "Meza angulo de sabloŝtona ĉielskrapanto"
     },
     "rct2tt.scenery_small.futsky54": {
         "reference-name": "Obsidian Skyscraper Roof Piece",
-        "name": "Tegmentoparto de Obsidiana Ĉielskrapanto"
+        "name": "Tegmentoparto de obsidiana ĉielskrapanto"
     },
     "rct2tt.scenery_small.fwrprdc1": {
         "reference-name": "Groovy Dancer",
-        "name": "Mojosa Dancisto"
+        "name": "Mojosa dancisto"
     },
     "rct2tt.scenery_small.gangster": {
         "reference-name": "Animatronic Gangster",
-        "name": "Animatronika Gangstero"
+        "name": "Animatronika gangstero"
     },
     "rct2tt.scenery_small.gdalien1": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Animatronika Bona Eksterterulo"
+        "name": "Animatronika bona eksterterulo"
     },
     "rct2tt.scenery_small.gdalien2": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Animatronika Bona Eksterterulo"
+        "name": "Animatronika bona eksterterulo"
     },
     "rct2tt.scenery_small.gdalien3": {
         "reference-name": "Animatronic Good Alien",
-        "name": "Animatronika Bona Eksterterulo"
+        "name": "Animatronika bona eksterterulo"
     },
     "rct2tt.scenery_small.geyserxx": {
         "reference-name": "Geysers",
@@ -7381,11 +7381,11 @@
     },
     "rct2tt.scenery_small.ggntocto": {
         "reference-name": "B-Movie Giant Octopus",
-        "name": "B-Filmo Giganta Oktopuso"
+        "name": "B-filma giganta oktopuso"
     },
     "rct2tt.scenery_small.ggntspid": {
         "reference-name": "B-Movie Giant Spider",
-        "name": "B-Filmo Giganta Araneo"
+        "name": "B-Filma giganta araneo"
     },
     "rct2tt.scenery_small.gldchest": {
         "reference-name": "Treasure Chest",
@@ -7393,19 +7393,19 @@
     },
     "rct2tt.scenery_small.goldflec": {
         "reference-name": "Golden Fleece",
-        "name": "Ora Ŝaffelo"
+        "name": "Ora ŝaffelo"
     },
     "rct2tt.scenery_small.gscorpo2": {
         "reference-name": "Animatronic attacking Scorpion",
-        "name": "Animatronika agresa Skorpio"
+        "name": "Animatronika agresa skorpio"
     },
     "rct2tt.scenery_small.gscorpon": {
         "reference-name": "Animatronic attacking Scorpion",
-        "name": "Animatronika agresa Skorpio"
+        "name": "Animatronika agresa skorpio"
     },
     "rct2tt.scenery_small.guyqwifx": {
         "reference-name": "Singer with Quiff",
-        "name": "Kantanto kun Hartufo"
+        "name": "Kantanto kun hartufo"
     },
     "rct2tt.scenery_small.haybails": {
         "reference-name": "Hay Bale",
@@ -7413,87 +7413,87 @@
     },
     "rct2tt.scenery_small.hevbth01": {
         "reference-name": "Heavenly Bath Pool",
-        "name": "Baseno de Ĉiela Bano"
+        "name": "Baseno de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth02": {
         "reference-name": "Heavenly Bath Pool Corner",
-        "name": "Angulo de Baseno de Ĉiela Bano"
+        "name": "Angulo de baseno de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth03": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Fontano de Ĉiela Bano"
+        "name": "Fontano de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth04": {
         "reference-name": "Heavenly Baths Fountain",
-        "name": "Fontano de Ĉiela Bano"
+        "name": "Fontano de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth05": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Arkaĵo de Ĉiela Bano"
+        "name": "Arkaĵo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth06": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Arkaĵo de Ĉiela Bano"
+        "name": "Arkaĵo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth07": {
         "reference-name": "Heavenly Baths Arch",
-        "name": "Arkaĵo de Ĉiela Bano"
+        "name": "Arkaĵo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth08": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Ŝtuparo de Ĉiela Bano"
+        "name": "Ŝtuparo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth09": {
         "reference-name": "Heavenly Baths Stairway",
-        "name": "Ŝtuparo de Ĉiela Bano"
+        "name": "Ŝtuparo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth10": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Arĥitekturo de Ĉiela Bano"
+        "name": "Arĥitekturo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth11": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Arĥitekturo de Ĉiela Bano"
+        "name": "Arĥitekturo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth12": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Arĥitekturo de Ĉiela Bano"
+        "name": "Arĥitekturo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth13": {
         "reference-name": "Heavenly Baths Architecture",
-        "name": "Arĥitekturo de Ĉiela Bano"
+        "name": "Arĥitekturo de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth14": {
         "reference-name": "Heavenly Bath Window",
-        "name": "Fenestro de Ĉiela Bano"
+        "name": "Fenestro de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth15": {
         "reference-name": "Heavenly Bath Floor",
-        "name": "Planko de Ĉiela Bano"
+        "name": "Planko de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth16": {
         "reference-name": "Heavenly Bath Pool Steps",
-        "name": "Ŝtupoj de Baseno de Ĉiela Bano"
+        "name": "Ŝtupoj de baseno de ĉiela bano"
     },
     "rct2tt.scenery_small.hevbth17": {
         "reference-name": "Heavenly Bath Pool Edge",
-        "name": "Bordo de Baseno de Ĉiela Bano"
+        "name": "Bordo de baseno de ĉiela bano"
     },
     "rct2tt.scenery_small.hevrof01": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Tegmento de Ĉiela Bano"
+        "name": "Tegmento de ĉiela bano"
     },
     "rct2tt.scenery_small.hevrof02": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Tegmento de Ĉiela Bano"
+        "name": "Tegmento de ĉiela bano"
     },
     "rct2tt.scenery_small.hevrof03": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Tegmento de Ĉiela Bano"
+        "name": "Tegmento de ĉiela bano"
     },
     "rct2tt.scenery_small.hevrof04": {
         "reference-name": "Heavenly Bath Roof",
-        "name": "Tegmento de Ĉiela Bano"
+        "name": "Tegmento de ĉiela bano"
     },
     "rct2tt.scenery_small.horsecrt": {
         "reference-name": "Horse",
@@ -7501,43 +7501,43 @@
     },
     "rct2tt.scenery_small.hovrcar1": {
         "reference-name": "Hovercar on Stand",
-        "name": "Flugpendanta Aŭto sur Apogstangilo"
+        "name": "Flugpendanta aŭto sur apogstangilo"
     },
     "rct2tt.scenery_small.hovrcar2": {
         "reference-name": "Hovercar on Stand",
-        "name": "Flugpendanta Aŭto sur Apogstangilo"
+        "name": "Flugpendanta aŭto sur apogstangilo"
     },
     "rct2tt.scenery_small.hovrcar3": {
         "reference-name": "Hovercar Flying",
-        "name": "Fluganta Flugpendanta Aŭto"
+        "name": "Fluganta flugpendanta aŭto"
     },
     "rct2tt.scenery_small.hovrcar4": {
         "reference-name": "Hovercar Flying",
-        "name": "Fluganta Flugpendanta Aŭto"
+        "name": "Fluganta flugpendanta aŭto"
     },
     "rct2tt.scenery_small.hrbwal01": {
         "reference-name": "Harbour Wall",
-        "name": "Muro de Haveno"
+        "name": "Muro de haveno"
     },
     "rct2tt.scenery_small.hrbwal02": {
         "reference-name": "Harbour Wall with Fishing Gear",
-        "name": "Muro de Haveno kun Fiŝkaptiloj"
+        "name": "Muro de haveno kun fiŝkaptiloj"
     },
     "rct2tt.scenery_small.hrbwal03": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Muro de Haveno kun Alligejo"
+        "name": "Muro de haveno kun alligejo"
     },
     "rct2tt.scenery_small.hrbwal04": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Muro de Haveno kun Alligejo"
+        "name": "Muro de haveno kun alligejo"
     },
     "rct2tt.scenery_small.hrbwal05": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Muro de Haveno kun Alligejo"
+        "name": "Muro de haveno kun alligejo"
     },
     "rct2tt.scenery_small.hrbwal06": {
         "reference-name": "Harbour Wall with Moor",
-        "name": "Muro de Haveno kun Alligejo"
+        "name": "Muro de haveno kun alligejo"
     },
     "rct2tt.scenery_small.hurcluls": {
         "reference-name": "Hercules",
@@ -7545,219 +7545,219 @@
     },
     "rct2tt.scenery_small.hvrbike1": {
         "reference-name": "Hoverbike on Stand",
-        "name": "Flugpendanta Biciklo sur Apogstangilo"
+        "name": "Flugpendanta biciklo sur apogstangilo"
     },
     "rct2tt.scenery_small.hvrbike2": {
         "reference-name": "Hoverbike on Stand",
-        "name": "Flugpendanta Biciklo sur Apogstangilo"
+        "name": "Flugpendanta biciklo sur apogstangilo"
     },
     "rct2tt.scenery_small.hvrbike3": {
         "reference-name": "Hoverbike Flying",
-        "name": "Fluganta Flugpendanta Biciklo"
+        "name": "Fluganta flugpendanta biciklo"
     },
     "rct2tt.scenery_small.hvrbike4": {
         "reference-name": "Hoverbike Flying",
-        "name": "Fluganta Flugpendanta Biciklo"
+        "name": "Fluganta flugpendanta biciklo"
     },
     "rct2tt.scenery_small.indwal01": {
         "reference-name": "Industrial Wall Set",
-        "name": "Industria Muraro"
+        "name": "Industria muraro"
     },
     "rct2tt.scenery_small.indwal02": {
         "reference-name": "Industrial Wall Set",
-        "name": "Industria Muraro"
+        "name": "Industria muraro"
     },
     "rct2tt.scenery_small.indwal03": {
         "reference-name": "Industrial Wall Set",
-        "name": "Industria Muraro"
+        "name": "Industria muraro"
     },
     "rct2tt.scenery_small.indwal04": {
         "reference-name": "Industrial Wall Set",
-        "name": "Industria Muraro"
+        "name": "Industria muraro"
     },
     "rct2tt.scenery_small.indwal05": {
         "reference-name": "Industrial Roof Corner Piece",
-        "name": "Anguloparto de Industria Tegmento"
+        "name": "Anguloparto de industria tegmento"
     },
     "rct2tt.scenery_small.indwal06": {
         "reference-name": "Industrial Roof Corner Piece",
-        "name": "Anguloparto de Industria Tegmento"
+        "name": "Anguloparto de industria tegmento"
     },
     "rct2tt.scenery_small.indwal07": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal08": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal09": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal10": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal11": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal12": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal13": {
         "reference-name": "Industrial Wall with Doorway",
-        "name": "Industria Muro kun Pordo"
+        "name": "Industria muro kun pordo"
     },
     "rct2tt.scenery_small.indwal14": {
         "reference-name": "Industrial Wall Corner Piece",
-        "name": "Anguloparto de Industria Muro"
+        "name": "Anguloparto de industria muro"
     },
     "rct2tt.scenery_small.indwal15": {
         "reference-name": "Industrial Wall Corner Piece",
-        "name": "Anguloparto de Industria Muro"
+        "name": "Anguloparto de industria muro"
     },
     "rct2tt.scenery_small.indwal16": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal17": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal18": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal19": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal20": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal21": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal22": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal23": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal24": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal25": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal26": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal27": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal28": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal29": {
         "reference-name": "Industrial Roof Piece",
-        "name": "Industria Tegmentoparto"
+        "name": "Industria tegmentoparto"
     },
     "rct2tt.scenery_small.indwal30": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal31": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.indwal32": {
         "reference-name": "Industrial Wall with Window",
-        "name": "Industria Muro kun Fenestro"
+        "name": "Industria muro kun fenestro"
     },
     "rct2tt.scenery_small.jailxx01": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx02": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx03": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx04": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx05": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx06": {
         "reference-name": "Prison Wall Piece",
-        "name": "Muroparto de Malliberejo"
+        "name": "Muroparto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx07": {
         "reference-name": "Prison Wall Roof",
-        "name": "Tegmento de Muro de Malliberejo"
+        "name": "Tegmento de muro de malliberejo"
     },
     "rct2tt.scenery_small.jailxx08": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx09": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx10": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx11": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx12": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx13": {
         "reference-name": "Prison Inverted Piece",
-        "name": "Inversigita Parto de Malliberejo"
+        "name": "Inversigita parto de malliberejo"
     },
     "rct2tt.scenery_small.jailxx14": {
         "reference-name": "Prison Watch Tower Stairs",
-        "name": "Ŝtuparo de Gardoturo de Malliberejo"
+        "name": "Ŝtuparo de gardoturo de malliberejo"
     },
     "rct2tt.scenery_small.jailxx15": {
         "reference-name": "Prison Watch Tower Stairs",
-        "name": "Ŝtuparo de Gardoturo de Malliberejo"
+        "name": "Ŝtuparo de gardoturo de malliberejo"
     },
     "rct2tt.scenery_small.jailxx16": {
         "reference-name": "Prison Watch Tower",
-        "name": "Gardoturo de Malliberejo"
+        "name": "Gardoturo de malliberejo"
     },
     "rct2tt.scenery_small.jailxx20": {
         "reference-name": "Prison Wall Corner",
-        "name": "Murangulo de Malliberejo"
+        "name": "Murangulo de malliberejo"
     },
     "rct2tt.scenery_small.jailxx21": {
         "reference-name": "Prison Wall Corner",
-        "name": "Murangulo de Malliberejo"
+        "name": "Murangulo de malliberejo"
     },
     "rct2tt.scenery_small.jazzmbr1": {
         "reference-name": "Jazz Band Member",
@@ -7777,59 +7777,59 @@
     },
     "rct2tt.scenery_small.killrvin": {
         "reference-name": "Climbing Vine Tree",
-        "name": "Arbo de Grimpantaj Vitoj"
+        "name": "Arbo de grimpantaj vitoj"
     },
     "rct2tt.scenery_small.knfight1": {
         "reference-name": "Animatronic Dark Knight",
-        "name": "Animatronika Malluma Kavaliro"
+        "name": "Animatronika malluma kavaliro"
     },
     "rct2tt.scenery_small.knfight2": {
         "reference-name": "Animatronic Dark Knight",
-        "name": "Animatronika Malluma Kavaliro"
+        "name": "Animatronika malluma kavaliro"
     },
     "rct2tt.scenery_small.largecpu": {
         "reference-name": "Super Computer Large CPU",
-        "name": "Granda Ĉefprocesoro de Superkomputilo"
+        "name": "Granda ĉefprocesoro de superkomputilo"
     },
     "rct2tt.scenery_small.laserx01": {
         "reference-name": "Laser Fence",
-        "name": "Lasera Barilo"
+        "name": "Lasera barilo"
     },
     "rct2tt.scenery_small.laserx02": {
         "reference-name": "Laser Fence Corner",
-        "name": "Angulo de Lasera Barilo"
+        "name": "Angulo de lasera barilo"
     },
     "rct2tt.scenery_small.mamthw01": {
         "reference-name": "Large Mammoth Fence",
-        "name": "Granda Mamuto-Barilo"
+        "name": "Granda mamuto-barilo"
     },
     "rct2tt.scenery_small.mamthw02": {
         "reference-name": "Large Mammoth Fence",
-        "name": "Granda Mamuto-Barilo"
+        "name": "Granda mamuto-barilo"
     },
     "rct2tt.scenery_small.mamthw03": {
         "reference-name": "Large Angled Mammoth Fence",
-        "name": "Granda Anguligita Mamuto-Barilo"
+        "name": "Granda anguligita mamuto-barilo"
     },
     "rct2tt.scenery_small.mamthw04": {
         "reference-name": "Large Angled Mammoth Fence",
-        "name": "Granda Anguligita Mamuto-Barilo"
+        "name": "Granda anguligita mamuto-barilo"
     },
     "rct2tt.scenery_small.mamthw05": {
         "reference-name": "Small Angled Mammoth Fence",
-        "name": "Malgranda Anguligita Mamuto-Barilo"
+        "name": "Malgranda anguligita mamuto-barilo"
     },
     "rct2tt.scenery_small.mamthw06": {
         "reference-name": "Small Angled Mammoth Fence",
-        "name": "Malgranda Anguligita Mamuto-Barilo"
+        "name": "Malgranda anguligita mamuto-barilo"
     },
     "rct2tt.scenery_small.mcastl02": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2tt.scenery_small.mcastl03": {
         "reference-name": "Castle Wall",
-        "name": "Muro de Kastelo"
+        "name": "Muro de kastelo"
     },
     "rct2tt.scenery_small.mcastl04": {
         "reference-name": "Castle Wall",
@@ -7837,31 +7837,31 @@
     },
     "rct2tt.scenery_small.mcastl05": {
         "reference-name": "Castle Ramparts Corner",
-        "name": "Angulo de Murego de Kastelo"
+        "name": "Angulo de murego de kastelo"
     },
     "rct2tt.scenery_small.mcastl06": {
         "reference-name": "Castle Ramparts",
-        "name": "Murego de Kastelo"
+        "name": "Murego de kastelo"
     },
     "rct2tt.scenery_small.mcastl07": {
         "reference-name": "Castle Ramparts Corner",
-        "name": "Angulo de Murego de Kastelo"
+        "name": "Angulo de murego de kastelo"
     },
     "rct2tt.scenery_small.mcastl08": {
         "reference-name": "Castle Ramparts Inverted Corner",
-        "name": "Inversigita Angulo de Murego de Kastelo"
+        "name": "Inversigita angulo de murego de kastelo"
     },
     "rct2tt.scenery_small.mcastl09": {
         "reference-name": "Castle Corner Piece",
-        "name": "Angulo de Kastelo"
+        "name": "Angulo de kastelo"
     },
     "rct2tt.scenery_small.mcastl10": {
         "reference-name": "Castle Ramparts Corner",
-        "name": "Angulo de Murego de Kastelo"
+        "name": "Angulo de murego de kastelo"
     },
     "rct2tt.scenery_small.mcastl19": {
         "reference-name": "Castle Corner Piece",
-        "name": "Angulo de Kastelo"
+        "name": "Angulo de kastelo"
     },
     "rct2tt.scenery_small.mdbucket": {
         "reference-name": "Bucket",
@@ -7869,7 +7869,7 @@
     },
     "rct2tt.scenery_small.mdusasta": {
         "reference-name": "Animatronic Medusa",
-        "name": "Animatronika Meduzo"
+        "name": "Animatronika meduzo"
     },
     "rct2tt.scenery_small.medstool": {
         "reference-name": "Stool",
@@ -7877,27 +7877,27 @@
     },
     "rct2tt.scenery_small.medtools": {
         "reference-name": "Farm Tools",
-        "name": "Iloj de Bieno"
+        "name": "Iloj de bieno"
     },
     "rct2tt.scenery_small.medtrget": {
         "reference-name": "Archery Target",
-        "name": "Celdisko por Arkopafo"
+        "name": "Celdisko por arkopafo"
     },
     "rct2tt.scenery_small.meteorcr": {
         "reference-name": "Meteor Crater Corner",
-        "name": "Angulo de Bolido-Kratero"
+        "name": "Angulo de bolido-kratero"
     },
     "rct2tt.scenery_small.meteorst": {
         "reference-name": "Meteor Crater Wall",
-        "name": "Muro de Bolido-Kratero"
+        "name": "Muro de bolido-kratero"
     },
     "rct2tt.scenery_small.metrcrs1": {
         "reference-name": "Meteor Crater Wall with Crystals",
-        "name": "Muro de Bolido-Kratero kun Kristaloj"
+        "name": "Muro de bolido-kratero kun kristaloj"
     },
     "rct2tt.scenery_small.metrcrs2": {
         "reference-name": "Meteor Crater Wall with Crystals",
-        "name": "Muro de Bolido-Kratero kun Kristaloj"
+        "name": "Muro de bolido-kratero kun kristaloj"
     },
     "rct2tt.scenery_small.minotaur": {
         "reference-name": "Minotaur Statue",
@@ -7905,287 +7905,287 @@
     },
     "rct2tt.scenery_small.oldnyk01": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk02": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk03": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk04": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk05": {
         "reference-name": "New York Roof Piece",
-        "name": "Novjorka Tegmentoparto"
+        "name": "Novjorka tegmentoparto"
     },
     "rct2tt.scenery_small.oldnyk06": {
         "reference-name": "New York Corner Filler",
-        "name": "Novjorka Diversaĵo por Angulo"
+        "name": "Novjorka diversaĵo por angulo"
     },
     "rct2tt.scenery_small.oldnyk07": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Inversigita Novjorka Anguloparto"
+        "name": "Inversigita novjorka anguloparto"
     },
     "rct2tt.scenery_small.oldnyk08": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Inversigita Novjorka Anguloparto"
+        "name": "Inversigita novjorka anguloparto"
     },
     "rct2tt.scenery_small.oldnyk09": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Inversigita Novjorka Anguloparto"
+        "name": "Inversigita novjorka anguloparto"
     },
     "rct2tt.scenery_small.oldnyk10": {
         "reference-name": "New York Inverted Corner Piece",
-        "name": "Inversigita Novjorka Anguloparto"
+        "name": "Inversigita novjorka anguloparto"
     },
     "rct2tt.scenery_small.oldnyk11": {
         "reference-name": "New York Wall with Line",
-        "name": "Novjorka Muro kun Pendigŝnuro"
+        "name": "Novjorka muro kun pendigŝnuro"
     },
     "rct2tt.scenery_small.oldnyk12": {
         "reference-name": "New York Washing Line",
-        "name": "Novjorka Pendigŝnuro"
+        "name": "Novjorka pendigŝnuro"
     },
     "rct2tt.scenery_small.oldnyk13": {
         "reference-name": "New York Wall with Line",
-        "name": "Novjorka Muro kun Pendigŝnuro"
+        "name": "Novjorka muro kun pendigŝnuro"
     },
     "rct2tt.scenery_small.oldnyk14": {
         "reference-name": "New York Washing Line",
-        "name": "Novjorka Pendigŝnuro"
+        "name": "Novjorka pendigŝnuro"
     },
     "rct2tt.scenery_small.oldnyk15": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk16": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk17": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk18": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk19": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk31": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk33": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk34": {
         "reference-name": "New York Wall Piece",
-        "name": "Novjorka Muroparto"
+        "name": "Novjorka muroparto"
     },
     "rct2tt.scenery_small.oldnyk35": {
         "reference-name": "New York Roof Piece",
-        "name": "Novjorka Tegmentoparto"
+        "name": "Novjorka tegmentoparto"
     },
     "rct2tt.scenery_small.pdflag02": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag03": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag04": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag05": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag06": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag08": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag13": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag14": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag15": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.pdflag16": {
         "reference-name": "Period Flag",
-        "name": "Historia Flago"
+        "name": "Historia flago"
     },
     "rct2tt.scenery_small.polwtbtn": {
         "reference-name": "Animatronic Police Officer",
-        "name": "Animatronika Policisto"
+        "name": "Animatronika policisto"
     },
     "rct2tt.scenery_small.primhead": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primhear": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primroor": {
         "reference-name": "Wood Fence with Climbing Vines",
-        "name": "Ligna Barilo kun Grimpantaj Vitejoj"
+        "name": "Ligna barilo kun grimpantaj vitejoj"
     },
     "rct2tt.scenery_small.primroot": {
         "reference-name": "Wood Fence with Climbing Vines",
-        "name": "Ligna Barilo kun Grimpantaj Vitejoj"
+        "name": "Ligna barilo kun grimpantaj vitejoj"
     },
     "rct2tt.scenery_small.primscrn": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primst01": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primst02": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primst03": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primtall": {
         "reference-name": "Wood Fence with Man Eating Plant",
-        "name": "Ligna Barilo kun Hommanĝanta Kreskaĵo"
+        "name": "Ligna barilo kun hommanĝanta kreskaĵo"
     },
     "rct2tt.scenery_small.primwal1": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Ligna Barilo kun Malvivaj Vitejoj"
+        "name": "Ligna barilo kun malvivaj vitejoj"
     },
     "rct2tt.scenery_small.primwal2": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Ligna Barilo kun Malvivaj Vitejoj"
+        "name": "Ligna barilo kun malvivaj vitejoj"
     },
     "rct2tt.scenery_small.primwal3": {
         "reference-name": "Wood Fence with Dead Vines",
-        "name": "Ligna Barilo kun Malvivaj Vitejoj"
+        "name": "Ligna barilo kun malvivaj vitejoj"
     },
     "rct2tt.scenery_small.psntwl01": {
         "reference-name": "Dark Age Village Roof with Chimney",
-        "name": "Tegmento de Vilaĝo de Malluma Epoko kun Fumtubo"
+        "name": "Tegmento de vilaĝo de Malluma Epoko kun fumtubo"
     },
     "rct2tt.scenery_small.psntwl02": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl03": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl04": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl05": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl06": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl07": {
         "reference-name": "Dark Age Village Lower Wall Piece",
-        "name": "Suba Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl08": {
         "reference-name": "Dark Age Village Lower Corner Piece",
-        "name": "Suba Anguloparto de Vilaĝo de Malluma Epoko"
+        "name": "Suba anguloparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl09": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Supra Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl10": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Supra Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl11": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Supra Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl12": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Supra Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl13": {
         "reference-name": "Dark Age Village Upper Wall Piece",
-        "name": "Supra Muroparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra muroparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl14": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl15": {
         "reference-name": "Dark Age Village Inverted Roof Piece",
-        "name": "Inversigita Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Inversigita tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl16": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl17": {
         "reference-name": "Dark Age Village Roof Piece",
-        "name": "Tegmentoparto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmentoparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl20": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Tegmento de Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmento de fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl21": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Tegmento de Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmento de fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl23": {
         "reference-name": "Dark Age Village Upper Corner Piece",
-        "name": "Supra Anguloparto de Vilaĝo de Malluma Epoko"
+        "name": "Supra anguloparto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl24": {
         "reference-name": "Dark Age Village Window Box",
-        "name": "Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl25": {
         "reference-name": "Dark Age Village Window Box",
-        "name": "Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl29": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Tegmento de Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmento de fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl30": {
         "reference-name": "Dark Age Village Window Box Roof",
-        "name": "Tegmento de Fenestrokesto de Vilaĝo de Malluma Epoko"
+        "name": "Tegmento de fenestrokesto de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.psntwl31": {
         "reference-name": "Dark Age Village Corner Roof Piece",
-        "name": "Anguloparto de Tegmento de Vilaĝo de Malluma Epoko"
+        "name": "Anguloparto de tegmento de vilaĝo de Malluma Epoko"
     },
     "rct2tt.scenery_small.rcknrolr": {
         "reference-name": "Cool Dude",
@@ -8193,11 +8193,11 @@
     },
     "rct2tt.scenery_small.rdmeto03": {
         "reference-name": "Red Meteor Crater Wall",
-        "name": "Muro de Ruĝa Bolido-Kratero"
+        "name": "Muro de ruĝa bolido-kratero"
     },
     "rct2tt.scenery_small.rdmeto04": {
         "reference-name": "Red Meteor Crater Inverted Corner",
-        "name": "Inversigita Angulo de Ruĝa Bolido-Kratero"
+        "name": "Inversigita angulo de ruĝa bolido-kratero"
     },
     "rct2tt.scenery_small.robnhood": {
         "reference-name": "Animatronic Robin Hood",
@@ -8205,31 +8205,31 @@
     },
     "rct2tt.scenery_small.rswatres": {
         "reference-name": "Rollerskating Waitress",
-        "name": "Radŝuanta Kelnerino"
+        "name": "Radŝuanta kelnerino"
     },
     "rct2tt.scenery_small.runway01": {
         "reference-name": "Runway Piece",
-        "name": "Parto de Aviokurejo"
+        "name": "Parto de aviokurejo"
     },
     "rct2tt.scenery_small.runway02": {
         "reference-name": "Runway Piece",
-        "name": "Parto de Aviokurejo"
+        "name": "Parto de aviokurejo"
     },
     "rct2tt.scenery_small.runway03": {
         "reference-name": "Runway Corner Piece",
-        "name": "Anguloparto de Aviokurejo"
+        "name": "Anguloparto de aviokurejo"
     },
     "rct2tt.scenery_small.runway04": {
         "reference-name": "Runway Edge Piece",
-        "name": "Bordoparto de Aviokurejo"
+        "name": "Bordoparto de aviokurejo"
     },
     "rct2tt.scenery_small.runway05": {
         "reference-name": "Runway Piece",
-        "name": "Parto de Aviokurejo"
+        "name": "Parto de aviokurejo"
     },
     "rct2tt.scenery_small.runway06": {
         "reference-name": "Runway Inverted Corner Piece",
-        "name": "Inversigita Anguloparto de Aviokurejo"
+        "name": "Inversigita anguloparto de aviokurejo"
     },
     "rct2tt.scenery_small.schnbost": {
         "reference-name": "Buoy",
@@ -8241,7 +8241,7 @@
     },
     "rct2tt.scenery_small.schncrsh": {
         "reference-name": "Wrecked Seaplane",
-        "name": "Rompita Hidroplano"
+        "name": "Rompita hidroplano"
     },
     "rct2tt.scenery_small.schndrum": {
         "reference-name": "Oil Barrel",
@@ -8273,135 +8273,135 @@
     },
     "rct2tt.scenery_small.schntnny": {
         "reference-name": "Racing Tannoy",
-        "name": "Vetkuranta Laŭtparolilo"
+        "name": "Vetkuranta laŭtparolilo"
     },
     "rct2tt.scenery_small.sdragfly": {
         "reference-name": "Animatronic Dragonflies",
-        "name": "Animatronikaj Libeloj"
+        "name": "Animatronikaj libeloj"
     },
     "rct2tt.scenery_small.shwdfrst": {
         "reference-name": "Forest Trees",
-        "name": "Arboj de Arbaro"
+        "name": "Arboj de arbaro"
     },
     "rct2tt.scenery_small.skeleto1": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Animatronika Skeleta Armeo"
+        "name": "Animatronika skeleta armeo"
     },
     "rct2tt.scenery_small.skeleto2": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Animatronika Skeleta Armeo"
+        "name": "Animatronika skeleta armeo"
     },
     "rct2tt.scenery_small.skeleto3": {
         "reference-name": "Animatronic Skeletal Army",
-        "name": "Animatronika Skeleta Armeo"
+        "name": "Animatronika skeleta armeo"
     },
     "rct2tt.scenery_small.smallcpu": {
         "reference-name": "Super Computer Small CPU",
-        "name": "Malgranda Ĉefprocesoro de Superkomputilo"
+        "name": "Malgranda ĉefprocesoro de superkomputilo"
     },
     "rct2tt.scenery_small.smoksk01": {
         "reference-name": "Large Smoking Chimney",
-        "name": "Granda Fulmanta Fumtubo"
+        "name": "Granda fulmanta fumtubo"
     },
     "rct2tt.scenery_small.smoksk02": {
         "reference-name": "Smoke Stack Mid",
-        "name": "Mezo de Fumstako"
+        "name": "Mezo de fumstako"
     },
     "rct2tt.scenery_small.smoksk03": {
         "reference-name": "Smoke Stack Base",
-        "name": "Bazo de Fumstako"
+        "name": "Bazo de fumstako"
     },
     "rct2tt.scenery_small.soupcrn2": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.soupcrnr": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.souped01": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.souped02": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.souptl01": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.souptl02": {
         "reference-name": "Primordial Soup",
-        "name": "Praa Supo"
+        "name": "Praa supo"
     },
     "rct2tt.scenery_small.spacrang": {
         "reference-name": "Animatronic Space Ranger",
-        "name": "Animatronika Policisto de Kosmaspaco"
+        "name": "Animatronika policisto de kosmaspaco"
     },
     "rct2tt.scenery_small.spcshp01": {
         "reference-name": "Space Ship Cargo Section",
-        "name": "Kargoparto de Kosmoŝipo"
+        "name": "Kargoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp02": {
         "reference-name": "Space Ship Comms Section",
-        "name": "Komunikadoparto de Kosmoŝipo"
+        "name": "Komunikadoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp03": {
         "reference-name": "Space Ship Solar Section",
-        "name": "Sunparto de Kosmoŝipo"
+        "name": "Sunpanela sekcio de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp04": {
         "reference-name": "Space Ship Solar Panels",
-        "name": "Sunpaneloj de Kosmoŝipo"
+        "name": "Sunpaneloj de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp05": {
         "reference-name": "Space Ship Gravity Section",
-        "name": "Gravitoparto de Kosmoŝipo"
+        "name": "Gravitoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp06": {
         "reference-name": "Space Ship Cross Section",
-        "name": "Sekco de Kosmoŝipo"
+        "name": "Sekco de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp07": {
         "reference-name": "Space Ship Control Deck",
-        "name": "Regferdeko de Kosmoŝipo"
+        "name": "Regferdeko de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp08": {
         "reference-name": "Space Ship Fuel Section",
-        "name": "Fueloparto de Kosmoŝipo"
+        "name": "Fueloparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp09": {
         "reference-name": "Space Ship Docking Section",
-        "name": "Dokoparto de Kosmoŝipo"
+        "name": "Dokoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp10": {
         "reference-name": "Space Ship Engine Section",
-        "name": "Motoroparto de Kosmoŝipo"
+        "name": "Motoroparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp11": {
         "reference-name": "Space Ship Living Section",
-        "name": "Vivoparto de Kosmoŝipo"
+        "name": "Vivoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.spcshp12": {
         "reference-name": "Space Ship Science Section",
-        "name": "Sciencoparto de Kosmoŝipo"
+        "name": "Sciencoparto de kosmoŝipo"
     },
     "rct2tt.scenery_small.speakr01": {
         "reference-name": "Small Speaker",
-        "name": "Malgranda Laŭtparolilo"
+        "name": "Malgranda laŭtparolilo"
     },
     "rct2tt.scenery_small.speakr02": {
         "reference-name": "Large Speaker",
-        "name": "Granda Laŭtparolilo"
+        "name": "Granda laŭtparolilo"
     },
     "rct2tt.scenery_small.spiktail": {
         "reference-name": "Animatronic Stegosaurus",
-        "name": "Animatronika Stegosaŭro"
+        "name": "Animatronika stegosaŭro"
     },
     "rct2tt.scenery_small.spterdac": {
         "reference-name": "Animatronic flapping Pterodactyl",
-        "name": "Animatronika fluganta Pterodaktilo"
+        "name": "Animatronika fluganta pterodaktilo"
     },
     "rct2tt.scenery_small.stgband1": {
         "reference-name": "Band Member",
@@ -8421,23 +8421,23 @@
     },
     "rct2tt.scenery_small.stmdran1": {
         "reference-name": "Steaming Drains",
-        "name": "Vaporantaj Defluejoj"
+        "name": "Vaporantaj defluejoj"
     },
     "rct2tt.scenery_small.stnesta1": {
         "reference-name": "Men Turned to Stone",
-        "name": "Homoj Farigitaj al Ŝtono"
+        "name": "Homoj farigitaj al ŝtono"
     },
     "rct2tt.scenery_small.stnesta2": {
         "reference-name": "Men Turned to Stone",
-        "name": "Homoj Farigitaj al Ŝtono"
+        "name": "Homoj farigitaj al ŝtono"
     },
     "rct2tt.scenery_small.stnesta3": {
         "reference-name": "Men Turned to Stone",
-        "name": "Homoj Farigitaj al Ŝtono"
+        "name": "Homoj farigitaj al ŝtono"
     },
     "rct2tt.scenery_small.stnesta4": {
         "reference-name": "Men Turned to Stone",
-        "name": "Homoj Farigitaj al Ŝtono"
+        "name": "Homoj farigitaj al ŝtono"
     },
     "rct2tt.scenery_small.stoolset": {
         "reference-name": "Stools",
@@ -8445,7 +8445,7 @@
     },
     "rct2tt.scenery_small.strictop": {
         "reference-name": "Animatronic Triceratops",
-        "name": "Animatronika Triceratopo"
+        "name": "Animatronika triceratopo"
     },
     "rct2tt.scenery_small.swamplt1": {
         "reference-name": "Swamp Plant",
@@ -8485,63 +8485,63 @@
     },
     "rct2tt.scenery_small.swrdstne": {
         "reference-name": "Sword in the Stone",
-        "name": "Glavo en la Ŝtono"
+        "name": "Glavo en la ŝtono"
     },
     "rct2tt.scenery_small.tarpit01": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit02": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit03": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit04": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit05": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit06": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit07": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit08": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit09": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit10": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit11": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit12": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit13": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.tarpit14": {
         "reference-name": "Bubbling Tarpit",
-        "name": "Bobelanta Gudrejo"
+        "name": "Bobelanta gudrejo"
     },
     "rct2tt.scenery_small.titansta": {
         "reference-name": "Atlas Statue",
@@ -8549,7 +8549,7 @@
     },
     "rct2tt.scenery_small.tyranrex": {
         "reference-name": "Animatronic T-Rex",
-        "name": "Animatronika Tiranosaŭro"
+        "name": "Animatronika tiranosaŭro"
     },
     "rct2tt.scenery_small.valkri01": {
         "reference-name": "Valkyrie",
@@ -8561,15 +8561,15 @@
     },
     "rct2tt.scenery_small.volcvent": {
         "reference-name": "Active Volcanic Vent",
-        "name": "Aktiva Vulkano"
+        "name": "Aktiva vulkano"
     },
     "rct2tt.scenery_small.waveking": {
         "reference-name": "Animatronic Waving King",
-        "name": "Animatronika Mangestanta Reĝo"
+        "name": "Animatronika mangestanta reĝo"
     },
     "rct2tt.scenery_small.wdncart2": {
         "reference-name": "Wooden Cart",
-        "name": "Ligna Ĉarelo"
+        "name": "Ligna ĉarelo"
     },
     "rct2tt.scenery_small.wepnrack": {
         "reference-name": "Weapon Set",
@@ -8577,15 +8577,15 @@
     },
     "rct2tt.scenery_small.whccolds": {
         "reference-name": "Witches around Cauldron",
-        "name": "Sorĉistinoj ĉirkaŭ Kaldrono"
+        "name": "Sorĉistinoj ĉirkaŭ kaldrono"
     },
     "rct2tt.scenery_small.wiskybl1": {
         "reference-name": "Whisky Barrel",
-        "name": "Viskio-Barelo"
+        "name": "Viskio-barelo"
     },
     "rct2tt.scenery_small.wiskybl2": {
         "reference-name": "Whisky Barrels",
-        "name": "Viskio-Bareloj"
+        "name": "Viskio-bareloj"
     },
     "rct2tt.scenery_small.yewtreex": {
         "reference-name": "Yew Tree",
@@ -8597,43 +8597,43 @@
     },
     "rct2tt.scenery_wall.jailxx19": {
         "reference-name": "Prison Fence",
-        "name": "Barilo de Malliberejo"
+        "name": "Barilo de malliberejo"
     },
     "rct2tt.scenery_wall.mspkwa01": {
         "reference-name": "Spiked Fence",
-        "name": "Pinta Barilo"
+        "name": "Pinta barilo"
     },
     "rct2ww.park_entrance.africent": {
         "reference-name": "Africa Park Entrance",
-        "name": "Afrika Parkenirejo"
+        "name": "Afrika parkenirejo"
     },
     "rct2ww.park_entrance.euroent": {
         "reference-name": "European Park Entrance",
-        "name": "Eŭropa Parkenirejo"
+        "name": "Eŭropa parkenirejo"
     },
     "rct2ww.park_entrance.iceent": {
         "reference-name": "Ice Park Entrance",
-        "name": "Glacio-Parkenirejo"
+        "name": "Glacia parkenirejo"
     },
     "rct2ww.park_entrance.japent": {
         "reference-name": "Japanese Park Entrance",
-        "name": "Japana Parkenirejo"
+        "name": "Japana parkenirejo"
     },
     "rct2ww.park_entrance.naent": {
         "reference-name": "North America Park Entrance",
-        "name": "Nordamerika Parkenirejo"
+        "name": "Nordamerika parkenirejo"
     },
     "rct2ww.park_entrance.ozentran": {
         "reference-name": "Australasian Park Entrance",
-        "name": "Aŭstralazia Parkenirejo"
+        "name": "Aŭstralazia parkenirejo"
     },
     "rct2ww.park_entrance.samerent": {
         "reference-name": "South American Park Entrance",
-        "name": "Sudamerika Parkenirejo"
+        "name": "Sudamerika parkenirejo"
     },
     "rct2ww.ride.anaconda": {
         "reference-name": "Anaconda Trains",
-        "name": "Anakondaj Trajnoj",
+        "name": "Anakondaj trajnoj",
         "reference-description": "Spacious trains with simple lap restraints",
         "description": "Grandspacaj trajnoj kun simplaj sinobridoj",
         "reference-capacity": "6 passengers per car",
@@ -8641,15 +8641,15 @@
     },
     "rct2ww.ride.blackcab": {
         "reference-name": "Black Cabs",
-        "name": "Nigraj Taksioj",
+        "name": "Nigraj taksioj",
         "reference-description": "Powered vehicles in the shape of London Taxis",
-        "description": "Ŝaltitaj veturiloj formitaj kiel Taksioj de Londono",
+        "description": "Ŝaltitaj veturiloj, formitaj kiel taksioj de Londono",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por aŭto"
     },
     "rct2ww.ride.bomerang": {
         "reference-name": "Boomerang Trains",
-        "name": "Bumerango-Trajnoj",
+        "name": "Bumerango-trajnoj",
         "reference-description": "Air-powered launched roller coaster trains in the shape of boomerangs",
         "description": "Trajnoj de onda fervojo, lanĉitaj per aero kaj formitaj kiel bumerangoj",
         "reference-capacity": "2 passengers per car",
@@ -8659,13 +8659,13 @@
         "reference-name": "Bullet Trains",
         "name": "Ŝinkansenoj",
         "reference-description": "Japanese Bullet Train themed roller coaster cars",
-        "description": "Ĉaroj de onda fervojo kun temo de Japana Ŝinkanseno",
+        "description": "Ĉaroj de onda fervojo kun temo de japana Ŝinkanseno",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.caddilac": {
         "reference-name": "Limousine Trains",
-        "name": "Limuzino-Trajnoj",
+        "name": "Limuzino-trajnoj",
         "reference-description": "Limousine-themed roller coaster cars",
         "description": "Ĉaroj de onda fervojo kun temo de limuzino",
         "reference-capacity": "4 passengers per car",
@@ -8673,7 +8673,7 @@
     },
     "rct2ww.ride.coffeecu": {
         "reference-name": "Coffee Cup Ride",
-        "name": "Kafotaso-Atrakcio",
+        "name": "Kafotaso-atrakcio",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large animated coffee grinder",
         "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda animita kafmuelilo",
         "reference-capacity": "18 passengers",
@@ -8681,7 +8681,7 @@
     },
     "rct2ww.ride.condorrd": {
         "reference-name": "Condor Trains",
-        "name": "Kondoro-Trajnoj",
+        "name": "Kondoro-trajnoj",
         "reference-description": "Riding in special harnesses below the track, riders experience the feeling of flight in condor-shaped trains",
         "description": "Rajdante en specialaj jungaĵoj sub la trako, rajdantoj spertas la senton de flugado en kondorformaj trajnoj",
         "reference-capacity": "4 passengers per car",
@@ -8689,7 +8689,7 @@
     },
     "rct2ww.ride.congaeel": {
         "reference-name": "Conger Eel Trains",
-        "name": "Kongro-Trajnoj",
+        "name": "Kongro-trajnoj",
         "reference-description": "Trains with shoulder restraints, in the shape of conger eels",
         "description": "Trajnoj kun ŝultrobridoj, formitaj kiel kongroj",
         "reference-capacity": "4 passengers per car",
@@ -8697,31 +8697,31 @@
     },
     "rct2ww.ride.crnvbfly": {
         "reference-name": "Carnival Butterfly Cars",
-        "name": "Karnavalaj Papilio-Ĉaroj",
+        "name": "Karnavalaj papilio-ĉaroj",
         "reference-description": "Cars in the shape of butterfly carnival floats",
-        "description": "Ĉaroj formitaj kiel papilio-paradiloj",
+        "description": "Ĉaroj, formitaj kiel papilio-paradiloj",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.crnvfrog": {
         "reference-name": "Carnival Frog Cars",
-        "name": "Karnavalaj Rano-Ĉaroj",
+        "name": "Karnavalaj rano-ĉaroj",
         "reference-description": "Cars in the shape of frog carnival floats",
-        "description": "Ĉaroj formitaj kiel rano-paradiloj",
+        "description": "Ĉaroj, formitaj kiel rano-paradiloj",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.crnvlzrd": {
         "reference-name": "Carnival Lizard Cars",
-        "name": "Karnavalaj Lacerto-Ĉaroj",
+        "name": "Karnavalaj lacerto-ĉaroj",
         "reference-description": "Cars in the shape of lizard carnival floats",
-        "description": "Ĉaroj formitaj kiel lacerto-paradiloj",
+        "description": "Ĉaroj, formitaj kiel lacerto-paradiloj",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.crocflum": {
         "reference-name": "Crocodile Boats",
-        "name": "Krokadilo-Boatoj",
+        "name": "Krokadilo-boatoj",
         "reference-description": "Crocodile-shaped boats built for running in water channels",
         "description": "Krokadiloformaj boatoj konstruitaj por veturi en akvokanaloj",
         "reference-capacity": "4 passengers per boat",
@@ -8729,7 +8729,7 @@
     },
     "rct2ww.ride.dhowwatr": {
         "reference-name": "Dhow Boats",
-        "name": "Daŭo-Boatoj",
+        "name": "Daŭo-boatoj",
         "reference-description": "Decorative fishing boats, which the passengers paddle themselves",
         "description": "Boatoj por fiŝkapti, kiujn la pasaĝeroj padelas per si mem",
         "reference-capacity": "2 passengers per boat",
@@ -8737,7 +8737,7 @@
     },
     "rct2ww.ride.diamondr": {
         "reference-name": "Diamond Ride",
-        "name": "Diamanto-Atrakcio",
+        "name": "Diamanto-atrakcio",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large diamond",
         "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda diamanto",
         "reference-capacity": "18 passengers",
@@ -8745,7 +8745,7 @@
     },
     "rct2ww.ride.dolphinr": {
         "reference-name": "Dolphin Boats",
-        "name": "Delfeno-Boatoj",
+        "name": "Delfeno-boatoj",
         "reference-description": "Single-seater dolphin-shaped vehicles which riders can drive themselves",
         "description": "Delfenoformaj veturiloj, kiujn rajdantoj povas stiri per si mem",
         "reference-capacity": "1 rider per vehicle",
@@ -8753,15 +8753,15 @@
     },
     "rct2ww.ride.dragdodg": {
         "reference-name": "Chinese Dragonhead Dodgems",
-        "name": "Ĉinaj Drakokapaj Doĝemoj",
+        "name": "Ĉinaj drakokapaj kunfrapemaj aŭtetoj",
         "reference-description": "Guests battle each other in dragonhead-shaped dodgems",
-        "description": "Gastoj batalas unu la alian en drakokapoformaj doĝemoj",
+        "description": "Gastoj batalas unu la alian en drakokapoformaj aŭtetoj",
         "reference-capacity": "1 person per car",
         "capacity": "Po 1 ulo por ĉaro"
     },
     "rct2ww.ride.dragon": {
         "reference-name": "Dragon Trains",
-        "name": "Drako-Trajnoj",
+        "name": "Drako-trajnoj",
         "reference-description": "Dragon-themed roller coaster cars",
         "description": "Ĉaroj de onda fervojo kun drakotemo",
         "reference-capacity": "4 passengers per car",
@@ -8769,7 +8769,7 @@
     },
     "rct2ww.ride.faberge": {
         "reference-name": "Fabergé Egg Ride",
-        "name": "Atrakcio de Ovo de Fabergé",
+        "name": "Atrakcio de ovo de Fabergé",
         "reference-description": "Riders ride in pairs of themed seats rotating around a large Fabergé egg replica",
         "description": "Rajdantoj rajdas en paroj da temitaj seĝoj, kiuj turniĝas ĉirkaŭ granda replikaĵo de ovo de Fabergé",
         "reference-capacity": "18 passengers",
@@ -8777,7 +8777,7 @@
     },
     "rct2ww.ride.fightkit": {
         "reference-name": "Fighting Kite Ride",
-        "name": "Atrakcio de Batalantaj Flugludiloj",
+        "name": "Atrakcio de batalantaj flugludiloj",
         "reference-description": "Riders ride in pairs of seats rotating around the ends of three long rotating arms",
         "description": "Rajdantoj rajdas en paroj da seĝoj, kiuj turniĝas ĉirkaŭ la finoj de tri longaj turniĝantaj brakoj",
         "reference-capacity": "18 passengers",
@@ -8785,7 +8785,7 @@
     },
     "rct2ww.ride.firecrak": {
         "reference-name": "Fire Cracker Ride",
-        "name": "Fajraĵo-Atrakcio",
+        "name": "Fajraĵo-atrakcio",
         "reference-description": "Rotating wheel with suspended passenger pods, which first starts spinning and is then tilted up by a supporting arm",
         "description": "Turniĝanta radego kun penditaj pasaĝerujoj, kiu unue komencas turniĝi, kaj tiam estas klinita supren per apoga brako",
         "reference-capacity": "16 passengers",
@@ -8793,7 +8793,7 @@
     },
     "rct2ww.ride.football": {
         "reference-name": "Football Trains",
-        "name": "Piedpilko-Trajnoj",
+        "name": "Piedpilko-trajnoj",
         "reference-description": "Suspended roller coaster trains consisting of football-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el piedpilkoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
         "reference-capacity": "4 passengers per car",
@@ -8801,7 +8801,7 @@
     },
     "rct2ww.ride.gorilla": {
         "reference-name": "Gorilla Trains",
-        "name": "Gorilo-Trajnoj",
+        "name": "Gorilo-trajnoj",
         "reference-description": "Suspended roller coaster trains consisting of gorilla-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el goriloformaj ĉaroj, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
         "reference-capacity": "4 passengers per car",
@@ -8809,7 +8809,7 @@
     },
     "rct2ww.ride.gratwhte": {
         "reference-name": "Great White Shark Trains",
-        "name": "Trajnoj de Granda Blanka Ŝarko",
+        "name": "Granda-blanka-ŝarko-stilaj trajnoj",
         "reference-description": "Trains with shoulder restraints, in the shape of a great white shark",
         "description": "Trajnoj kun ŝultrobridoj, formitaj kiel granda blanka ŝarko",
         "reference-capacity": "4 passengers per car",
@@ -8817,7 +8817,7 @@
     },
     "rct2ww.ride.hipporid": {
         "reference-name": "Hippo Submarines",
-        "name": "Hipopotamo-Submarŝipoj",
+        "name": "Hipopotamo-submarŝipoj",
         "reference-description": "Riders ride in a submerged hippo-shaped submarine through an underwater course",
         "description": "Rajdantoj rajdas en subakvigita hipopotamoforma submarŝipo tra subakva kurso",
         "reference-capacity": "5 passengers per submarine",
@@ -8825,7 +8825,7 @@
     },
     "rct2ww.ride.huskie": {
         "reference-name": "Huskie Car",
-        "name": "Sledhundo-Ĉaro",
+        "name": "Sledhundo-ĉaro",
         "reference-description": "Powered vehicles in the shape of Huskie sleds",
         "description": "Ŝaltitaj veturiloj, formitaj kiel sledoj de sledhundoj",
         "reference-capacity": "2 passengers per car",
@@ -8833,7 +8833,7 @@
     },
     "rct2ww.ride.italypor": {
         "reference-name": "Italian Police Ride",
-        "name": "Itala Polico-Atrakcio",
+        "name": "Itala polico-atrakcio",
         "reference-description": "Riders ride in pairs in Italian police car replicas and rotate in circles",
         "description": "Rajdantoj rajdas pare en replikaĵoj de italaj policaj aŭtoj, kaj turniĝas cirkle",
         "reference-capacity": "18 passengers",
@@ -8841,7 +8841,7 @@
     },
     "rct2ww.ride.jaguarrd": {
         "reference-name": "Jaguar Cars",
-        "name": "Jaguaro-Aŭtoj",
+        "name": "Jaguaro-aŭtoj",
         "reference-description": "Roller coaster cars themed to look like jaguars",
         "description": "Ĉaroj de onda fervojo temitaj por aspekti kiel jaguaroj",
         "reference-capacity": "4 passengers per car",
@@ -8849,7 +8849,7 @@
     },
     "rct2ww.ride.junkswng": {
         "reference-name": "Chinese Junk Swing Ride",
-        "name": "Sving-Atrackio de Ĉina Ĵonko",
+        "name": "Sving-atrackio de ĉina ĵonko",
         "reference-description": "Ship is attached to an arm with a counterweight at the opposite end, and swings through a complete 360 degrees",
         "description": "La ŝipo estas fiksita al brako, kiu havas kontraŭpezon al la kontraŭa flanko, kaj svingiĝas tra plenaj 360 gradoj",
         "reference-capacity": "12 passengers",
@@ -8857,7 +8857,7 @@
     },
     "rct2ww.ride.killwhal": {
         "reference-name": "Killer Whale Submarines",
-        "name": "Granda-Orcino-Submarŝipoj",
+        "name": "Granda-orcino-submarŝipoj",
         "reference-description": "Riders ride in a submerged whale-shaped submarine through an underwater course",
         "description": "Rajdantoj rajdas en subakvigita orcinoforma submarŝipo tra subakva kurso",
         "reference-capacity": "5 passengers per submarine",
@@ -8865,7 +8865,7 @@
     },
     "rct2ww.ride.kolaride": {
         "reference-name": "Koala Car",
-        "name": "Koalo-Ĉaro",
+        "name": "Koalo-ĉaro",
         "reference-description": "Large koala-shaped coaster car for the Reverse Freefall Coaster",
         "description": "Granda koaloforma ĉaro de onda fervojo por la Onda Fervojo kun Dorsantaŭa Libera Falo",
         "reference-capacity": "8 passengers per car",
@@ -8873,7 +8873,7 @@
     },
     "rct2ww.ride.lionride": {
         "reference-name": "Lion Cars",
-        "name": "Leono-Ĉaroj",
+        "name": "Leono-ĉaroj",
         "reference-description": "Roller coaster cars themed to look like lions",
         "description": "Ĉaroj de onda fervojo temitaj por aspekti kiel leonoj",
         "reference-capacity": "4 passengers per car",
@@ -8881,15 +8881,15 @@
     },
     "rct2ww.ride.londonbs": {
         "reference-name": "Routemaster Buses",
-        "name": "Londonaj Etaĝaj Busoj",
+        "name": "Londonaj etaĝaj busoj",
         "reference-description": "Replicas of the famous London Routemaster bus",
-        "description": "Replikaĵoj de la fama Londona Etaĝa Buso",
+        "description": "Replikaĵoj de la fama londona etaĝa buso",
         "reference-capacity": "10 passengers per car",
         "capacity": "Po 10 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.mandarin": {
         "reference-name": "Mandarin Duck Boats",
-        "name": "Mandarenanaso-Boatoj",
+        "name": "Mandarenanaso-boatoj",
         "reference-description": "Duck-shaped boats, propelled by the pedalling front seat passengers",
         "description": "Anasoformaj boatoj, kiujn la pedalado de la frontaj pasaĝeroj antaŭenigas",
         "reference-capacity": "2 passengers per boat",
@@ -8897,7 +8897,7 @@
     },
     "rct2ww.ride.mantaray": {
         "reference-name": "Manta Ray Boats",
-        "name": "Mantarajo-Boatoj",
+        "name": "Mantarajo-boatoj",
         "reference-description": "Coaster boats in the shape of a manta ray",
         "description": "Boatoj de onda fervojo formitaj kiel mantarajo",
         "reference-capacity": "6 passengers per boat",
@@ -8905,7 +8905,7 @@
     },
     "rct2ww.ride.minecart": {
         "reference-name": "Mine Cart Trains",
-        "name": "Trajnoj de Minĉaro",
+        "name": "Trajnoj de minĉaro",
         "reference-description": "Wooden roller coaster trains with padded seats and lap bar restraints",
         "description": "Lignaj trajnoj de onda fervojo, kun komfortaj seĝoj kaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -8913,7 +8913,7 @@
     },
     "rct2ww.ride.minelift": {
         "reference-name": "Mine Lift Cabin",
-        "name": "Kajuto de Minlifto",
+        "name": "Kajuto de minlifto",
         "reference-description": "A steel lift cabin commonly used in mines",
         "description": "Ŝtala liftokajuto ofte uzita en minoj",
         "reference-capacity": "16 passengers",
@@ -8921,7 +8921,7 @@
     },
     "rct2ww.ride.ostrich": {
         "reference-name": "Ostrich Trains",
-        "name": "Struto-Trajnoj",
+        "name": "Struto-trajnoj",
         "reference-description": "Roller coaster trains in which the riders ride in a standing position and the cars are themed to look like ostriches",
         "description": "Trajnoj de onda fervojo, en kiuj la rajdantoj rajdas en staranta pozicio, kaj la aŭtoj estas temitaj por aspekti kiel strutoj",
         "reference-capacity": "4 passengers per car",
@@ -8929,7 +8929,7 @@
     },
     "rct2ww.ride.outriggr": {
         "reference-name": "Outrigger Canoes",
-        "name": "Polineziaj Kanuoj",
+        "name": "Polineziaj kanuoj",
         "reference-description": "Long canoes which the passengers paddle themselves",
         "description": "Longaj kanuoj, kiujn la pasaĝeroj padelas per si mem",
         "reference-capacity": "2 passengers per canoe",
@@ -8937,7 +8937,7 @@
     },
     "rct2ww.ride.penguinb": {
         "reference-name": "Penguin Trains",
-        "name": "Pingveno-Trajnoj",
+        "name": "Pingveno-trajnoj",
         "reference-description": "Penguin-shaped trains consisting of 2-seater cars where the riders are behind each other",
         "description": "Pingvenoformaj trajnoj, konsista el ĉaroj kun 2 seĝoj, kie la rajdantoj estas post unu la alian",
         "reference-capacity": "2 passengers per car",
@@ -8945,7 +8945,7 @@
     },
     "rct2ww.ride.polarber": {
         "reference-name": "Polar Bear Trains",
-        "name": "Blankaj Urso-Trajnoj",
+        "name": "Blanka-urso-trajnoj",
         "reference-description": "Polar bear-shaped suspended roller coaster trains in which riders sit in pairs facing either forwards or backwards",
         "description": "Penditaj trajnoj formitaj kiel blankaj ursoj, en kiuj rajdantoj sidas pare, kaj frontas aŭ antaŭe aŭ malantaŭe",
         "reference-capacity": "4 passengers per car",
@@ -8953,7 +8953,7 @@
     },
     "rct2ww.ride.rhinorid": {
         "reference-name": "Rhino Trains",
-        "name": "Rinocero-Trajnoj",
+        "name": "Rinocero-trajnoj",
         "reference-description": "Compact roller coaster trains with cars with in-line seating, themed to look like rhinos",
         "description": "Kompaktaj trajnoj de onda fervojo kun kolono da seĝoj, temitaj por aspekti kiel rinoceroj",
         "reference-capacity": "6 passengers per car",
@@ -8961,7 +8961,7 @@
     },
     "rct2ww.ride.rocket": {
         "reference-name": "1950s Rockets",
-        "name": "Raketoj de la 1950-aj",
+        "name": "Raketoj de la 1950-aj jaroj",
         "reference-description": "Suspended rocket-shaped roller coaster trains consisting of cars able to swing freely as the train goes around corners",
         "description": "Penditaj raketoformaj trajnoj de onda fervojo, kiuj enhavas ĉarojn, kiuj povas svingiĝi libere kiam la trajno iras ĉirkaŭ anguloj",
         "reference-capacity": "4 passengers per car",
@@ -8969,7 +8969,7 @@
     },
     "rct2ww.ride.rssncrrd": {
         "reference-name": "Trabant Cars",
-        "name": "Trabant-Aŭtoj",
+        "name": "Trabant-aŭtoj",
         "reference-description": "Roller coaster cars in the shape of replica Trabant cars",
         "description": "Trajnoj de onda fervojo formitaj kiel replikaĵoj de Trabant-aŭtoj",
         "reference-capacity": "4 passengers per car",
@@ -8985,7 +8985,7 @@
     },
     "rct2ww.ride.seals": {
         "reference-name": "Seal Trains",
-        "name": "Foko-Trajnoj",
+        "name": "Foko-trajnoj",
         "reference-description": "Roller coaster trains with shoulder restraints themed to look like seals",
         "description": "Trajnoj de onda fervojo kun ŝultrobridoj, temitaj por aspekti kiel fokoj",
         "reference-capacity": "4 passengers per car",
@@ -8993,7 +8993,7 @@
     },
     "rct2ww.ride.skidoo": {
         "reference-name": "Snowmobile Dodgems",
-        "name": "Motorsledoformaj Doĝemoj",
+        "name": "Motorsledoformaj kunfrapantaj aŭtetoj",
         "reference-description": "Guests slide around in snowmobile-shaped vehicles that they freely control",
         "description": "Gastoj glitas en motorsledoformaj veturiloj, kiujn ili stiras libere",
         "reference-capacity": "1 person per car",
@@ -9001,7 +9001,7 @@
     },
     "rct2ww.ride.sloth": {
         "reference-name": "Sloth Trains",
-        "name": "Bradipo-Trajnoj",
+        "name": "Bradipo-trajnoj",
         "reference-description": "Suspended roller coaster trains consisting of sloth-shaped cars able to swing freely as the train goes around corners",
         "description": "Penditaj trajnoj de onda fervojo, kiuj konsistas el bradipoformaj ĉaroj, kiuj svingiĝas libere kiam la trajno iras ĉirkaŭ anguloj",
         "reference-capacity": "4 passengers per car",
@@ -9009,15 +9009,15 @@
     },
     "rct2ww.ride.sputnikr": {
         "reference-name": "Sputnik Cars",
-        "name": "Sputnik-formaj Ĉaroj",
+        "name": "Sputnik-formaj ĉaroj",
         "reference-description": "Russian satellite-shaped cars which swing from the rail above",
-        "description": "Rusaj satelitoformaj ĉaroj, kiuj svingiĝas sub la relo supere",
+        "description": "Ĉaroj, formitaj kiel rusaj satelitoj, kiuj svingiĝas sub la relo supere",
         "reference-capacity": "2 passengers per car",
         "capacity": "Po 2 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.steamtrn": {
         "reference-name": "Maharaja Steam Trains",
-        "name": "Maharaĝo-Lokomotivoj",
+        "name": "Maharaĝo-lokomotivoj",
         "reference-description": "Miniature steam trains consisting of a replica steam locomotive and tender, pulling closed-top wooden carriages",
         "description": "Miniaturaj lokomotivoj, kiuj konsistas el replikaĵo de lokomotivo kaj tendro, kiuj tenas nesubĉielajn lignajn kaleŝojn",
         "reference-capacity": "6 passengers per carriage",
@@ -9033,7 +9033,7 @@
     },
     "rct2ww.ride.surfbrdc": {
         "reference-name": "Surfing Trains",
-        "name": "Surfantaj Trajnoj",
+        "name": "Surfantaj trajnoj",
         "reference-description": "Wide coaster trains on which the riders stand on a surfboard with specially designed restraints",
         "description": "Larĝaj trajnoj de onda fervojo, sur kiuj la rajdantoj staras sur surfotabulo kun speciale desegnitaj sinobridoj",
         "reference-capacity": "4 passengers per car",
@@ -9041,15 +9041,15 @@
     },
     "rct2ww.ride.taxicstr": {
         "reference-name": "Yellow Taxi Trains",
-        "name": "Flavaj Taksio-Trajnoj",
+        "name": "Flavaj taksio-trajnoj",
         "reference-description": "Roller coaster trains for the Giga Coaster, themed to look like long yellow taxis",
-        "description": "Trajnoj por la Altega Onda Fervojo, temitaj por aspekti kiel longaj flavaj taksioj",
+        "description": "Trajnoj por la altega onda fervojo, temitaj por aspekti kiel longaj flavaj taksioj",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.tgvtrain": {
         "reference-name": "TGV Trains",
-        "name": "TGV Trajnoj",
+        "name": "TGV-stilaj trajnoj",
         "reference-description": "Roller coaster trains in the style of French high-speed trains (TGV) that are accelerated by linear induction motors",
         "description": "Trajnoj de onda fervojo en la stilo de francaj rapidaj trajnoj (TGV), kiuj akceliĝas per linearaj induktaj motoroj",
         "reference-capacity": "4 passengers per car",
@@ -9057,15 +9057,15 @@
     },
     "rct2ww.ride.tigrtwst": {
         "reference-name": "Bengal Tiger Cars",
-        "name": "Bengala Tigro-Ĉaroj",
+        "name": "Bengala tigro-ĉaroj",
         "reference-description": "Roller coaster cars capable of heartline twists, themend to look like Bengal tigers",
-        "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, temitaj por aspekti kiel Bengalaj Tigroj",
+        "description": "Ĉaroj de onda fervojo, kiuj povas fari ĉekorajn tvistojn, temitaj por aspekti kiel bengalaj tigroj",
         "reference-capacity": "4 passengers per car",
         "capacity": "Po 4 pasaĝeroj por ĉaro"
     },
     "rct2ww.ride.tutlboat": {
         "reference-name": "Turtle Boats",
-        "name": "Testudo-Boatoj",
+        "name": "Testudo-boatoj",
         "reference-description": "Small circular dinghies powered by a centrally-mounted motor controlled by the passengers",
         "description": "Malgrandaj rondaj boatetoj ŝaltitaj per centra motoro, kiun la pasaĝeroj funkciigas",
         "reference-capacity": "2 passengers per boat",
@@ -9097,9 +9097,9 @@
     },
     "rct2ww.scenario_meta.canyon_calamities": {
         "reference-name": "Canyon Calamities",
-        "name": "Kanjono-Katastrofoj",
+        "name": "Kanjonaj Katastrofoj",
         "reference-park_name": "Canyon Calamities",
-        "park_name": "Kanjono-Katastrofoj",
+        "park_name": "Kanjonaj Katastrofoj",
         "reference-details": "You have to build a park on limited land either side of this natural treasure - you do have the opportunity to buy neighbouring land from the Native American Indians. You need to complete the objective to sustain the local town’s population.",
         "details": "Vi devas konstrui parkon sur limigita tereno ambaŭflanke de ĉi tiu natura trezoro - vi havas la oportunecon por aĉeti najbaran terenon de la Indiĝenaj Amerikanoj. Vi devas kompletigi la celon por daŭrigi la loĝantaron de la loka vilaĝo."
     },
@@ -9137,9 +9137,9 @@
     },
     "rct2ww.scenario_meta.lost_city_founder": {
         "reference-name": "Lost City Founder",
-        "name": "Fondinto de la Perdita Urbo",
+        "name": "Fondinto de la Malaperinta Urbo",
         "reference-park_name": "Lost City Founder",
-        "park_name": "Fondinto de la Perdita Urbo",
+        "park_name": "Fondinto de la Malaperinta Urbo",
         "reference-details": "To further boost local tourism you must construct a park that is in tune with its surroundings.",
         "details": "Por plue akceli lokan turismon, vi devas konstrui parkon, kiu akordas kun sia ĉirkaŭaĵo."
     },
@@ -9161,9 +9161,9 @@
     },
     "rct2ww.scenario_meta.okinawa_coast": {
         "reference-name": "Okinawa Coast",
-        "name": "Okinavo-Marbordo",
+        "name": "Okinava Marbordo",
         "reference-park_name": "Okinawa Coast",
-        "park_name": "Okinavo-Marbordo",
+        "park_name": "Okinava Marbordo",
         "reference-details": "An existing park has run out of space. Your only option is to build out into the sea, and so you have taken out a loan. Height restrictions on your building are enforced due to foundations and earthquake risk.",
         "details": "Ekzistanta parko elĉerpiĝis de spaco. Via sola eblo estas konstrui sur la maron, kaj tial vi elprenis prunton. Alteco-limigoj de viaj konstruaĵoj estas observigitaj pro fondaĵoj kaj tertremo-risko."
     },
@@ -9177,17 +9177,17 @@
     },
     "rct2ww.scenario_meta.park_maharaja": {
         "reference-name": "Park Maharaja",
-        "name": "Parko-Maharaĝo",
+        "name": "Maharaĝa Parko",
         "reference-park_name": "Park Maharaja",
-        "park_name": "Parko-Maharaĝo",
+        "park_name": "Maharaĝa Parko",
         "reference-details": "You have been commissioned by the Maharaja to bring entertainment to the large local population. Build a park inspired by the Maharaja’s palace.",
         "details": "Vi estis komisiita de la Maharaĝo por alporti amuzadon al la granda loka loĝantaro. Konstruu parkon inspiritan de la palaco de Maharaĝo."
     },
     "rct2ww.scenario_meta.rainforest_romp": {
         "reference-name": "Rainforest Romp",
-        "name": "Pluvarbaro-Kapriolo",
+        "name": "Pluvarbara Kapriolo",
         "reference-park_name": "Rainforest Romp",
-        "park_name": "Pluvarbaro-Kapriolo",
+        "park_name": "Pluvarbara Kapriolo",
         "reference-details": "Space is limited in the precious rainforest - you must cram as much as possible into the existing clearing, in order to provide a viable alternative to the local timber industry.",
         "details": "Spaco estas limigita en la altvalora pluvarbaro - vi devas plenegigi kiel eble plej multe en la ekzistantan senarbejon, por havigi vivipovan alternativon je la loka ligno-industrio."
     },
@@ -9201,9 +9201,9 @@
     },
     "rct2ww.scenario_meta.sugarloaf_shores": {
         "reference-name": "Sugarloaf Shores",
-        "name": "Sukerpano-Marbordoj",
+        "name": "Sukerpanaj Marbordoj",
         "reference-park_name": "Sugarloaf Shores",
-        "park_name": "Sukerpano-Marbordoj",
+        "park_name": "Sukerpanaj Marbordoj",
         "reference-details": "You run a small park near Rio but the bank has called in your loan. You need to quickly increase your earning capacity to repay this unexpected debt.",
         "details": "Vi administras malgrandan parkon proksime de Rio-de-Ĵanejro, sed la banko alvokis vian prunton. Vi devas rapide pliigi vian enspezado-kapablon por repagi ĉi tiun neatenditan ŝuldon."
     },
@@ -9217,83 +9217,83 @@
     },
     "rct2ww.scenery_group.scgafric": {
         "reference-name": "Africa Theming",
-        "name": "Afrika Temo"
+        "name": "Afrika temo"
     },
     "rct2ww.scenery_group.scgartic": {
         "reference-name": "Antarctic Theming",
-        "name": "Antarkta Temo"
+        "name": "Antarkta temo"
     },
     "rct2ww.scenery_group.scgasia": {
         "reference-name": "Asia Theming",
-        "name": "Azia Temo"
+        "name": "Azia temo"
     },
     "rct2ww.scenery_group.scgaustr": {
         "reference-name": "Australasian Theming",
-        "name": "Aŭstralazia Temo"
+        "name": "Aŭstralazia temo"
     },
     "rct2ww.scenery_group.scgeurop": {
         "reference-name": "Europe Theming",
-        "name": "Eŭropa Temo"
+        "name": "Eŭropa temo"
     },
     "rct2ww.scenery_group.scgnamrc": {
         "reference-name": "North America Theming",
-        "name": "Nordamerika Temo"
+        "name": "Nordamerika temo"
     },
     "rct2ww.scenery_group.scgsamer": {
         "reference-name": "South America Theming",
-        "name": "Sudamerika Temo"
+        "name": "Sudamerika temo"
     },
     "rct2ww.scenery_large.1x2abr01": {
         "reference-name": "Aboriginal Plain Tile",
-        "name": "Aborigena Senornama Bloko"
+        "name": "Aborigena senornama bloko"
     },
     "rct2ww.scenery_large.1x2abr02": {
         "reference-name": "Aboriginal Snake Artwork",
-        "name": "Aborigena Artpeco de Serpento"
+        "name": "Aborigena artpeco de serpento"
     },
     "rct2ww.scenery_large.1x2abr03": {
         "reference-name": "Aboriginal Spirit Artwork",
-        "name": "Aborigena Artpeco de Animo"
+        "name": "Aborigena artpeco de animo"
     },
     "rct2ww.scenery_large.1x2azt01": {
         "reference-name": "Temple Wall Piece with Head",
-        "name": "Muroparto de Templo kun Kapo"
+        "name": "Muroparto de templo kun kapo"
     },
     "rct2ww.scenery_large.1x2azt02": {
         "reference-name": "Temple Broken Wall Piece with Head",
-        "name": "Rompita Muroparto de Templo kun Kapo"
+        "name": "Rompita muroparto de templo kun kapo"
     },
     "rct2ww.scenery_large.1x2glama": {
         "reference-name": "Gold Llama",
-        "name": "Ora Lamo"
+        "name": "Ora lamo"
     },
     "rct2ww.scenery_large.1x2lgchm": {
         "reference-name": "Log Cabin Side Chimney",
-        "name": "Flanka Fumtubo de Blokhaŭso"
+        "name": "Flanka fumtubo de blokhaŭso"
     },
     "rct2ww.scenery_large.1x4brg01": {
         "reference-name": "Suspension Bridge Start side 1",
-        "name": "Komenco de Pentoponto, flanko 1"
+        "name": "Komenco de pentoponto, flanko 1"
     },
     "rct2ww.scenery_large.1x4brg02": {
         "reference-name": "Suspension Bridge Start side 2",
-        "name": "Komenco de Pentoponto, flanko 2"
+        "name": "Komenco de pentoponto, flanko 2"
     },
     "rct2ww.scenery_large.1x4brg03": {
         "reference-name": "Suspension Bridge Tower side 1",
-        "name": "Turo de Pentoponto, flanko 1"
+        "name": "Turo de pentoponto, flanko 1"
     },
     "rct2ww.scenery_large.1x4brg04": {
         "reference-name": "Suspension Bridge Tower side 2",
-        "name": "Turo de Pentoponto, flanko 2"
+        "name": "Turo de pentoponto, flanko 2"
     },
     "rct2ww.scenery_large.1x4brg05": {
         "reference-name": "Suspension Bridge Cable Section",
-        "name": "Kabloparto de Pentoponto"
+        "name": "Kabloparto de pentoponto"
     },
     "rct2ww.scenery_large.3x3altre": {
         "reference-name": "Jungle Tree with Leopards",
-        "name": "Ĝangaloarbo kun Leopardoj"
+        "name": "Ĝangaloarbo kun leopardoj"
     },
     "rct2ww.scenery_large.3x3atre1": {
         "reference-name": "Jungle Tree 2",
@@ -9305,7 +9305,7 @@
     },
     "rct2ww.scenery_large.3x3atre3": {
         "reference-name": "Jungle Tree with Vines",
-        "name": "Ĝangaloarbo kun Vitoj"
+        "name": "Ĝangaloarbo kun vitoj"
     },
     "rct2ww.scenery_large.3x3eucal": {
         "reference-name": "Eucalyptus Tree",
@@ -9321,11 +9321,11 @@
     },
     "rct2ww.scenery_large.50rocket": {
         "reference-name": "1950s Rocket",
-        "name": "Raketo de la 1950-aj"
+        "name": "Raketo de la 1950-aj jaroj"
     },
     "rct2ww.scenery_large.adultele": {
         "reference-name": "Adult Indian Elephant",
-        "name": "Plenaĝa Barata Elefanto"
+        "name": "Plenaĝa barata elefanto"
     },
     "rct2ww.scenery_large.afrclion": {
         "reference-name": "Lion",
@@ -9349,15 +9349,15 @@
     },
     "rct2ww.scenery_large.bamborf1": {
         "reference-name": "Bamboo Roof Corner",
-        "name": "Bambua Tegmentangulo"
+        "name": "Bambua tegmentangulo"
     },
     "rct2ww.scenery_large.bamborf2": {
         "reference-name": "Bamboo Roof",
-        "name": "Bambua Tegmento"
+        "name": "Bambua tegmento"
     },
     "rct2ww.scenery_large.bamborf3": {
         "reference-name": "Bamboo Roof Inverted Corner",
-        "name": "Inversigita Angulo de Bambua Tegmento"
+        "name": "Inversigita angulo de bambua tegmento"
     },
     "rct2ww.scenery_large.bigben": {
         "reference-name": "Big Ben and the Houses of Parliament",
@@ -9365,15 +9365,15 @@
     },
     "rct2ww.scenery_large.bigdish": {
         "reference-name": "Satellite Dish",
-        "name": "Anteno de Satelito"
+        "name": "Anteno de satelito"
     },
     "rct2ww.scenery_large.biggeosp": {
         "reference-name": "Big Geosphere",
-        "name": "Granda Geosfero"
+        "name": "Granda geosfero"
     },
     "rct2ww.scenery_large.cdragon": {
         "reference-name": "Chinese Dragon",
-        "name": "Ĉina Drako"
+        "name": "Ĉina drako"
     },
     "rct2ww.scenery_large.circus": {
         "reference-name": "Circus",
@@ -9389,11 +9389,11 @@
     },
     "rct2ww.scenery_large.damtower": {
         "reference-name": "Dam Tower",
-        "name": "Turo de Baraĵo"
+        "name": "Turo de baraĵo"
     },
     "rct2ww.scenery_large.damtower_fix": {
         "reference-name": "Dam Tower",
-        "name": "Turo de Baraĵo"
+        "name": "Turo de baraĵo"
     },
     "rct2ww.scenery_large.easerlnd": {
         "reference-name": "Easter Island Statue",
@@ -9405,7 +9405,7 @@
     },
     "rct2ww.scenery_large.evilsam": {
         "reference-name": "Evil Samurai",
-        "name": "Malbona Samurajo"
+        "name": "Malbona samurajo"
     },
     "rct2ww.scenery_large.fatbudda": {
         "reference-name": "Fat Buddha",
@@ -9413,11 +9413,11 @@
     },
     "rct2ww.scenery_large.gdstaue1": {
         "reference-name": "Gold Statue 1",
-        "name": "Ora Statuo 1"
+        "name": "Ora statuo 1"
     },
     "rct2ww.scenery_large.gdstaue2": {
         "reference-name": "Gold Statue 2",
-        "name": "Ora Statuo 2"
+        "name": "Ora statuo 2"
     },
     "rct2ww.scenery_large.geisha": {
         "reference-name": "Geisha",
@@ -9437,15 +9437,15 @@
     },
     "rct2ww.scenery_large.goodsam": {
         "reference-name": "Good Samurai",
-        "name": "Bona Samurajo"
+        "name": "Bona samurajo"
     },
     "rct2ww.scenery_large.gwoctur1": {
         "reference-name": "Great Wall Of China Turret Straight",
-        "name": "Rektaparto de Turetejo de la Granda Ĉina Muro"
+        "name": "Rektaparto de turetejo de la Granda Ĉina Muro"
     },
     "rct2ww.scenery_large.gwoctur2": {
         "reference-name": "Great Wall Of China Turret Corner",
-        "name": "Angulo de Turetejo de la Granda Ĉina Muro"
+        "name": "Angulo de turetejo de la Granda Ĉina Muro"
     },
     "rct2ww.scenery_large.helipad": {
         "reference-name": "Helipad",
@@ -9473,7 +9473,7 @@
     },
     "rct2ww.scenery_large.largeju1": {
         "reference-name": "Large Rainforest Tree",
-        "name": "Granda Arbo de Pluvarbaro"
+        "name": "Granda arbo de pluvarbaro"
     },
     "rct2ww.scenery_large.lincolns": {
         "reference-name": "Washington Statue",
@@ -9481,15 +9481,15 @@
     },
     "rct2ww.scenery_large.mbskyr01": {
         "reference-name": "Skyscraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_large.mbskyr02": {
         "reference-name": "Skyscraper Tip",
-        "name": "Pinto de Ĉielskrapanto"
+        "name": "Pinto de ĉielskrapanto"
     },
     "rct2ww.scenery_large.ovrgrwnt": {
         "reference-name": "Old Overgrown Tree",
-        "name": "Maljuna Surkreskata Arbo"
+        "name": "Maljuna surkreskata arbo"
     },
     "rct2ww.scenery_large.pagodam": {
         "reference-name": "Pagoda",
@@ -9501,7 +9501,7 @@
     },
     "rct2ww.scenery_large.pagodatw": {
         "reference-name": "Pagoda Tower",
-        "name": "Turo de Pagodo"
+        "name": "Turo de pagodo"
     },
     "rct2ww.scenery_large.pogodal": {
         "reference-name": "Pagoda",
@@ -9509,23 +9509,23 @@
     },
     "rct2ww.scenery_large.radar": {
         "reference-name": "Radar Dish",
-        "name": "Radara Anteno"
+        "name": "Radara anteno"
     },
     "rct2ww.scenery_large.rdrab01": {
         "reference-name": "Drab Large Tower Mid-Section",
-        "name": "Mezparto de Dubekolora Granda Turo"
+        "name": "Mezparto de dubekolora granda turo"
     },
     "rct2ww.scenery_large.rdrab02": {
         "reference-name": "Drab Large Tower Base",
-        "name": "Bazo de Dubekolora Granda Turo"
+        "name": "Bazo de dubekolora granda turo"
     },
     "rct2ww.scenery_large.rdrab03": {
         "reference-name": "Drab Large Tower Top",
-        "name": "Supro de Dubekolora Granda Turo"
+        "name": "Supro de dubekolora granda turo"
     },
     "rct2ww.scenery_large.rdrab04": {
         "reference-name": "Drab Large Tower Broken Base",
-        "name": "Rompita Bazo de Dubekolora Granda Turo"
+        "name": "Rompita bazo de dubekolora granda turo"
     },
     "rct2ww.scenery_large.redwood": {
         "reference-name": "Redwood Tree",
@@ -9533,23 +9533,23 @@
     },
     "rct2ww.scenery_large.rkreml08": {
         "reference-name": "Kremlin Large Tower Base",
-        "name": "Bazo de Granda Turo de Kremlo"
+        "name": "Bazo de granda turo de Kremlo"
     },
     "rct2ww.scenery_large.rkreml09": {
         "reference-name": "Kremlin Large Tower Top",
-        "name": "Supro de Granda Turo de Kremlo"
+        "name": "supro de granda turo de Kremlo"
     },
     "rct2ww.scenery_large.rkreml10": {
         "reference-name": "Kremlin Large Tower Mid-Section",
-        "name": "Mezparto de Granda Turo de Kremlo"
+        "name": "Mezparto de granda turo de Kremlo"
     },
     "rct2ww.scenery_large.rtudor05": {
         "reference-name": "Tudor Roof Piece 3",
-        "name": "Tudorstila Tegmentoparto 3"
+        "name": "Tudorstila tegmentoparto 3"
     },
     "rct2ww.scenery_large.rtudor06": {
         "reference-name": "Tudor Roof Piece 4",
-        "name": "Tudorstila Tegmentoparto 4"
+        "name": "Tudorstila tegmentoparto 4"
     },
     "rct2ww.scenery_large.shiva": {
         "reference-name": "Shiva",
@@ -9561,7 +9561,7 @@
     },
     "rct2ww.scenery_large.spaceorb": {
         "reference-name": "Space Orbs",
-        "name": "Kosmaj Orboj"
+        "name": "Kosmaj orboj"
     },
     "rct2ww.scenery_large.sputnik": {
         "reference-name": "Sputnik",
@@ -9569,19 +9569,19 @@
     },
     "rct2ww.scenery_large.sunken": {
         "reference-name": "Sunken Ship",
-        "name": "Subakviĝita Ŝipo"
+        "name": "Subakviĝita ŝipo"
     },
     "rct2ww.scenery_large.tajmcbse": {
         "reference-name": "Maharaja Palace Tower Base",
-        "name": "Bazo de Turo de Maharaĝo-Palaco"
+        "name": "Bazo de turo de Maharaĝo-Palaco"
     },
     "rct2ww.scenery_large.tajmcolm": {
         "reference-name": "Maharaja Palace Tower Column",
-        "name": "Mezparto de Turo de Maharaĝo-Palaco"
+        "name": "Mezparto de turo de Maharaĝo-Palaco"
     },
     "rct2ww.scenery_large.tajmctop": {
         "reference-name": "Maharaja Palace Tower Top",
-        "name": "Supro de Turo de Maharaĝo-Palaco"
+        "name": "Supro de turo de Maharaĝo-Palaco"
     },
     "rct2ww.scenery_large.tajmdome": {
         "reference-name": "Maharaja Palace Dome",
@@ -9613,11 +9613,11 @@
     },
     "rct2ww.scenery_small.1x1jugt2": {
         "reference-name": "Small Rainforest Tree 1",
-        "name": "Malgranda Arbo de Pluvarbaro 1"
+        "name": "Malgranda arbo de pluvarbaro 1"
     },
     "rct2ww.scenery_small.1x1jugt3": {
         "reference-name": "Small Rainforest Tree 2",
-        "name": "Malgranda Arbo de Pluvarbaro 2"
+        "name": "Malgranda arbo de pluvarbaro 2"
     },
     "rct2ww.scenery_small.1x1kanga": {
         "reference-name": "Kangaroo",
@@ -9629,19 +9629,19 @@
     },
     "rct2ww.scenery_small.adpanda": {
         "reference-name": "Adult Panda",
-        "name": "Plenaĝa Pando"
+        "name": "Plenaĝa pando"
     },
     "rct2ww.scenery_small.antilopf": {
         "reference-name": "Antelope Female",
-        "name": "Antilopo Femala"
+        "name": "Antilopo femala"
     },
     "rct2ww.scenery_small.antilopm": {
         "reference-name": "Antelope Male",
-        "name": "Antilopo Vira"
+        "name": "Antilopo vira"
     },
     "rct2ww.scenery_small.antilopp": {
         "reference-name": "Antelope Pair",
-        "name": "Duo da Antilopoj"
+        "name": "Duo da antilopoj"
     },
     "rct2ww.scenery_small.babpanda": {
         "reference-name": "Baby Panda",
@@ -9649,51 +9649,51 @@
     },
     "rct2ww.scenery_small.babyele": {
         "reference-name": "Baby Indian Elephant",
-        "name": "Barata Elefantido"
+        "name": "Barata elefantido"
     },
     "rct2ww.scenery_small.balllan2": {
         "reference-name": "Ball Lantern",
-        "name": "Bulo-Lanterno"
+        "name": "Bulo-lanterno"
     },
     "rct2ww.scenery_small.balllant": {
         "reference-name": "Ball Lantern",
-        "name": "Bulo-Lanterno"
+        "name": "Bulo-lanterno"
     },
     "rct2ww.scenery_small.bamboobs": {
         "reference-name": "Bamboo Bush",
-        "name": "Bambuo-Arbeto"
+        "name": "Bambuo-arbeto"
     },
     "rct2ww.scenery_small.bamboopl": {
         "reference-name": "Bamboo Plinth",
-        "name": "Bambua Soklo"
+        "name": "Bambua soklo"
     },
     "rct2ww.scenery_small.bstatue1": {
         "reference-name": "Broken Statue",
-        "name": "Rompita Statuo"
+        "name": "Rompita statuo"
     },
     "rct2ww.scenery_small.campfani": {
         "reference-name": "Animated Camp Fire",
-        "name": "Animita Tendarfajro"
+        "name": "Animita tendarfajro"
     },
     "rct2ww.scenery_small.conveyr1": {
         "reference-name": "Conveyer Belt Corner",
-        "name": "Angulo de Muntbendo"
+        "name": "Angulo de muntbendo"
     },
     "rct2ww.scenery_small.conveyr2": {
         "reference-name": "Conveyer Belt Rise",
-        "name": "Kreskaparto de Muntbendo"
+        "name": "Kreskaparto de muntbendo"
     },
     "rct2ww.scenery_small.conveyr3": {
         "reference-name": "Conveyer Belt End",
-        "name": "Fino de Muntbendo"
+        "name": "Fino de muntbendo"
     },
     "rct2ww.scenery_small.conveyr4": {
         "reference-name": "Conveyer Belt Straight",
-        "name": "Rektaparto de Muntbendo"
+        "name": "Rektaparto de muntbendo"
     },
     "rct2ww.scenery_small.conveyr5": {
         "reference-name": "Conveyer Belt Corner Reverse",
-        "name": "Inversa Angulo de Muntbendo"
+        "name": "Inversa angulo de muntbendo"
     },
     "rct2ww.scenery_small.fishhole": {
         "reference-name": "Fish Hole",
@@ -9701,27 +9701,27 @@
     },
     "rct2ww.scenery_small.flamngo1": {
         "reference-name": "Flamingo Feeding",
-        "name": "Flamengo Manĝanta"
+        "name": "Flamengo manĝanta"
     },
     "rct2ww.scenery_small.flamngo2": {
         "reference-name": "Flamingo Looking",
-        "name": "Flamengo Rigardanta"
+        "name": "Flamengo rigardanta"
     },
     "rct2ww.scenery_small.flamngo3": {
         "reference-name": "Flamingo Preening",
-        "name": "Flamengo Sinpuriganta"
+        "name": "Flamengo sinpuriganta"
     },
     "rct2ww.scenery_small.fountarc": {
         "reference-name": "Australian Fountain Set 2",
-        "name": "Aŭstralazia Fontanaro 2"
+        "name": "Aŭstralazia fontanaro 2"
     },
     "rct2ww.scenery_small.fountrow": {
         "reference-name": "Australian Fountain Set 1",
-        "name": "Aŭstralazia Fontanaro 1"
+        "name": "Aŭstralazia fontanaro 1"
     },
     "rct2ww.scenery_small.fstatue1": {
         "reference-name": "Fixed Statue",
-        "name": "Riparita Statuo"
+        "name": "Riparita statuo"
     },
     "rct2ww.scenery_small.g1dancer": {
         "reference-name": "Mardi Gras Dancer",
@@ -9733,35 +9733,35 @@
     },
     "rct2ww.scenery_small.icebarl1": {
         "reference-name": "Iced Barrels",
-        "name": "Glaciaj Bareloj"
+        "name": "Glaciaj bareloj"
     },
     "rct2ww.scenery_small.icebarl2": {
         "reference-name": "Iced Barrels",
-        "name": "Glaciaj Bareloj"
+        "name": "Glaciaj bareloj"
     },
     "rct2ww.scenery_small.icebarl3": {
         "reference-name": "Iced Barrels",
-        "name": "Glaciaj Bareloj"
+        "name": "Glaciaj bareloj"
     },
     "rct2ww.scenery_small.inflag01": {
         "reference-name": "Indian Silk Flag",
-        "name": "Barata Silkflago"
+        "name": "Barata silkflago"
     },
     "rct2ww.scenery_small.inflag02": {
         "reference-name": "Indian Silk Flag",
-        "name": "Barata Silkflago"
+        "name": "Barata silkflago"
     },
     "rct2ww.scenery_small.inflag03": {
         "reference-name": "Indian Silk Flag",
-        "name": "Barata Silkflago"
+        "name": "Barata silkflago"
     },
     "rct2ww.scenery_small.inflag04": {
         "reference-name": "Indian Silk Flag",
-        "name": "Barata Silkflago"
+        "name": "Barata silkflago"
     },
     "rct2ww.scenery_small.inflag05": {
         "reference-name": "Indian Silk Flag",
-        "name": "Barata Silkflago"
+        "name": "Barata silkflago"
     },
     "rct2ww.scenery_small.inuit": {
         "reference-name": "Inuit",
@@ -9773,43 +9773,43 @@
     },
     "rct2ww.scenery_small.jachtree": {
         "reference-name": "Japanese Cherry Tree",
-        "name": "Japana Ĉerizoarbo"
+        "name": "Japana ĉerizoarbo"
     },
     "rct2ww.scenery_small.japchblo": {
         "reference-name": "Japanese Cherry Blossom Tree",
-        "name": "Japana Sakuroarbo"
+        "name": "Japana sakuroarbo"
     },
     "rct2ww.scenery_small.jappintr": {
         "reference-name": "Japanese Pine Tree",
-        "name": "Japana Pinoarbo"
+        "name": "Japana pinoarbo"
     },
     "rct2ww.scenery_small.japsnotr": {
         "reference-name": "Japanese Snowball Tree",
-        "name": "Japana Neĝbuloarbo"
+        "name": "Japana neĝbuloarbo"
     },
     "rct2ww.scenery_small.jpflag01": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.jpflag02": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.jpflag03": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.jpflag04": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.jpflag05": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.jpflag06": {
         "reference-name": "Japanese Silk Flag",
-        "name": "Japana Silkflago"
+        "name": "Japana silkflago"
     },
     "rct2ww.scenery_small.oilpump": {
         "reference-name": "Oil Pump",
@@ -9817,7 +9817,7 @@
     },
     "rct2ww.scenery_small.oriegong": {
         "reference-name": "Asian Gong",
-        "name": "Azia Gongo"
+        "name": "Azia gongo"
     },
     "rct2ww.scenery_small.pcg": {
         "reference-name": "Pipe",
@@ -9829,15 +9829,15 @@
     },
     "rct2ww.scenery_small.pipebase": {
         "reference-name": "Ice Pipe Base",
-        "name": "Tubobazo el Glacio"
+        "name": "Tubobazo el glacio"
     },
     "rct2ww.scenery_small.pipevent": {
         "reference-name": "Ice Pipe Vent",
-        "name": "Tubo-Eligejo el Glacio"
+        "name": "Tubo-eligejo el glacio"
     },
     "rct2ww.scenery_small.postbox": {
         "reference-name": "British Post Box",
-        "name": "Brita Poŝtujo"
+        "name": "Brita poŝtujo"
     },
     "rct2ww.scenery_small.pst": {
         "reference-name": "Pipe",
@@ -9857,239 +9857,239 @@
     },
     "rct2ww.scenery_small.rbrick01": {
         "reference-name": "Red Brick Inverted Roof Piece",
-        "name": "Inverisigita Ruĝa Brika Tegmentoparto"
+        "name": "Inverisigita ruĝa brika tegmentoparto"
     },
     "rct2ww.scenery_small.rbrick02": {
         "reference-name": "Red Brick Corner Roof Piece",
-        "name": "Anguloparto de Ruĝa Brika Tegmento"
+        "name": "Anguloparto de ruĝa brika tegmento"
     },
     "rct2ww.scenery_small.rbrick03": {
         "reference-name": "Red Brick Flat Roof Edge Piece",
-        "name": "Bordoparto de Ruĝa Brika Plata Tegmento"
+        "name": "Bordoparto de ruĝa brika plata tegmento"
     },
     "rct2ww.scenery_small.rbrick04": {
         "reference-name": "Red Brick Flat Roof Corner",
-        "name": "Angulo de Ruĝa Brika Plata Tegmento"
+        "name": "Angulo de ruĝa brika plata tegmento"
     },
     "rct2ww.scenery_small.rbrick05": {
         "reference-name": "Red Brick Roof Piece 2",
-        "name": "Ruĝa Brika Tegmentoparto 2"
+        "name": "Ruĝa brika tegmentoparto 2"
     },
     "rct2ww.scenery_small.rbrick07": {
         "reference-name": "Red Brick Roof Piece 3",
-        "name": "Ruĝa Brika Tegmentoparto 3"
+        "name": "ruĝa brika tegmentoparto 3"
     },
     "rct2ww.scenery_small.rbrick08": {
         "reference-name": "Red Brick Roof Piece 1",
-        "name": "Ruĝa Brika Tegmentoparto 1"
+        "name": "Ruĝa brika tegmentoparto 1"
     },
     "rct2ww.scenery_small.rcorr01": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr02": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr03": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr04": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr05": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr07": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr08": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr09": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr10": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rcorr11": {
         "reference-name": "Corrugated Roof Piece",
-        "name": "Onda Tegmentoparto"
+        "name": "Onda tegmentoparto"
     },
     "rct2ww.scenery_small.rdrab05": {
         "reference-name": "Drab Small Tower Minaret Base",
-        "name": "Bazo de Dubekolora Malgranda Turo-Minareto"
+        "name": "Bazo de dubekolora malgranda turo-minareto"
     },
     "rct2ww.scenery_small.rdrab06": {
         "reference-name": "Drab Small Tower Top or Mid-Section",
-        "name": "Dubekolora Malgranda Supro aŭ Mezparto de Turo"
+        "name": "Dubekolora malgranda supro aŭ mezparto de turo"
     },
     "rct2ww.scenery_small.rdrab07": {
         "reference-name": "Drab Small Tower Base",
-        "name": "Bazo de Dubekolora Malgranda Turo"
+        "name": "Bazo de dubekolora malgranda turo"
     },
     "rct2ww.scenery_small.rdrab08": {
         "reference-name": "Drab Minaret Piece 1",
-        "name": "Dubekolora Minaretoparto 1"
+        "name": "Dubekolora minaretoparto 1"
     },
     "rct2ww.scenery_small.rdrab09": {
         "reference-name": "Drab Minaret Piece 2",
-        "name": "Dubekolora Minaretoparto 2"
+        "name": "Dubekolora minaretoparto 2"
     },
     "rct2ww.scenery_small.rdrab10": {
         "reference-name": "Drab Minaret Piece 3",
-        "name": "Dubekolora Minaretoparto 3"
+        "name": "Dubekolora minaretoparto 3"
     },
     "rct2ww.scenery_small.rdrab11": {
         "reference-name": "Drab Roof Piece 1",
-        "name": "Dubekolora Tegmentoparto 1"
+        "name": "Dubekolora tegmentoparto 1"
     },
     "rct2ww.scenery_small.rdrab12": {
         "reference-name": "Drab Roof Piece 2",
-        "name": "Dubekolora Tegmentoparto 2"
+        "name": "Dubekolora tegmentoparto 2"
     },
     "rct2ww.scenery_small.rdrab13": {
         "reference-name": "Drab Roof Piece 3",
-        "name": "Dubekolora Tegmentoparto 3"
+        "name": "Dubekolora tegmentoparto 3"
     },
     "rct2ww.scenery_small.rdrab14": {
         "reference-name": "Drab Roof Piece 4",
-        "name": "Dubekolora Tegmentoparto 4"
+        "name": "Dubekolora tegmentoparto 4"
     },
     "rct2ww.scenery_small.rgeorg01": {
         "reference-name": "Georgian Roof End Piece 1",
-        "name": "Georgia Finoparto de Tegmento 1"
+        "name": "Georgia finoparto de tegmento 1"
     },
     "rct2ww.scenery_small.rgeorg02": {
         "reference-name": "Georgian Roof End Piece 2",
-        "name": "Georgia Finoparto de Tegmento 2"
+        "name": "Georgia finoparto de tegmento 2"
     },
     "rct2ww.scenery_small.rgeorg03": {
         "reference-name": "Georgian Roof Piece 1",
-        "name": "Georgia Tegmentoparto 1"
+        "name": "Georgia tegmentoparto 1"
     },
     "rct2ww.scenery_small.rgeorg04": {
         "reference-name": "Georgian Roof Piece 2",
-        "name": "Georgia Tegmentoparto 2"
+        "name": "Georgia tegmentoparto 2"
     },
     "rct2ww.scenery_small.rgeorg05": {
         "reference-name": "Georgian Roof Piece 3",
-        "name": "Georgia Tegmentoparto 3"
+        "name": "Georgia tegmentoparto 3"
     },
     "rct2ww.scenery_small.rgeorg06": {
         "reference-name": "Georgian Roof Piece 4",
-        "name": "Georgia Tegmentoparto 4"
+        "name": "Georgia tegmentoparto 4"
     },
     "rct2ww.scenery_small.rgeorg07": {
         "reference-name": "Georgian Roof Piece 5",
-        "name": "Georgia Tegmentoparto 5"
+        "name": "Georgia tegmentoparto 5"
     },
     "rct2ww.scenery_small.rgeorg08": {
         "reference-name": "Georgian Ground Floor Wall Piece 7",
-        "name": "Georgia Ternivela Muroparto 7"
+        "name": "Georgia ternivela muroparto 7"
     },
     "rct2ww.scenery_small.rgeorg09": {
         "reference-name": "Georgian Flat Roof Edge 1",
-        "name": "Georgia Plata Tegmentobordo 1"
+        "name": "Georgia plata tegmentobordo 1"
     },
     "rct2ww.scenery_small.rgeorg10": {
         "reference-name": "Georgian Flat Roof Edge 2",
-        "name": "Georgia Plata Tegmentobordo 2"
+        "name": "Georgia plata tegmentobordo 2"
     },
     "rct2ww.scenery_small.rgeorg11": {
         "reference-name": "Georgian Flat Roof Corner",
-        "name": "Georgia Plata Tegmentangulo"
+        "name": "Georgia plata tegmentangulo"
     },
     "rct2ww.scenery_small.rgeorg12": {
         "reference-name": "Georgian Roof Piece 7",
-        "name": "Georgia Tegmentoparto 7"
+        "name": "Georgia tegmentoparto 7"
     },
     "rct2ww.scenery_small.rkreml01": {
         "reference-name": "Kremlin Minaret Piece 1",
-        "name": "Minareto de Kremlo, Parto 1"
+        "name": "Minareto de Kremlo, parto 1"
     },
     "rct2ww.scenery_small.rkreml02": {
         "reference-name": "Kremlin Minaret Piece 2",
-        "name": "Minareto de Kremlo, Parto 2"
+        "name": "Minareto de Kremlo, parto 2"
     },
     "rct2ww.scenery_small.rkreml03": {
         "reference-name": "Kremlin Minaret Piece 3",
-        "name": "Minareto de Kremlo, Parto 3"
+        "name": "Minareto de Kremlo, parto 3"
     },
     "rct2ww.scenery_small.rkreml04": {
         "reference-name": "Kremlin Roof Piece 1",
-        "name": "Tegmento de Kremlo, Parto 1"
+        "name": "Tegmento de Kremlo, parto 1"
     },
     "rct2ww.scenery_small.rkreml05": {
         "reference-name": "Kremlin Roof Piece 2",
-        "name": "Tegmento de Kremlo, Parto 2"
+        "name": "Tegmento de Kremlo, parto 2"
     },
     "rct2ww.scenery_small.rkreml06": {
         "reference-name": "Kremlin Small Tower Mid-Section",
-        "name": "Mezparto de Malgranda Turo de Kremlo"
+        "name": "Mezparto de malgranda turo de Kremlo"
     },
     "rct2ww.scenery_small.rkreml07": {
         "reference-name": "Kremlin Small Tower Base",
-        "name": "Bazo de Malgranda Turo de Kremlo"
+        "name": "Bazo de malgranda turo de Kremlo"
     },
     "rct2ww.scenery_small.rkreml11": {
         "reference-name": "Kremlin Small Tower Minaret Base",
-        "name": "Bazo de Malgranda Turo-Minareto de Kremlo"
+        "name": "Bazo de malgranda turo-minareto de Kremlo"
     },
     "rct2ww.scenery_small.rlog01": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Tegmentoparto de Blokhaŭso"
+        "name": "Tegmentoparto de blokhaŭso"
     },
     "rct2ww.scenery_small.rlog02": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Tegmentoparto de Blokhaŭso"
+        "name": "Tegmentoparto de blokhaŭso"
     },
     "rct2ww.scenery_small.rlog03": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_small.rlog04": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_small.rlog05": {
         "reference-name": "Log Cabin Roof Piece",
-        "name": "Tegmentoparto de Blokhaŭso"
+        "name": "Tegmentoparto de blokhaŭso"
     },
     "rct2ww.scenery_small.rmarble1": {
         "reference-name": "Marble Roof",
-        "name": "Marmora Tegmento"
+        "name": "Marmora tegmento"
     },
     "rct2ww.scenery_small.rmarble2": {
         "reference-name": "Marble Roof",
-        "name": "Marmora Tegmento"
+        "name": "Marmora tegmento"
     },
     "rct2ww.scenery_small.rmarble3": {
         "reference-name": "Marble Roof",
-        "name": "Marmora Tegmento"
+        "name": "Marmora tegmento"
     },
     "rct2ww.scenery_small.rmarble4": {
         "reference-name": "Marble Roof",
-        "name": "Marmora Tegmento"
+        "name": "Marmora tegmento"
     },
     "rct2ww.scenery_small.rmud01": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Parto de Kurba Kotomuro"
+        "name": "Parto de kurba kotomuro"
     },
     "rct2ww.scenery_small.rmud02": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Parto de Kurba Kotomuro"
+        "name": "Parto de kurba kotomuro"
     },
     "rct2ww.scenery_small.rmud03": {
         "reference-name": "Curved Mud Wall Piece",
-        "name": "Parto de Kurba Kotomuro"
+        "name": "Parto de kurba kotomuro"
     },
     "rct2ww.scenery_small.rmud05": {
         "reference-name": "Wattle & Daub Roof",
@@ -10097,71 +10097,71 @@
     },
     "rct2ww.scenery_small.roofice1": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofice2": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofice3": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofice4": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofice5": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofice6": {
         "reference-name": "Ice Roof",
-        "name": "Tegmento el Glacio"
+        "name": "Tegmento el glacio"
     },
     "rct2ww.scenery_small.roofig01": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_small.roofig02": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_small.roofig03": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_small.roofig04": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_small.roofig06": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_small.rshogi1": {
         "reference-name": "Japanese Roof",
-        "name": "Japana Tegmento"
+        "name": "Japana tegmento"
     },
     "rct2ww.scenery_small.rshogi2": {
         "reference-name": "Japanese Roof",
-        "name": "Japana Tegmento"
+        "name": "Japana tegmento"
     },
     "rct2ww.scenery_small.rshogi3": {
         "reference-name": "Japanese Roof",
-        "name": "Japana Tegmento"
+        "name": "Japana tegmento"
     },
     "rct2ww.scenery_small.rtudor01": {
         "reference-name": "Tudor Roof Piece 1",
-        "name": "Tudorstila Tegmentoparto 1"
+        "name": "Tudorstila tegmentoparto 1"
     },
     "rct2ww.scenery_small.rtudor02": {
         "reference-name": "Tudor Roof Piece 1 Extender Piece",
-        "name": "Plilongilo de Tudorstila Tegmentoparto 1"
+        "name": "Plilongilo de tudorstila tegmentoparto 1"
     },
     "rct2ww.scenery_small.rtudor03": {
         "reference-name": "Tudor Roof Piece 2",
-        "name": "Tudorstila Tegmentoparto 2"
+        "name": "Tudorstila tegmentoparto 2"
     },
     "rct2ww.scenery_small.rwdaub01": {
         "reference-name": "Wattle & Daub Roof",
@@ -10177,27 +10177,27 @@
     },
     "rct2ww.scenery_small.sb1hspb1": {
         "reference-name": "Suspension Bridge Base Piece",
-        "name": "Bazoparto de Pentoponto"
+        "name": "Bazoparto de pentoponto"
     },
     "rct2ww.scenery_small.sb1hspb2": {
         "reference-name": "Suspension Bridge Base Spacer Piece",
-        "name": "Bazoparto-Interaĵo de Pentoponto"
+        "name": "Bazoparto-interaĵo de pentoponto"
     },
     "rct2ww.scenery_small.sb1hspb3": {
         "reference-name": "Suspension Bridge Mid Section Piece",
-        "name": "Mezparto de Pentoponto"
+        "name": "Mezparto de pentoponto"
     },
     "rct2ww.scenery_small.sb2palm1": {
         "reference-name": "Cabana Porch",
-        "name": "Portiko de Budo"
+        "name": "Portiko de budo"
     },
     "rct2ww.scenery_small.sb2sky01": {
         "reference-name": "Stone Skyscraper Stairway Base",
-        "name": "Ŝtuparobazo de Ŝtona Ĉielskrapanto"
+        "name": "Ŝtuparobazo de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_small.sballoon": {
         "reference-name": "Animated Balloons",
-        "name": "Animitaj Balonoj"
+        "name": "Animitaj balonoj"
     },
     "rct2ww.scenery_small.sbh1tepe": {
         "reference-name": "Tee Pee",
@@ -10205,7 +10205,7 @@
     },
     "rct2ww.scenery_small.sbh1wgwh": {
         "reference-name": "Wagon Wheel",
-        "name": "Rado de Ĉarego"
+        "name": "Rado de ĉarego"
     },
     "rct2ww.scenery_small.sbh2shlt": {
         "reference-name": "Search Light",
@@ -10225,7 +10225,7 @@
     },
     "rct2ww.scenery_small.sbh3cskl": {
         "reference-name": "Cattle Skull",
-        "name": "Kranio de Bovo"
+        "name": "Kranio de bovo"
     },
     "rct2ww.scenery_small.sbh3oscr": {
         "reference-name": "Rollercoaster Award Statue",
@@ -10249,223 +10249,223 @@
     },
     "rct2ww.scenery_small.sbh4totm": {
         "reference-name": "Large Totem Pole",
-        "name": "Granda Totemfosto"
+        "name": "Granda totemfosto"
     },
     "rct2ww.scenery_small.sbskys01": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Muroparto de Ŝtona Ĉielskrapanto"
+        "name": "Muroparto de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys02": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Muroparto de Ŝtona Ĉielskrapanto"
+        "name": "Muroparto de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys03": {
         "reference-name": "Skyscraper Lift Piece",
-        "name": "Liftoparto de Ĉielskrapanto"
+        "name": "Liftoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys04": {
         "reference-name": "Skyscraper Lift Piece",
-        "name": "Liftoparto de Ĉielskrapanto"
+        "name": "Liftoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys05": {
         "reference-name": "Skyscraper Metal Set 1 Convex Piece",
-        "name": "Metalaro de Ĉielskrapanto 1 Konveksa Parto"
+        "name": "Konveksa parto de metalaro de ĉielskrapanto 1"
     },
     "rct2ww.scenery_small.sbskys06": {
         "reference-name": "Skyscraper Metal Set 1 Concave Piece",
-        "name": "Metalaro de Ĉielskrapanto 1 Konkava Parto"
+        "name": "Konkava parto de metalaro de ĉielskrapanto 1"
     },
     "rct2ww.scenery_small.sbskys07": {
         "reference-name": "Skyscraper Metal Set 2 Convex Piece",
-        "name": "Metalaro de Ĉielskrapanto 2 Konveksa Parto"
+        "name": "Konveksa parto de metalaro de ĉielskrapanto 2"
     },
     "rct2ww.scenery_small.sbskys08": {
         "reference-name": "Skyscraper Metal Set 2 Concave Piece",
-        "name": "Metalaro de Ĉielskrapanto 2 Konkava Parto"
+        "name": "Konkava parto de metalaro de ĉielskrapanto 2"
     },
     "rct2ww.scenery_small.sbskys09": {
         "reference-name": "Skyscraper Metal Set 2 Concave Piece",
-        "name": "Metalaro de Ĉielskrapanto 2 Konkava Parto"
+        "name": "Konkava parto de metalaro de ĉielskrapanto 2"
     },
     "rct2ww.scenery_small.sbskys10": {
         "reference-name": "Skyscraper Concave Piece",
-        "name": "Konkava Parto de Ĉielskrapanto"
+        "name": "Konkava parto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys11": {
         "reference-name": "Skyscraper Concave Roof",
-        "name": "Konkava Tegmento de Ĉielskrapanto"
+        "name": "Konkava tegmento de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys12": {
         "reference-name": "Skyscraper Convex Piece",
-        "name": "Konveksa Parto de Ĉielskrapanto"
+        "name": "Konveksa parto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys13": {
         "reference-name": "Skyscraper Convex Roof",
-        "name": "Konveksa Tegmento de Ĉielskrapanto"
+        "name": "Konveksa tegmento de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys14": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys15": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys16": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys17": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbskys18": {
         "reference-name": "Sky Scraper Roof Piece",
-        "name": "Tegmentoparto de Ĉielskrapanto"
+        "name": "Tegmentoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_small.sbwind01": {
         "reference-name": "Wind Sculpted Concave Wall Corner",
-        "name": "Vento-Skulptita Konkava Murangulo"
+        "name": "Vento-skulptita konkava murangulo"
     },
     "rct2ww.scenery_small.sbwind02": {
         "reference-name": "Wind Sculpted Concave Roof Corner",
-        "name": "Vento-Skulptita Konkava Tegmentangulo"
+        "name": "Vento-skulptita konkava tegmentangulo"
     },
     "rct2ww.scenery_small.sbwind03": {
         "reference-name": "Wind Sculpted Concave Wall Corner",
-        "name": "Vento-Skulptita Konkava Murangulo"
+        "name": "Vento-skulptita konkava murangulo"
     },
     "rct2ww.scenery_small.sbwind04": {
         "reference-name": "Wind Sculpted Convex Wall Corner",
-        "name": "Vento-Skulptita Konveksa Murangulo"
+        "name": "Vento-skulptita konveksa murangulo"
     },
     "rct2ww.scenery_small.sbwind05": {
         "reference-name": "Wind Sculpted Convex Roof Corner",
-        "name": "Vento-Skulptita Konveksa Tegmentangulo"
+        "name": "Vento-skulptita konveksa tegmentangulo"
     },
     "rct2ww.scenery_small.sbwind06": {
         "reference-name": "Wind Sculpted Convex Wall Corner",
-        "name": "Vento-Skulptita Konveksa Murangulo"
+        "name": "vento-skulptita konveksa murangulo"
     },
     "rct2ww.scenery_small.sbwind07": {
         "reference-name": "Wind Sculpted Rock Formation Base",
-        "name": "Bazo de Vento-Skulptita Ŝtonformo"
+        "name": "Bazo de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind08": {
         "reference-name": "Wind Sculpted Rock Formation Base",
-        "name": "Bazo de Vento-Skulptita Ŝtonformo"
+        "name": "Bazo de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind09": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Mezparto de Vento-Skulptita Ŝtonformo"
+        "name": "Mezparto de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind10": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Mezparto de Vento-Skulptita Ŝtonformo"
+        "name": "Mezparto de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind11": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Mezparto de Vento-Skulptita Ŝtonformo"
+        "name": "Mezparto de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind12": {
         "reference-name": "Wind Sculpted Rock Formation Mid Section",
-        "name": "Mezparto de Vento-Skulptita Ŝtonformo"
+        "name": "Mezparto de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind13": {
         "reference-name": "Wind Sculpted Rock Formation Top",
-        "name": "Supro de Vento-Skulptita Ŝtonformo"
+        "name": "Supro de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind14": {
         "reference-name": "Wind Sculpted Rock Formation Top",
-        "name": "Supro de Vento-Skulptita Ŝtonformo"
+        "name": "Supro de vento-skulptita ŝtonformo"
     },
     "rct2ww.scenery_small.sbwind15": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
+        "name": "Vento-skulptita tegmento - Plata tegmentoparto"
     },
     "rct2ww.scenery_small.sbwind16": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
+        "name": "Vento-skulptita tegmento - Plata tegmentoparto"
     },
     "rct2ww.scenery_small.sbwind17": {
         "reference-name": "Wind Sculpted Roof Flat Roof Piece",
-        "name": "Vento-Skulptita Tegmento - Plata Tegmentoparto"
+        "name": "Vento-skulptita tegmento - Plata tegmentoparto"
     },
     "rct2ww.scenery_small.sbwind18": {
         "reference-name": "Wind Sculpted Floor Piece",
-        "name": "Vento-Skulptita Plankoparto"
+        "name": "Vento-skulptita plankoparto"
     },
     "rct2ww.scenery_small.sbwind19": {
         "reference-name": "Wind Sculpted Floor Piece",
-        "name": "Vento-Skulptita Plankoparto"
+        "name": "Vento-skulptita plankoparto"
     },
     "rct2ww.scenery_small.sbwind20": {
         "reference-name": "Wind Sculpted Wall Base",
-        "name": "Vento-Skulptita Murobazo"
+        "name": "Vento-skulptita murobazo"
     },
     "rct2ww.scenery_small.sbwind21": {
         "reference-name": "Wind Sculpted Wall Base",
-        "name": "Vento-Skulptita Murobazo"
+        "name": "Vento-skulptita murobazo"
     },
     "rct2ww.scenery_small.sbwplm01": {
         "reference-name": "Cabana Top",
-        "name": "Supro de Budo"
+        "name": "supro de budo"
     },
     "rct2ww.scenery_small.sbwplm02": {
         "reference-name": "Cabana Porch",
-        "name": "Portiko de Budo"
+        "name": "Portiko de budo"
     },
     "rct2ww.scenery_small.sbwplm03": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Tegmentoparto de Budo"
+        "name": "Tegmentoparto de budo"
     },
     "rct2ww.scenery_small.sbwplm04": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Tegmentoparto de Budo"
+        "name": "Tegmentoparto de budo"
     },
     "rct2ww.scenery_small.sbwplm05": {
         "reference-name": "Cabana Roof Piece",
-        "name": "Tegmentoparto de Budo"
+        "name": "Tegmentoparto de budo"
     },
     "rct2ww.scenery_small.sbwplm06": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_small.sbwplm07": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_small.sbwplm08": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_small.smallgeo": {
         "reference-name": "Small Geosphere",
-        "name": "Malgranda Geosfero"
+        "name": "Malgranda geosfero"
     },
     "rct2ww.scenery_small.talllan1": {
         "reference-name": "Tall Lantern",
-        "name": "Alta Lanterno"
+        "name": "Alta lanterno"
     },
     "rct2ww.scenery_small.talllan2": {
         "reference-name": "Tall Lantern",
-        "name": "Alta Lanterno"
+        "name": "Alta lanterno"
     },
     "rct2ww.scenery_small.terrarmy": {
         "reference-name": "Terracotta Army",
-        "name": "Terakota Armeo"
+        "name": "Terakota armeo"
     },
     "rct2ww.scenery_small.tjblock1": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Parto de Maharaĝo-Palaco"
+        "name": "Parto de Maharaĝa Palaco"
     },
     "rct2ww.scenery_small.tjblock2": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Parto de Maharaĝo-Palaco"
+        "name": "Parto de Maharaĝa Palaco"
     },
     "rct2ww.scenery_small.tjblock3": {
         "reference-name": "Maharaja Palace Piece",
-        "name": "Parto de Maharaĝo-Palaco"
+        "name": "Parto de Maharaĝa Palaco"
     },
     "rct2ww.scenery_small.tnt1": {
         "reference-name": "TNT Stack",
@@ -10485,371 +10485,371 @@
     },
     "rct2ww.scenery_small.trckprt1": {
         "reference-name": "Diamond Cart",
-        "name": "Diamanto-Ĉaro"
+        "name": "Diamanto-ĉaro"
     },
     "rct2ww.scenery_small.trckprt2": {
         "reference-name": "Empty Cart",
-        "name": "Malplena Ĉaro"
+        "name": "Malplena ĉaro"
     },
     "rct2ww.scenery_small.trckprt3": {
         "reference-name": "Diamond Shaft",
-        "name": "Diamanto Propulsakso"
+        "name": "Diamanto propulsakso"
     },
     "rct2ww.scenery_small.trckprt4": {
         "reference-name": "Cart Shaft",
-        "name": "Propulsakso de Ĉaro"
+        "name": "Propulsakso de ĉaro"
     },
     "rct2ww.scenery_small.trckprt5": {
         "reference-name": "Track Bend",
-        "name": "Kurba Trako"
+        "name": "Kurba trako"
     },
     "rct2ww.scenery_small.trckprt6": {
         "reference-name": "Track Broke",
-        "name": "Rompita Trako"
+        "name": "Rompita trako"
     },
     "rct2ww.scenery_small.trckprt7": {
         "reference-name": "Track End",
-        "name": "Fino de Trako"
+        "name": "Fino de trako"
     },
     "rct2ww.scenery_small.trckprt8": {
         "reference-name": "Track Split",
-        "name": "Fendata Trako"
+        "name": "Fendata trako"
     },
     "rct2ww.scenery_small.trckprt9": {
         "reference-name": "Track Straight",
-        "name": "Rekta Trako"
+        "name": "Rekta trako"
     },
     "rct2ww.scenery_small.ukphone": {
         "reference-name": "British Telephone Box",
-        "name": "Brita Telefonbudo"
+        "name": "Brita telefonbudo"
     },
     "rct2ww.scenery_small.vertpipe": {
         "reference-name": "Ice Pipe Section",
-        "name": "Tuboparto el Glacio"
+        "name": "Tuboparto el glacio"
     },
     "rct2ww.scenery_small.waborg01": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg02": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg03": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg04": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg05": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg06": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg07": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waborg08": {
         "reference-name": "Aboriginal Art Set Piece",
-        "name": "Aborigena Artparto"
+        "name": "Aborigena artparto"
     },
     "rct2ww.scenery_small.waztec01": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec02": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec03": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec04": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec05": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec06": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec07": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec08": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec09": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec10": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec11": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Anguloparto de Muro de Templo"
+        "name": "Anguloparto de muro de templo"
     },
     "rct2ww.scenery_small.waztec12": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Anguloparto de Muro de Templo"
+        "name": "Anguloparto de muro de templo"
     },
     "rct2ww.scenery_small.waztec13": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec14": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec15": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec16": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec17": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec18": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec19": {
         "reference-name": "Temple Roof Piece",
-        "name": "Tegmentoparto de Templo"
+        "name": "Tegmentoparto de templo"
     },
     "rct2ww.scenery_small.waztec20": {
         "reference-name": "Temple Stairway Piece",
-        "name": "Ŝtuparoparto de Templo"
+        "name": "Ŝtuparoparto de templo"
     },
     "rct2ww.scenery_small.waztec21": {
         "reference-name": "Temple Stairway Piece",
-        "name": "Ŝtuparoparto de Templo"
+        "name": "Ŝtuparoparto de templo"
     },
     "rct2ww.scenery_small.waztec22": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec23": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec24": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec25": {
         "reference-name": "Temple Wall Piece",
-        "name": "Muroparto de Templo"
+        "name": "Muroparto de templo"
     },
     "rct2ww.scenery_small.waztec26": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Anguloparto de Muro de Templo"
+        "name": "Anguloparto de muro de templo"
     },
     "rct2ww.scenery_small.waztec27": {
         "reference-name": "Temple Wall Corner Piece",
-        "name": "Anguloparto de Muro de Templo"
+        "name": "Anguloparto de muro de templo"
     },
     "rct2ww.scenery_small.wcuzco01": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco02": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco03": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco04": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco05": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco06": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco07": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco08": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco09": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco10": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco11": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco12": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco13": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco14": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco15": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco16": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco17": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco18": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzco19": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Monumenta Parto de Ŝtuparo"
+        "name": "Monumenta parto de ŝtuparo"
     },
     "rct2ww.scenery_small.wcuzco20": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Monumenta Parto de Ŝtuparo"
+        "name": "Monumenta parto de ŝtuparo"
     },
     "rct2ww.scenery_small.wcuzco21": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Monumenta Anguloparto de Muro"
+        "name": "Monumenta anguloparto de muro"
     },
     "rct2ww.scenery_small.wcuzco22": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Monumenta Anguloparto de Muro"
+        "name": "Monumenta anguloparto de muro"
     },
     "rct2ww.scenery_small.wcuzco23": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Monumenta Anguloparto de Muro"
+        "name": "Monumenta anguloparto de muro"
     },
     "rct2ww.scenery_small.wcuzco24": {
         "reference-name": "Monumental Wall Corner Piece",
-        "name": "Monumenta Anguloparto de Muro"
+        "name": "Monumenta anguloparto de muro"
     },
     "rct2ww.scenery_small.wcuzco25": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Monumenta Parto de Ŝtuparo"
+        "name": "Monumenta parto de ŝtuparo"
     },
     "rct2ww.scenery_small.wcuzco26": {
         "reference-name": "Monumental Stairway Piece",
-        "name": "Monumenta Parto de Ŝtuparo"
+        "name": "Monumenta parto de ŝtuparo"
     },
     "rct2ww.scenery_small.wcuzco27": {
         "reference-name": "Monumental Wall Piece",
-        "name": "Monumenta Muroparto"
+        "name": "Monumenta muroparto"
     },
     "rct2ww.scenery_small.wcuzco28": {
         "reference-name": "Monumental Broken Wall Piece",
-        "name": "Monumenta Rompita Muroparto"
+        "name": "Monumenta rompita muroparto"
     },
     "rct2ww.scenery_small.wcuzfoun": {
         "reference-name": "Monumental Fountain",
-        "name": "Monumenta Fontano"
+        "name": "Monumenta fontano"
     },
     "rct2ww.scenery_small.wdrab09": {
         "reference-name": "Drab Step-up Piece 1",
-        "name": "Dubekolora Ŝtupoparto 1"
+        "name": "Dubekolora ŝtupoparto 1"
     },
     "rct2ww.scenery_small.wdrab10": {
         "reference-name": "Drab Wall Piece 9",
-        "name": "Dubekolora Muroparto 9"
+        "name": "Dubekolora muroparto 9"
     },
     "rct2ww.scenery_small.wdrab11": {
         "reference-name": "Drab Wall Piece 10",
-        "name": "Dubekolora Muroparto 10"
+        "name": "Dubekolora muroparto 10"
     },
     "rct2ww.scenery_small.wdrab12": {
         "reference-name": "Drab Wall Piece 11",
-        "name": "Dubekolora Muroparto 11"
+        "name": "Dubekolora muroparto 11"
     },
     "rct2ww.scenery_small.wdrab13": {
         "reference-name": "Drab Step-up Piece 2",
-        "name": "Dubekolora Ŝtupoparto 2"
+        "name": "Dubekolora ŝtupoparto 2"
     },
     "rct2ww.scenery_small.wgeorg07": {
         "reference-name": "Georgian Ground Floor Wall Piece 4",
-        "name": "Georgia Ternivela Muroparto 4"
+        "name": "Georgia ternivela muroparto 4"
     },
     "rct2ww.scenery_small.wgeorg08": {
         "reference-name": "Georgian Ground Floor Wall Piece 5",
-        "name": "Georgia Ternivela Muroparto 5"
+        "name": "Georgia ternivela muroparto 5"
     },
     "rct2ww.scenery_small.wgeorg09": {
         "reference-name": "Georgian Ground Floor Wall Piece 6",
-        "name": "Georgia Ternivela Muroparto 6"
+        "name": "Georgia ternivela muroparto 6"
     },
     "rct2ww.scenery_small.wgeorg10": {
         "reference-name": "Georgian Wall Piece 4",
-        "name": "Georgia Muroparto 4"
+        "name": "Georgia muroparto 4"
     },
     "rct2ww.scenery_small.wgeorg11": {
         "reference-name": "Georgian Wall Piece 5",
-        "name": "Georgia Muroparto 5"
+        "name": "Georgia muroparto 5"
     },
     "rct2ww.scenery_small.wgeorg12": {
         "reference-name": "Georgian Wall Piece 6",
-        "name": "Georgia Muroparto 6"
+        "name": "Georgia muroparto 6"
     },
     "rct2ww.scenery_small.wkreml01": {
         "reference-name": "Kremlin Step-up Wall Piece 1",
-        "name": "Ŝtupo de Kremlo, Muroparto 1"
+        "name": "Ŝtupo de Kremlo, muroparto 1"
     },
     "rct2ww.scenery_small.wkreml02": {
         "reference-name": "Kremlin Step-up Wall Piece 2",
-        "name": "Ŝtupo de Kremlo, Muroparto 2"
+        "name": "Ŝtupo de Kremlo, muroparto 2"
     },
     "rct2ww.scenery_small.wkreml03": {
         "reference-name": "Kremlin Wall Piece 1",
-        "name": "Muro de Kremlo, Parto 1"
+        "name": "Muro de Kremlo, parto 1"
     },
     "rct2ww.scenery_small.wkreml04": {
         "reference-name": "Kremlin Wall Piece 2",
-        "name": "Muro de Kremlo, Parto 2"
+        "name": "Muro de Kremlo, parto 2"
     },
     "rct2ww.scenery_small.wkreml05": {
         "reference-name": "Kremlin Wall Piece 3",
-        "name": "Muro de Kremlo, Parto 3"
+        "name": "Muro de Kremlo, parto 3"
     },
     "rct2ww.scenery_small.wkreml06": {
         "reference-name": "Kremlin Wall Piece 4",
-        "name": "Muro de Kremlo, Parto 4"
+        "name": "Muro de Kremlo, parto 4"
     },
     "rct2ww.scenery_small.wmayan01": {
         "reference-name": "Lost City Wall Piece",
@@ -10857,7 +10857,7 @@
     },
     "rct2ww.scenery_small.wmayan02": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Plata Tegmentoparto de Malaperinta Urbo"
+        "name": "Plata tegmentoparto de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan03": {
         "reference-name": "Lost City Wall Piece",
@@ -10897,23 +10897,23 @@
     },
     "rct2ww.scenery_small.wmayan12": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Parto de Ŝtuparo de Malaperinta Urbo"
+        "name": "Parto de ŝtuparo de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan13": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Parto de Ŝtuparo de Malaperinta Urbo"
+        "name": "Parto de ŝtuparo de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan14": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Parto de Ŝtuparo de Malaperinta Urbo"
+        "name": "Parto de ŝtuparo de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan15": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Parto de Ŝtuparo de Malaperinta Urbo"
+        "name": "Parto de ŝtuparo de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan16": {
         "reference-name": "Lost City Stairway Piece",
-        "name": "Parto de Ŝtuparo de Malaperinta Urbo"
+        "name": "Parto de ŝtuparo de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan17": {
         "reference-name": "Lost City Column Piece",
@@ -10929,59 +10929,59 @@
     },
     "rct2ww.scenery_small.wmayan21": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Plata Tegmentoparto de Malaperinta Urbo"
+        "name": "Plata tegmentoparto de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan22": {
         "reference-name": "Lost City Flat Roof Piece",
-        "name": "Plata Tegmentoparto de Malaperinta Urbo"
+        "name": "Plata tegmentoparto de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan23": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Anguloparto de Muro de Malaperinta Urbo"
+        "name": "Anguloparto de muro de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan24": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Anguloparto de Muro de Malaperinta Urbo"
+        "name": "Anguloparto de muro de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan25": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Anguloparto de Muro de Malaperinta Urbo"
+        "name": "Anguloparto de muro de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wmayan26": {
         "reference-name": "Lost City Wall Corner Piece",
-        "name": "Anguloparto de Muro de Malaperinta Urbo"
+        "name": "Anguloparto de muro de Malaperinta Urbo"
     },
     "rct2ww.scenery_small.wnauti01": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Naŭtika Tegmentoparto"
+        "name": "Naŭtika tegmentoparto"
     },
     "rct2ww.scenery_small.wnauti02": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Naŭtika Tegmentoparto"
+        "name": "Naŭtika tegmentoparto"
     },
     "rct2ww.scenery_small.wnauti03": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Naŭtika Tegmentoparto"
+        "name": "Naŭtika tegmentoparto"
     },
     "rct2ww.scenery_small.wnauti04": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Naŭtika Tegmentoparto"
+        "name": "Naŭtika tegmentoparto"
     },
     "rct2ww.scenery_small.wnauti05": {
         "reference-name": "Nautical Roof Piece",
-        "name": "Naŭtika Tegmentoparto"
+        "name": "Naŭtika tegmentoparto"
     },
     "rct2ww.scenery_small.wropecor": {
         "reference-name": "Nautical Corner Roof Railing",
-        "name": "Naŭtika Tegmentangulo-Balustrado"
+        "name": "Naŭtika tegmentangulo-balustrado"
     },
     "rct2ww.scenery_small.wropeswa": {
         "reference-name": "Nautical Roof Railing",
-        "name": "Naŭtika Tegmento-Balustrado"
+        "name": "Naŭtika tegmento-balustrado"
     },
     "rct2ww.scenery_small.wtudor12": {
         "reference-name": "Tudor Wall Piece 4",
-        "name": "Tudorstila Muroparto 4"
+        "name": "Tudorstila muroparto 4"
     },
     "rct2ww.scenery_small.wtudor13": {
         "reference-name": "Tudor Ground Bay Wall Piece",
@@ -10989,23 +10989,23 @@
     },
     "rct2ww.scenery_small.wtudor14": {
         "reference-name": "Tudor Ground Floor Wall Piece 1",
-        "name": "Tudorstila Ternivela Muroparto 1"
+        "name": "Tudorstila ternivela muroparto 1"
     },
     "rct2ww.scenery_small.wtudor15": {
         "reference-name": "Tudor Ground Floor Wall Piece 2",
-        "name": "Tudorstila Ternivela Muroparto 2"
+        "name": "Tudorstila ternivela muroparto 2"
     },
     "rct2ww.scenery_small.wtudor16": {
         "reference-name": "Tudor Ground Floor Wall Piece 3",
-        "name": "Tudorstila Ternivela Muroparto 3"
+        "name": "Tudorstila ternivela muroparto 3"
     },
     "rct2ww.scenery_small.wtudor17": {
         "reference-name": "Tudor Ground Floor Wall Piece 4",
-        "name": "Tudorstila Ternivela Muroparto 4"
+        "name": "Tudorstila ternivela muroparto 4"
     },
     "rct2ww.scenery_small.wtudor18": {
         "reference-name": "Tudor Ground Floor Wall Piece 5",
-        "name": "Tudorstila Ternivela Muroparto 5"
+        "name": "Tudorstila ternivela muroparto 5"
     },
     "rct2ww.scenery_wall.tmarch1": {
         "reference-name": "Maharaja Palace Arch 1",
@@ -11017,691 +11017,691 @@
     },
     "rct2ww.scenery_wall.w2corr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w2corr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.w3corr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wallic10": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice1": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice2": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice3": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice4": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice5": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice6": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice7": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice8": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallice9": {
         "reference-name": "Ice Wall",
-        "name": "Muro el Glacio"
+        "name": "Muro el glacio"
     },
     "rct2ww.scenery_wall.wallna01": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna02": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna03": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna04": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna05": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna06": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna07": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna08": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna09": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna10": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna11": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna12": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna13": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wallna14": {
         "reference-name": "Nautical Wall Piece",
-        "name": "Naŭtika Muroparto"
+        "name": "Naŭtika muroparto"
     },
     "rct2ww.scenery_wall.wbambo01": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo02": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo03": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo04": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo05": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo11": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo12": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo13": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo14": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo15": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambo21": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbambopc": {
         "reference-name": "Bamboo Wall",
-        "name": "Bambua Muro"
+        "name": "Bambua muro"
     },
     "rct2ww.scenery_wall.wbrick01": {
         "reference-name": "Red Brick Wall Piece 1",
-        "name": "Ruĝa Brika Muroparto 1"
+        "name": "Ruĝa brika muroparto 1"
     },
     "rct2ww.scenery_wall.wbrick02": {
         "reference-name": "Red Brick Wall Piece 2",
-        "name": "Ruĝa Brika Muroparto 2"
+        "name": "Ruĝa brika muroparto 2"
     },
     "rct2ww.scenery_wall.wbrick03": {
         "reference-name": "Red Brick Wall Piece 3",
-        "name": "Ruĝa Brika Muroparto 3"
+        "name": "Ruĝa brika muroparto 3"
     },
     "rct2ww.scenery_wall.wbrick04": {
         "reference-name": "Red Brick Wall Piece 4",
-        "name": "Ruĝa Brika Muroparto 4"
+        "name": "Ruĝa brika muroparto 4"
     },
     "rct2ww.scenery_wall.wbrick05": {
         "reference-name": "Red Brick Wall Piece 5",
-        "name": "Ruĝa Brika Muroparto 5"
+        "name": "Ruĝa brika muroparto 5"
     },
     "rct2ww.scenery_wall.wbrick08": {
         "reference-name": "Red Brick Wall Piece 8",
-        "name": "Ruĝa Brika Muroparto 8"
+        "name": "Ruĝa brika muroparto 8"
     },
     "rct2ww.scenery_wall.wbrick11": {
         "reference-name": "Red Brick Wall Piece 11",
-        "name": "Ruĝa Brika Muroparto 11"
+        "name": "Ruĝa brika muroparto 11"
     },
     "rct2ww.scenery_wall.wbrick12": {
         "reference-name": "Red Brick Wall Piece 12",
-        "name": "Ruĝa Brika Muroparto 12"
+        "name": "Ruĝa brika muroparto 12"
     },
     "rct2ww.scenery_wall.wbrick13": {
         "reference-name": "Red Brick Wall Piece 13",
-        "name": "Ruĝa Brika Muroparto 13"
+        "name": "Ruĝa brika muroparto 13"
     },
     "rct2ww.scenery_wall.wcorr01": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr02": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr03": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr04": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr05": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr06": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr07": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr08": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr09": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr10": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr11": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr12": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr13": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr14": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr15": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wcorr16": {
         "reference-name": "Corrugated Wall Piece",
-        "name": "Onda Muroparto"
+        "name": "Onda muroparto"
     },
     "rct2ww.scenery_wall.wdrab01": {
         "reference-name": "Drab Wall Piece 1",
-        "name": "Dubekolora Muroparto 1"
+        "name": "Dubekolora muroparto 1"
     },
     "rct2ww.scenery_wall.wdrab02": {
         "reference-name": "Drab Wall Piece 2",
-        "name": "Dubekolora Muroparto 2"
+        "name": "Dubekolora muroparto 2"
     },
     "rct2ww.scenery_wall.wdrab03": {
         "reference-name": "Drab Wall Piece 3",
-        "name": "Dubekolora Muroparto 3"
+        "name": "Dubekolora muroparto 3"
     },
     "rct2ww.scenery_wall.wdrab04": {
         "reference-name": "Drab Wall Piece 4",
-        "name": "Dubekolora Muroparto 4"
+        "name": "Dubekolora muroparto 4"
     },
     "rct2ww.scenery_wall.wdrab05": {
         "reference-name": "Drab Wall Piece 5",
-        "name": "Dubekolora Muroparto 5"
+        "name": "Dubekolora muroparto 5"
     },
     "rct2ww.scenery_wall.wdrab06": {
         "reference-name": "Drab Wall Piece 6",
-        "name": "Dubekolora Muroparto 6"
+        "name": "Dubekolora muroparto 6"
     },
     "rct2ww.scenery_wall.wdrab07": {
         "reference-name": "Drab Wall Piece 7",
-        "name": "Dubekolora Muroparto 7"
+        "name": "Dubekolora muroparto 7"
     },
     "rct2ww.scenery_wall.wdrab08": {
         "reference-name": "Drab Wall Piece 8",
-        "name": "Dubekolora Muroparto 8"
+        "name": "Dubekolora muroparto 8"
     },
     "rct2ww.scenery_wall.wgeorg01": {
         "reference-name": "Georgian Wall Piece 1",
-        "name": "Georgia Muroparto 1"
+        "name": "Georgia muroparto 1"
     },
     "rct2ww.scenery_wall.wgeorg02": {
         "reference-name": "Georgian Ground Floor Wall Piece 1",
-        "name": "Georgia Ternivela Muroparto 1"
+        "name": "Georgia ternivela muroparto 1"
     },
     "rct2ww.scenery_wall.wgeorg03": {
         "reference-name": "Georgian Wall Piece 2",
-        "name": "Georgia Muroparto 2"
+        "name": "Georgia muroparto 2"
     },
     "rct2ww.scenery_wall.wgeorg04": {
         "reference-name": "Georgian Ground Floor Wall Piece 2",
-        "name": "Georgia Ternivela Muroparto 2"
+        "name": "Georgia ternivela muroparto 2"
     },
     "rct2ww.scenery_wall.wgeorg05": {
         "reference-name": "Georgian Wall Piece 3",
-        "name": "Georgia Muroparto 3"
+        "name": "Georgia muroparto 3"
     },
     "rct2ww.scenery_wall.wgeorg06": {
         "reference-name": "Georgian Ground Floor Wall Piece 3",
-        "name": "Georgia Ternivela Muroparto 3"
+        "name": "Georgia ternivela muroparto 3"
     },
     "rct2ww.scenery_wall.wgwoc1": {
         "reference-name": "Great Wall Of China Front Wall Section",
-        "name": "Fronta Muroparto de la Granda Ĉina Muro"
+        "name": "Fronta muroparto de la Granda Ĉina Muro"
     },
     "rct2ww.scenery_wall.wgwoc2": {
         "reference-name": "Great Wall Of China Rear Wall Section",
-        "name": "Posta Muroparto de la Granda Ĉina Muro"
+        "name": "Posta muroparto de la Granda Ĉina Muro"
     },
     "rct2ww.scenery_wall.wgwoc3": {
         "reference-name": "Great Wall Of China Step up Wall Section",
-        "name": "Ŝtupo-Muroparto de la Granda Ĉina Muro"
+        "name": "Ŝtupo-muroparto de la Granda Ĉina Muro"
     },
     "rct2ww.scenery_wall.wigloo1": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_wall.wigloo2": {
         "reference-name": "Igloo Wall",
-        "name": "Muro de Iglo"
+        "name": "Muro de iglo"
     },
     "rct2ww.scenery_wall.wkreml07": {
         "reference-name": "Kremlin Wall Piece 5",
-        "name": "Muro de Kremlo, Parto 5"
+        "name": "Muro de Kremlo, parto 5"
     },
     "rct2ww.scenery_wall.wkreml08": {
         "reference-name": "Kremlin Wall Piece 6",
-        "name": "Muro de Kremlo, Parto 6"
+        "name": "Muro de Kremlo, parto 6"
     },
     "rct2ww.scenery_wall.wkreml09": {
         "reference-name": "Kremlin Wall Piece 7",
-        "name": "Muro de Kremlo, Parto 7"
+        "name": "Muro de Kremlo, parto 7"
     },
     "rct2ww.scenery_wall.wkreml10": {
         "reference-name": "Kremlin Wall Piece 8",
-        "name": "Muro de Kremlo, Parto 8"
+        "name": "Muro de Kremlo, parto 8"
     },
     "rct2ww.scenery_wall.wlog01": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wlog02": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wlog03": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wlog04": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wlog05": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wlog06": {
         "reference-name": "Log Cabin Wall Piece",
-        "name": "Muroparto de Blokhaŭso"
+        "name": "Muroparto de blokhaŭso"
     },
     "rct2ww.scenery_wall.wmarble1": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarble2": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarble3": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarble4": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarble5": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarble6": {
         "reference-name": "Ornate Marble Wall",
-        "name": "Ornamita Marmora Muro"
+        "name": "Ornamita marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl1": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl2": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl3": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl4": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl5": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl6": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmarbpl7": {
         "reference-name": "Plain Marble Wall",
-        "name": "Senornama Marmora Muro"
+        "name": "Senornama marmora muro"
     },
     "rct2ww.scenery_wall.wmud01": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud02": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud03": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud04": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud05": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud06": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud07": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Muro el Koto"
+        "name": "Parto de muro el koto"
     },
     "rct2ww.scenery_wall.wmud08": {
         "reference-name": "Mud Wall Piece",
-        "name": "Parto de Tegmento el Koto"
+        "name": "Parto de tegmento el koto"
     },
     "rct2ww.scenery_wall.wpalm01": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_wall.wpalm02": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_wall.wpalm03": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_wall.wpalm04": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_wall.wpalm05": {
         "reference-name": "Cabana Wall Piece",
-        "name": "Muroparto de Budo"
+        "name": "Muroparto de budo"
     },
     "rct2ww.scenery_wall.wshogi01": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi02": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi03": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi04": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi05": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi06": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi07": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi08": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi09": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi10": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi11": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi12": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi13": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi14": {
         "reference-name": "Shōji Wall",
-        "name": "Ŝoĵia Muro"
+        "name": "Ŝoĵia muro"
     },
     "rct2ww.scenery_wall.wshogi15": {
         "reference-name": "Japanese Fence",
-        "name": "Japana Barilo"
+        "name": "Japana barilo"
     },
     "rct2ww.scenery_wall.wshogi16": {
         "reference-name": "Japanese Fence",
-        "name": "Japana Barilo"
+        "name": "Japana barilo"
     },
     "rct2ww.scenery_wall.wshogi17": {
         "reference-name": "Japanese Fence",
-        "name": "Japana Barilo"
+        "name": "Japana barilo"
     },
     "rct2ww.scenery_wall.wskysc01": {
         "reference-name": "Skyscraper Metal Set 2 Wall Piece",
-        "name": "Metalaro de Ĉielskrapanto 2 Muroparto"
+        "name": "Muroparto de metalaro de ĉielskrapanto 2"
     },
     "rct2ww.scenery_wall.wskysc02": {
         "reference-name": "Skyscraper Metal Set 2 Wall Piece",
-        "name": "Metalaro de Ĉielskrapanto 2 Muroparto"
+        "name": "Muroparto de metalaro de ĉielskrapanto 2"
     },
     "rct2ww.scenery_wall.wskysc03": {
         "reference-name": "Skyscraper Metal Set 1 Wall Piece",
-        "name": "Metalaro de Ĉielskrapanto 1 Muroparto"
+        "name": "Muroparto de metalaro de ĉielskrapanto 1"
     },
     "rct2ww.scenery_wall.wskysc04": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Parto de Liftoparto de Ĉielskrapanto"
+        "name": "Parto de liftoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc05": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Parto de Liftoparto de Ĉielskrapanto"
+        "name": "Parto de liftoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc06": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Muroparto de Ĉielskrapanto"
+        "name": "Muroparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc07": {
         "reference-name": "Skyscraper Lift Section Piece",
-        "name": "Parto de Liftoparto de Ĉielskrapanto"
+        "name": "Parto de liftoparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc08": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Muroparto de Ĉielskrapanto"
+        "name": "Muroparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc09": {
         "reference-name": "Sky Scraper Wall Piece",
-        "name": "Muroparto de Ĉielskrapanto"
+        "name": "Muroparto de ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc10": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Muroparto de Ŝtona Ĉielskrapanto"
+        "name": "Muroparto de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc11": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Muroparto de Ŝtona Ĉielskrapanto"
+        "name": "Muroparto de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wskysc12": {
         "reference-name": "Stone Skyscraper Wall Piece",
-        "name": "Muroparto de Ŝtona Ĉielskrapanto"
+        "name": "Muroparto de ŝtona ĉielskrapanto"
     },
     "rct2ww.scenery_wall.wtudor01": {
         "reference-name": "Tudor Ground Floor Wall Piece 1",
-        "name": "Tudorstila Ternivela Muroparto 1"
+        "name": "Tudorstila ternivela muroparto 1"
     },
     "rct2ww.scenery_wall.wtudor02": {
         "reference-name": "Tudor Ground Floor Wall Piece 2",
-        "name": "Tudorstila Ternivela Muroparto 2"
+        "name": "Tudorstila ternivela muroparto 2"
     },
     "rct2ww.scenery_wall.wtudor03": {
         "reference-name": "Tudor Ground Floor Wall Piece 3",
-        "name": "Tudorstila Ternivela Muroparto 3"
+        "name": "Tudorstila ternivela muroparto 3"
     },
     "rct2ww.scenery_wall.wtudor04": {
         "reference-name": "Tudor Ground Floor Wall Piece 4",
-        "name": "Tudorstila Ternivela Muroparto 4"
+        "name": "Tudorstila ternivela muroparto 4"
     },
     "rct2ww.scenery_wall.wtudor05": {
         "reference-name": "Tudor Ground Floor Wall Piece 5",
-        "name": "Tudorstila Ternivela Muroparto 5"
+        "name": "Tudorstila ternivela muroparto 5"
     },
     "rct2ww.scenery_wall.wtudor06": {
         "reference-name": "Tudor Ground Floor Wall Piece 6",
-        "name": "Tudorstila Ternivela Muroparto 6"
+        "name": "Tudorstila ternivela muroparto 6"
     },
     "rct2ww.scenery_wall.wtudor07": {
         "reference-name": "Tudor Ground Floor Wall Piece 7",
-        "name": "Tudorstila Ternivela Muroparto 7"
+        "name": "Tudorstila ternivela muroparto 7"
     },
     "rct2ww.scenery_wall.wtudor08": {
         "reference-name": "Tudor Ground Floor Wall Piece 8",
-        "name": "Tudorstila Ternivela Muroparto 8"
+        "name": "Tudorstila ternivela muroparto 8"
     },
     "rct2ww.scenery_wall.wtudor09": {
         "reference-name": "Tudor Wall Piece 1",
-        "name": "Tudorstila Muroparto 1"
+        "name": "Tudorstila muroparto 1"
     },
     "rct2ww.scenery_wall.wtudor10": {
         "reference-name": "Tudor Wall Piece 2",
-        "name": "Tudorstila Muroparto 2"
+        "name": "Tudorstila muroparto 2"
     },
     "rct2ww.scenery_wall.wtudor11": {
         "reference-name": "Tudor Wall Piece 3",
-        "name": "Tudorstila Muroparto 3"
+        "name": "Tudorstila muroparto 3"
     },
     "rct2ww.scenery_wall.wwdaub01": {
         "reference-name": "Wattle & Daub Wall",
@@ -11733,19 +11733,19 @@
     },
     "rct2ww.scenery_wall.wwind03": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Vento-Skulptita Muroparto"
+        "name": "Vento-skulptita muroparto"
     },
     "rct2ww.scenery_wall.wwind04": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Vento-Skulptita Muroparto"
+        "name": "Vento-skulptita muroparto"
     },
     "rct2ww.scenery_wall.wwind05": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Vento-Skulptita Muroparto"
+        "name": "Vento-skulptita muroparto"
     },
     "rct2ww.scenery_wall.wwind06": {
         "reference-name": "Wind Sculpted Wall Piece",
-        "name": "Vento-Skulptita Muroparto"
+        "name": "Vento-skulptita muroparto"
     },
     "toontowner.scenery_small.ttpirf02": {
         "reference-name": "Roof",
@@ -11769,15 +11769,15 @@
     },
     "toontowner.scenery_small.ttrfgl01": {
         "reference-name": "Glass Roof",
-        "name": "Vitra Tegmento"
+        "name": "Vitra tegmento"
     },
     "toontowner.scenery_small.ttrfgl02": {
         "reference-name": "Glass Roof",
-        "name": "Vitra Tegmento"
+        "name": "Vitra tegmento"
     },
     "toontowner.scenery_small.ttrfgl03": {
         "reference-name": "Glass Roof",
-        "name": "Vitra Tegmento"
+        "name": "Vitra tegmento"
     },
     "toontowner.scenery_small.ttrftl02": {
         "reference-name": "Roof",
@@ -11853,9 +11853,9 @@
     },
     "uces.scenario_meta.camp_mockingbird": {
         "reference-name": "Camp Mockingbird",
-        "name": "Mokbirdo-Kampejo",
+        "name": "Mokbirda Kampejo",
         "reference-park_name": "Camp Mockingbird",
-        "park_name": "Mokbirdo-Kampejo",
+        "park_name": "Mokbirda Kampejo",
         "reference-details": "Only $500/week to this summer camp! Break open your bank and then have fun and build a park.",
         "details": "Nur 500 dolaroj semajne por ĉi tiu somera kampejo! Disrompu vian ŝparmonujon kaj tiam amuziĝu kaj konstruu parkon."
     },
@@ -11881,7 +11881,7 @@
         "reference-park_name": "Dragon Islands",
         "park_name": "Drakaj Insuloj",
         "reference-details": "Dragon Islands? I’m not sure I want to go there…",
-        "details": "Ĉu Drakaj Insuloj? Mi ne estas certa, ke mi volas iri tien…"
+        "details": "Ĉu Drakaj Insuloj? Mi ne certas, ke mi volas iri tien…"
     },
     "uces.scenario_meta.kiddie_karnival_ii": {
         "reference-name": "Kiddie Karnival II",
@@ -11921,7 +11921,7 @@
         "reference-park_name": "Rocky Mountain Miners",
         "park_name": "Ministoj de Roka Montaro",
         "reference-details": "A rockslide damaged your railway. Your workers have gone prospecting. Is there gold in roller coasters?",
-        "details": "Terŝoviĝo damaĝis vian fervojon. Viaj laboristoj foriris por esplori. Ĉu estas oro en onda-fervojojn?"
+        "details": "Terŝoviĝo damaĝis vian fervojon. Viaj laboristoj foriris por esplori. Ĉu estas oro en ondaj fervojoj?"
     },
     "uces.scenario_meta.sand_dune": {
         "reference-name": "Sand Dune",
@@ -11937,7 +11937,7 @@
         "reference-park_name": "The Lighthouse of Alexandria",
         "park_name": "La Lumturo de Aleksandrio",
         "reference-details": "Alexander built the city; Greeks, Romans, Egyptians left their mark. But the biggest honor was a Wonder of the Ancient World - the Lighthouse. Visit and make a park!",
-        "details": "Aleksandrio konstruis la urbon; Grekoj, romianoj, kaj egiptoj lasis siajn markojn. Sed la plej granda honoro estis Mirindaĵo de la Antikva Mondo - la Lumturo. Vizitu kaj farigu parkon!"
+        "details": "Aleksandrio konstruis la urbon; grekoj, romianoj, kaj egiptoj lasis siajn markojn. Sed la plej granda honoro estis Mirindaĵo de la Antikva Mondo - la Lumturo. Vizitu kaj farigu parkon!"
     },
     "uces.scenario_meta.the_sandbox": {
         "reference-name": "The Sandbox",
@@ -11977,6 +11977,6 @@
         "reference-park_name": "Urbis Incognitus",
         "park_name": "Urbis Incognitus",
         "reference-details": "The Romans are tired of boring gladiator fights. Give them a better thrill, turn a Roman city into the greatest amusement park of all time!",
-        "details": "La romianoj lacas enuigajn gladiatorajn batalojn. Donu al ili pli bonajn ravojn, transformu roman urbon en la plej bonan amuzparkon de ĉiuj tempoj!"
+        "details": "La romianoj lacas pro enuigaj gladiatoraj bataloj. Donu al ili pli bonajn ravojn, transformu romian urbon en la plej bonan amuzparkon de ĉiuj tempoj!"
     }
 }


### PR DESCRIPTION
Same process as for the data file, now applied to the objects file for Esperanto.

Title Case removed in names of ride vehicles, objects, etc., with exception of proper names and names of scenarios/parks.

"Bumbly Beach" and "Bumbly Bazaar" had the adjective "burda" (which has a literal sense of "related to a bumblebee" replaced with "plumpa", which, I think, is close enough in meaning to "bumbling", "clumsy" without being too insulting.

References to rides renamed in #3456 updated (surprisingly, one of the lines already uses the same term "aŭtetoj" for dodgems / bumper cars).

Lots of dual-noun scenario/park names (ex. "Diamond Heights") changed to have the first word in its adjective form.

In "Forest Frontiers", the word for "frontiers" changed from "limoj" (which literally means "border" and doesn't cover the meaning of "land untouched by civilization") to "krudlandoj" ("raw/crude lands")

All references to Ancient Rome (scenarios, theming, etc.) changed to use the word "Romio" and its forms, specifically referring to Rome (the historic state), as opposed to Rome (the city).

"Club-shaped Tree" reworded to make sure it references clubs (the playing card suit) instead of clubs (weapons), likewise for "Heart-shaped tree".

Some tree species names changed to ones matching Esperanto Wikipedia.

"Morta" replaced with "senviva" in "dead tree" objects, as the former is supposed to mean "deadly" or "related to the act of dying" (i.e. changing state from alive to dead) as opposed to "dead" (lifeless).

Some uses of phrases like "1920s" and "1960s" clarified with the word "years". (I was actually considering changing the phrase "Roaring Twenties" from a literal translation ("Muĝadaj Dudekaj Jaroj") to a more blunt "Usonaj 1920aj jaroj" (lit.: U.S. American 1920th years), but decided that this could be made as a separate PR with its own discussion later.

"Crater Carnage" changed from literal "Kratera Buĉado" (lit. "Crater Butchery") to "Kratera Katastrofo" to avoid an overly harsh word and restore alliteration.

In "Lost City Founder", changed "Perdita Urbo" (literally "lost city") to "Malaperinta Urbo" ("city which disappeared") to match the Esperanto Wikipedia term and names of lost city theming objects already in the game.

Slight grammar changes in other objects and scenario descriptions.

CC: @tellovishous