### PR TITLE
pt-BR: Corrigir tradução de atração

### DIFF
--- a/data/language/pt-BR.txt
+++ b/data/language/pt-BR.txt
@@ -2847,7 +2847,7 @@ STR_5788    :Intervalo de inspeção:
 STR_5789    :Desabilitar efeitos de relâmpago
 STR_5790    :Ativa preço estilo RCT1{NEWLINE}(atrações e entradas ambos pagos)
 STR_5791    :Define a confiança de todas as atrações em 100%{NEWLINE}e reinicia a data de construção para “este ano”
-STR_5792    :Conserta todos as atrações quebradas
+STR_5792    :Conserta todas as atrações quebradas
 STR_5793    :Reinicia o histórico de acidentes de uma atração,{NEWLINE}então visitantes não irão reclamar que não é seguro
 STR_5794    :Alguns cenários desabilitam a edição de algumas{NEWLINE}das atrações que já estão no parque.{NEWLINE}Esta trapaça desliga a restrição
 STR_5795    :Visitantes andam em todas as atrações{NEWLINE}do parque mesmo se a intensidade for extremamente alta
@@ -2926,7 +2926,7 @@ STR_5872    :Desabilita o envelhecimento das plantas para que elas não murchem.
 STR_5873    :Permitir corrente de elevação em todas{NEWLINE}as peças de pista
 STR_5874    :Permite que qualquer parte da pista tenha corrente de elevação
 STR_5875    :Motor gráfico:
-STR_5876    :Engine que será usada para renderizar o jogo.
+STR_5876    :Motor gráfico que será usado para renderizar o jogo.
 STR_5877    :Software
 STR_5878    :Software (exibição por hardware)
 STR_5879    :OpenGL (experimental)


### PR DESCRIPTION
<!--
If you are applying translations for an issue (or multiple), please list them below
-->

Corrige duas traduções em pt-BR:

- STR_5792: "Conserta todos as atrações quebradas" → "Conserta todas as atrações quebradas"
- STR_5876: "Engine que será usada para renderizar o jogo." → "Motor gráfico que será usado para renderizar o jogo."