### PR TITLE
Move actions on CI to latest

### DIFF
--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name:  Get Pull Request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: pr
           ref: ${{github.event.pull_request.head.ref}}
@@ -23,7 +23,7 @@ jobs:
           curl -sSLf https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/data/language/en-GB.txt -o OpenRCT2/data/language/en-GB.txt
 
       - name: Checkout translations before PR changes (for comparsion)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: master
           ref: ${{github.event.pull_request.head.ref}}
@@ -54,19 +54,19 @@ jobs:
         run: rm -rf master
 
       - name: Checkout upstream master as master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ steps.merge-base-commit.outputs.merge_base == github.event.pull_request.head.sha }}
         with:
           ref: master
           path: master
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
       - name: Checkout upstream master (in order to use the newest version of the script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: upstream_master
           ref: master
@@ -84,7 +84,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Create PR comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{github.event.pull_request.number}}
           body: ${{ steps.get-comment-body.outputs.body }}

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -1,7 +1,7 @@
 name: Translation Check
 
 on: 
-  pull_request:
+  pull_request_target:
     paths:
      - 'data/language/**.txt'
 

--- a/data/language/pt-BR.txt
+++ b/data/language/pt-BR.txt
@@ -3825,4 +3825,4 @@ STR_7034    :Estilo do Labirinto
 STR_7035    :Estilo da Loja
 STR_7036    :Estilo do Veículo
 STR_7037    :Modo de operação
-STR_7038    :Espera e carregamento
+STR_7038    :Espera e carregsamento

--- a/data/language/pt-BR.txt
+++ b/data/language/pt-BR.txt
@@ -3825,4 +3825,4 @@ STR_7034    :Estilo do Labirinto
 STR_7035    :Estilo da Loja
 STR_7036    :Estilo do Veículo
 STR_7037    :Modo de operação
-STR_7038    :Espera e carregsamento
+STR_7038    :Espera e carregamento


### PR DESCRIPTION
According to CI on #3505

Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/