### PR TITLE
Fix: use curl instead of checkout for en-GB.txt

### DIFF
--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: get en-GB.txt (curl)
         run: |
           mkdir -p OpenRCT2/data/language
-          curl -sSL https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/data/language/en-GB.txt -o OpenRCT2/data/language/en-GB.txt
+          curl -sSLf https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/data/language/en-GB.txt -o OpenRCT2/data/language/en-GB.txt
 
       - name: Checkout translations before PR changes (for comparsion)
         uses: actions/checkout@v4

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -17,12 +17,17 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Get OpenRCT2 develop (for en-GB.txt)
-        uses: actions/checkout@v4
-        with:
-          repository: OpenRCT2/OpenRCT2
-          ref: develop
-          path: OpenRCT2
+      # - name: Get OpenRCT2 develop (for en-GB.txt)
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: OpenRCT2/OpenRCT2
+      #     ref: develop
+      #     path: OpenRCT2
+
+      - name: get en-GB.txt (curl)
+        run: |
+          mkdir -p OpenRCT2/data/language
+          curl -sSL https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/data/language/en-GB.txt -o OpenRCT2/data/language/en-GB.txt
 
       - name: Checkout translations before PR changes (for comparsion)
         uses: actions/checkout@v4

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -17,13 +17,6 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      # - name: Get OpenRCT2 develop (for en-GB.txt)
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: OpenRCT2/OpenRCT2
-      #     ref: develop
-      #     path: OpenRCT2
-
       - name: get en-GB.txt (curl)
         run: |
           mkdir -p OpenRCT2/data/language


### PR DESCRIPTION
Replaces the `actions/checkout` of the `OpenRCT2/OpenRCT2` repo with a direct `curl` download of `en-GB.txt`.

- fetches only the single `en-GB.txt` file instead of cloning the whole repo.
- produces the same path the script expects (`OpenRCT2/data/language/en-GB.txt`) from the same source (`develop` branch).
- doesn't touch permissions, triggers, or the rest of the pipeline.