### PR TITLE
es-ES: add new translations for attraction types and related messages (STR_7007-STR_7032)

### DIFF
--- a/data/language/es-ES.txt
+++ b/data/language/es-ES.txt
@@ -3804,3 +3804,29 @@ STR_7003    :El archivo de audio ‘{STRING}’ está truncado. Se esperaban {IN
 STR_7004    :Forzar redibujado
 STR_7005    :Arrastrar un área de sendero
 STR_7006    :Dibujar borde alrededor de los botones con imágenes
+STR_7007    :Tipo de atracción
+STR_7008    :Tipo de atracción desconocido ({INT32})
+STR_7009    :Recibiendo scripts…
+STR_7010    :No se pudo iniciar la repetición, el archivo ‘{STRING}’ no existe o no es válido
+STR_7011    :No se pudo iniciar la repetición
+STR_7012    :Zloty polaco (PLN)
+STR_7013    :Arrastrar áreas de sendero
+STR_7014    :Tengo el juego en Steam, pero aún no lo he instalado.
+STR_7015    :Por favor, cierra Steam si está abierto, luego haz clic en ‘Aceptar’.
+STR_7016    :OpenRCT2 ha intentado iniciar una descarga en Steam. Abre Steam y deja que descargue el juego. Cuando Steam termine, haz clic en ‘Aceptar’.
+STR_7017    :Salir
+STR_7018    :{SPRITE}{MOVE_X}{17}{STRINGID}
+STR_7019    :{SPRITE}{MOVE_X}{27}{STRINGID}
+STR_7020    :{MOVE_X}{10}{SPRITE}{NEWLINE_SMALLER}{MOVE_X}{36}{STRINGID}
+STR_7021    :{MOVE_X}{10}{SPRITE}{NEWLINE_SMALLER}»{MOVE_X}{36}{STRINGID}
+STR_7022    :{STRING} - -
+STR_7023    :Hacer invisible
+STR_7024    :Hace invisible toda la atracción
+STR_7025    :Hacer visible
+STR_7026    :Hace visible toda la atracción
+STR_7027    :{MOVE_X}{29}{STRINGID}
+STR_7028    :Cuarto de hélice hacia arriba
+STR_7029    :Cuarto de hélice hacia abajo
+STR_7030    :{WINDOW_COLOUR_2}Visitantes entretenidos: {BLACK}{COMMA32}
+STR_7031    :Desactivar el crecimiento de la hierba
+STR_7032    :Desactivar el envejecimiento de la hierba para que no crezca.


### PR DESCRIPTION
I've added missing translations from said ranges